### PR TITLE
Generic Asset Module Events

### DIFF
--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -17,15 +17,15 @@
 
 #![cfg(test)]
 
-use parity_codec::{Encode, Decode};
-use serde::{Serialize, Deserialize};
+use parity_codec::{Decode, Encode};
 use primitives::{
 	testing::{Digest, DigestItem, Header},
-	traits::{BlakeTwo256, IdentityLookup, Verify, Lazy},
+	traits::{BlakeTwo256, IdentityLookup, Lazy, Verify},
 	BuildStorage,
 };
+use serde::{Deserialize, Serialize};
 use substrate_primitives::{Blake2Hasher, H256};
-use support::{impl_outer_origin, impl_outer_event};
+use support::{impl_outer_event, impl_outer_origin};
 
 use super::*;
 
@@ -74,7 +74,7 @@ mod generic_asset {
 	pub use crate::Event;
 }
 
-impl_outer_event!{
+impl_outer_event! {
 	pub enum TestEvent for Test {
 		generic_asset<T>,
 	}

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -25,7 +25,7 @@ use primitives::{
 	BuildStorage,
 };
 use substrate_primitives::{Blake2Hasher, H256};
-use support::impl_outer_origin;
+use support::{impl_outer_origin, impl_outer_event};
 
 use super::*;
 
@@ -59,7 +59,7 @@ impl system::Trait for Test {
 	type AccountId = u64;
 	type Lookup = IdentityLookup<u64>;
 	type Header = Header;
-	type Event = ();
+	type Event = TestEvent;
 	type Log = DigestItem;
 	type Signature = Signature;
 }
@@ -67,10 +67,22 @@ impl system::Trait for Test {
 impl Trait for Test {
 	type Balance = u64;
 	type AssetId = u32;
-	type Event = ();
+	type Event = TestEvent;
+}
+
+mod generic_asset {
+	pub use crate::Event;
+}
+
+impl_outer_event!{
+	pub enum TestEvent for Test {
+		generic_asset<T>,
+	}
 }
 
 pub type GenericAsset = Module<Test>;
+
+pub type System = system::Module<Test>;
 
 pub struct ExtBuilder {
 	asset_id: u32,

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -18,7 +18,7 @@
 #![cfg(test)]
 
 use super::*;
-use crate::mock::{new_test_ext, ExtBuilder, GenericAsset, Origin, Test, System, TestEvent};
+use crate::mock::{new_test_ext, ExtBuilder, GenericAsset, Origin, System, Test, TestEvent};
 use runtime_io::with_externalities;
 use support::{assert_noop, assert_ok};
 
@@ -1260,11 +1260,8 @@ fn update_permission_should_raise_event() {
 			));
 
 			// Assert
-			assert!(
-				System::events().iter().any(
-					|record| record.event ==
-						TestEvent::generic_asset(
-							RawEvent::PermissionUpdated(asset_id, permissions.clone()))));
+			assert!(System::events().iter().any(|record| record.event
+				== TestEvent::generic_asset(RawEvent::PermissionUpdated(asset_id, permissions.clone()))));
 		},
 	);
 }
@@ -1299,19 +1296,12 @@ fn mint_should_raise_event() {
 			));
 
 			// Act
-			assert_ok!(GenericAsset::mint(
-				Origin::signed(origin),
-				asset_id,
-				to,
-				amount
-			));
+			assert_ok!(GenericAsset::mint(Origin::signed(origin), asset_id, to, amount));
 
 			// Assert
-			assert!(
-				System::events().iter().any(
-					|record| record.event ==
-						TestEvent::generic_asset(
-							RawEvent::Minted(asset_id, to, amount))));
+			assert!(System::events()
+				.iter()
+				.any(|record| record.event == TestEvent::generic_asset(RawEvent::Minted(asset_id, to, amount))));
 		},
 	);
 }
@@ -1345,19 +1335,12 @@ fn burn_should_raise_event() {
 			));
 
 			// Act
-			assert_ok!(GenericAsset::burn(
-				Origin::signed(origin),
-				asset_id,
-				origin,
-				amount
-			));
+			assert_ok!(GenericAsset::burn(Origin::signed(origin), asset_id, origin, amount));
 
 			// Assert
-			assert!(
-				System::events().iter().any(
-					|record| record.event ==
-						TestEvent::generic_asset(
-							RawEvent::Burned(asset_id, origin, amount))));
+			assert!(System::events()
+				.iter()
+				.any(|record| record.event == TestEvent::generic_asset(RawEvent::Burned(asset_id, origin, amount))));
 		},
 	);
 }

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -18,7 +18,7 @@
 #![cfg(test)]
 
 use super::*;
-use crate::mock::{new_test_ext, ExtBuilder, GenericAsset, Origin, Test};
+use crate::mock::{new_test_ext, ExtBuilder, GenericAsset, Origin, Test, System, TestEvent};
 use runtime_io::with_externalities;
 use support::{assert_noop, assert_ok};
 
@@ -1221,6 +1221,143 @@ fn create_should_reserve_stake_asset() {
 				GenericAsset::reserved_balance(&GenericAsset::staking_asset_id(), &1),
 				GenericAsset::create_asset_stake()
 			);
+		},
+	);
+}
+
+#[test]
+fn update_permission_should_raise_event() {
+	// Arrange
+	let staking_asset_id = 16000;
+	let asset_id = 1000;
+	let origin = 1;
+	let initial_balance = 1000;
+	let permissions = PermissionLatest {
+		update: Owner::Address(origin),
+		mint: Owner::Address(origin),
+		burn: Owner::Address(origin),
+	};
+
+	with_externalities(
+		&mut ExtBuilder::default()
+			.next_asset_id(asset_id)
+			.free_balance((staking_asset_id, origin, initial_balance))
+			.build(),
+		|| {
+			assert_ok!(GenericAsset::create(
+				Origin::signed(origin),
+				AssetOptions {
+					initial_issuance: 0,
+					permissions: permissions.clone(),
+				}
+			));
+
+			// Act
+			assert_ok!(GenericAsset::update_permission(
+				Origin::signed(origin),
+				asset_id,
+				permissions.clone()
+			));
+
+			// Assert
+			assert!(
+				System::events().iter().any(
+					|record| record.event ==
+						TestEvent::generic_asset(
+							RawEvent::PermissionUpdated(asset_id, permissions.clone()))));
+		},
+	);
+}
+
+#[test]
+fn mint_should_raise_event() {
+	// Arrange
+	let staking_asset_id = 16000;
+	let asset_id = 1000;
+	let origin = 1;
+	let initial_balance = 1000;
+	let permissions = PermissionLatest {
+		update: Owner::Address(origin),
+		mint: Owner::Address(origin),
+		burn: Owner::Address(origin),
+	};
+	let to = 2;
+	let amount = 100;
+
+	with_externalities(
+		&mut ExtBuilder::default()
+			.next_asset_id(asset_id)
+			.free_balance((staking_asset_id, origin, initial_balance))
+			.build(),
+		|| {
+			assert_ok!(GenericAsset::create(
+				Origin::signed(origin),
+				AssetOptions {
+					initial_issuance: 0,
+					permissions: permissions.clone(),
+				}
+			));
+
+			// Act
+			assert_ok!(GenericAsset::mint(
+				Origin::signed(origin),
+				asset_id,
+				to,
+				amount
+			));
+
+			// Assert
+			assert!(
+				System::events().iter().any(
+					|record| record.event ==
+						TestEvent::generic_asset(
+							RawEvent::Minted(asset_id, to, amount))));
+		},
+	);
+}
+
+#[test]
+fn burn_should_raise_event() {
+	// Arrange
+	let staking_asset_id = 16000;
+	let asset_id = 1000;
+	let origin = 1;
+	let initial_balance = 1000;
+	let permissions = PermissionLatest {
+		update: Owner::Address(origin),
+		mint: Owner::Address(origin),
+		burn: Owner::Address(origin),
+	};
+	let amount = 100;
+
+	with_externalities(
+		&mut ExtBuilder::default()
+			.next_asset_id(asset_id)
+			.free_balance((staking_asset_id, origin, initial_balance))
+			.build(),
+		|| {
+			assert_ok!(GenericAsset::create(
+				Origin::signed(origin),
+				AssetOptions {
+					initial_issuance: amount,
+					permissions: permissions.clone(),
+				}
+			));
+
+			// Act
+			assert_ok!(GenericAsset::burn(
+				Origin::signed(origin),
+				asset_id,
+				origin,
+				amount
+			));
+
+			// Assert
+			assert!(
+				System::events().iter().any(
+					|record| record.event ==
+						TestEvent::generic_asset(
+							RawEvent::Burned(asset_id, origin, amount))));
 		},
 	);
 }


### PR DESCRIPTION
This PR ensures that:

* An event is raised when permissions on an asset are updated.
* An event is raised when an asset is minted.
* An event is raised when an asset is burned.