### PR TITLE
Issue/18 unify usage of primitives

### DIFF
--- a/crml/cennzx-spot/Cargo.toml
+++ b/crml/cennzx-spot/Cargo.toml
@@ -9,7 +9,7 @@ cennznet-primitives = { path = "../../primitives", default-features = false }
 fees = { package="prml-fees", path = "../../prml/fees", default-features = false }
 serde = { version = "1.0", optional = true }
 parity-codec = { version = "3.1", default-features = false, features = ["derive"] }
-substrate-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+primitives = { package = "substrate-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 rstd = { package="sr-std", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 runtime_io = { package="sr-io", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 runtime_primitives = { package="sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
@@ -24,7 +24,7 @@ std = [
 	"fees/std",
 	"serde",
 	"parity-codec/std",
-	"substrate-primitives/std",
+	"primitives/std",
 	"runtime_primitives/std",
 	"runtime_io/std",
 	"rstd/std",

--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -21,7 +21,7 @@ use cennznet_primitives::FeeExchange;
 use fees::BuyFeeAsset;
 use rstd::{marker::PhantomData, mem, prelude::*};
 use runtime_primitives::traits::{As, Hash};
-use substrate_primitives::crypto::{UncheckedFrom, UncheckedInto};
+use primitives::crypto::{UncheckedFrom, UncheckedInto};
 use support::dispatch::Result;
 
 /// A function that generates an `AccountId` for a CENNZX-SPOT exchange / (core, asset) pair
@@ -81,7 +81,7 @@ pub(crate) mod impl_tests {
 	use crate::tests::{CennzXSpot, ExtBuilder, Test};
 	use cennznet_primitives::FeeExchange;
 	use runtime_io::with_externalities;
-	use substrate_primitives::H256;
+	use primitives::H256;
 
 	const CORE_ASSET: u32 = 0;
 	const OTHER_ASSET: u32 = 1;

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -30,7 +30,7 @@ use runtime_primitives::{
 	traits::{BlakeTwo256, IdentityLookup, Zero},
 	BuildStorage,
 };
-use substrate_primitives::{crypto::UncheckedInto, Blake2Hasher, H256};
+use primitives::{crypto::UncheckedInto, Blake2Hasher, H256};
 use support::{impl_outer_origin, StorageValue};
 
 use parity_codec::{Decode, Encode};

--- a/crml/sylo/Cargo.toml
+++ b/crml/sylo/Cargo.toml
@@ -6,27 +6,27 @@ authors = ["Centrality Developers <support@centrality.ai>"]
 [dependencies]
 serde = { version = "1.0", default-features = false }
 parity-codec = { version = "3.1", default-features = false, features = ["derive"] }
-substrate-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+primitives = { package = "substrate-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 sr-std = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 sr-io = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
-sr-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+runtime-primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 srml-support = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 srml-system = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 srml-balances = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 
 [dev-dependencies]
-substrate-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+primitives = { package = "substrate-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 sr-io = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
-sr-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+runtime-primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 
 [features]
 default = ["std"]
 std = [
 	"parity-codec/std",
-	"substrate-primitives/std",
+	"primitives/std",
 	"sr-std/std",
 	"sr-io/std",
-	"sr-primitives/std",
+	"runtime-primitives/std",
 	"srml-support/std",
 	"srml-system/std",
 	"srml-balances/std",

--- a/crml/sylo/src/e2ee.rs
+++ b/crml/sylo/src/e2ee.rs
@@ -17,8 +17,8 @@ use srml_support::{dispatch::Vec, StorageMap};
 use {device, groups, inbox, response, system, system::ensure_signed};
 
 extern crate sr_io;
-extern crate sr_primitives;
-extern crate substrate_primitives;
+extern crate runtime_primitives;
+extern crate primitives;
 
 const MAX_PKBS: usize = 50;
 
@@ -99,13 +99,13 @@ pub(super) mod tests {
 	use super::*;
 	use codec::{Decode, Encode};
 	use serde::{Deserialize, Serialize};
-	use primitives::traits::{Verify, Lazy};
+	use runtime_primitives::traits::{Verify, Lazy};
 
 	use self::sr_io::with_externalities;
-	use self::substrate_primitives::{Blake2Hasher, H256};
+	use self::primitives::{Blake2Hasher, H256};
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are requried.
-	use self::sr_primitives::{
+	use self::runtime_primitives::{
 		testing::{Digest, DigestItem, Header},
 		traits::{BlakeTwo256, IdentityLookup},
 		BuildStorage,

--- a/crml/sylo/src/groups/mod.rs
+++ b/crml/sylo/src/groups/mod.rs
@@ -17,9 +17,9 @@
 #[cfg(test)]
 extern crate sr_io;
 
-extern crate substrate_primitives;
+extern crate primitives;
 // Needed for various traits. In our case, `OnFinalise`.
-extern crate sr_primitives;
+extern crate runtime_primitives;
 
 // `system` module provides us with all sorts of useful stuff and macros
 // depend on it being around.
@@ -30,8 +30,8 @@ extern crate parity_codec;
 mod tests;
 
 use self::parity_codec::{Decode, Encode};
-use groups::substrate_primitives::ed25519;
-use groups::substrate_primitives::hash::H256;
+use groups::primitives::ed25519;
+use groups::primitives::hash::H256;
 use srml_support::runtime_primitives::traits::Verify;
 use srml_support::{dispatch::Result, dispatch::Vec, StorageMap};
 use vault::{VaultKey, VaultValue};

--- a/crml/sylo/src/groups/tests.rs
+++ b/crml/sylo/src/groups/tests.rs
@@ -17,13 +17,13 @@
 mod tests {
 	use codec::Decode;
 	use serde::{Deserialize, Serialize};
-	use primitives::traits::{Verify, Lazy};
+	use runtime_primitives::traits::{Verify, Lazy};
 	use groups::sr_io::with_externalities;
-	use groups::substrate_primitives::{ed25519, Pair};
-	use groups::substrate_primitives::{Blake2Hasher, H256};
+	use groups::primitives::{ed25519, Pair};
+	use groups::primitives::{Blake2Hasher, H256};
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are requried.
-	use groups::sr_primitives::{
+	use groups::runtime_primitives::{
 		testing::{Digest, DigestItem, Header},
 		traits::{BlakeTwo256, IdentityLookup},
 		BuildStorage,

--- a/crml/sylo/src/inbox.rs
+++ b/crml/sylo/src/inbox.rs
@@ -18,10 +18,10 @@ use system::ensure_signed;
 
 extern crate sr_io;
 extern crate sr_std;
-extern crate substrate_primitives;
+extern crate primitives;
 
 // Needed for various traits. In our case, `OnFinalise`.
-extern crate sr_primitives;
+extern crate runtime_primitives;
 
 // `system` module provides us with all sorts of useful stuff and macros
 // depend on it being around.
@@ -117,13 +117,13 @@ mod tests {
 
 	use codec::{Decode, Encode};
 	use serde::{Deserialize, Serialize};
-	use primitives::traits::{Verify, Lazy};
+	use runtime_primitives::traits::{Verify, Lazy};
 
 	use self::sr_io::with_externalities;
-	use self::substrate_primitives::{Blake2Hasher, H256};
+	use self::primitives::{Blake2Hasher, H256};
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are requried.
-	use self::sr_primitives::{
+	use self::runtime_primitives::{
 		testing::{Digest, DigestItem, Header},
 		traits::{BlakeTwo256, IdentityLookup},
 		BuildStorage,

--- a/crml/sylo/src/lib.rs
+++ b/crml/sylo/src/lib.rs
@@ -21,10 +21,10 @@ extern crate serde;
 extern crate parity_codec as codec;
 extern crate sr_io as runtime_io;
 extern crate sr_std as rstd;
-extern crate substrate_primitives;
+extern crate primitives;
 #[macro_use]
 extern crate srml_support;
-extern crate sr_primitives as primitives;
+extern crate runtime_primitives;
 extern crate srml_balances as balances;
 extern crate srml_system as system;
 

--- a/crml/sylo/src/response.rs
+++ b/crml/sylo/src/response.rs
@@ -21,8 +21,8 @@ use system::ensure_signed;
 extern crate srml_system as system;
 
 extern crate sr_io;
-extern crate sr_primitives;
-extern crate substrate_primitives;
+extern crate runtime_primitives;
+extern crate primitives;
 
 pub trait Trait: system::Trait {}
 
@@ -71,13 +71,13 @@ pub(super) mod tests {
 
 	use codec::{Decode, Encode};
 	use serde::{Deserialize, Serialize};
-	use primitives::traits::{Verify, Lazy};
+	use runtime_primitives::traits::{Verify, Lazy};
 
 	use self::sr_io::with_externalities;
-	use self::substrate_primitives::{Blake2Hasher, H256};
+	use self::primitives::{Blake2Hasher, H256};
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are requried.
-	use self::sr_primitives::{
+	use self::runtime_primitives::{
 		testing::{Digest, DigestItem, Header},
 		traits::{BlakeTwo256, IdentityLookup},
 		BuildStorage,

--- a/crml/sylo/src/vault.rs
+++ b/crml/sylo/src/vault.rs
@@ -17,8 +17,8 @@ use srml_support::{dispatch::Vec, StorageMap};
 use {system, system::ensure_signed};
 
 extern crate sr_io;
-extern crate sr_primitives;
-extern crate substrate_primitives;
+extern crate runtime_primitives;
+extern crate primitives;
 
 pub const KEYS_MAX: usize = 100;
 
@@ -79,13 +79,13 @@ mod tests {
 
 	use codec::{Decode, Encode};
 	use serde::{Deserialize, Serialize};
-	use primitives::traits::{Verify, Lazy};
+	use runtime_primitives::traits::{Verify, Lazy};
 
 	use self::sr_io::with_externalities;
-	use self::substrate_primitives::{Blake2Hasher, H256};
+	use self::primitives::{Blake2Hasher, H256};
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are requried.
-	use self::sr_primitives::{
+	use self::runtime_primitives::{
 		testing::{Digest, DigestItem, Header},
 		traits::{BlakeTwo256, IdentityLookup},
 		BuildStorage,

--- a/prml/attestation/Cargo.toml
+++ b/prml/attestation/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 parity-codec = { version = "3.1", default-features = false, features = ["derive"] }
 primitives = { package = "substrate-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
-runtime_primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+runtime-primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 sr-std = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 sr-io = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 srml-support = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }

--- a/prml/attestation/Cargo.toml
+++ b/prml/attestation/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 
 [dependencies]
 parity-codec = { version = "3.1", default-features = false, features = ["derive"] }
-substrate-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
-sr-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+primitives = { package = "substrate-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+runtime_primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 sr-std = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 sr-io = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 srml-support = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
@@ -17,8 +17,8 @@ srml-system = { git = "https://github.com/cennznet/plug-blockchain", default-fea
 default = ["std"]
 std = [
 	"parity-codec/std",
-	"substrate-primitives/std",
-	"sr-primitives/std",
+	"primitives/std",
+	"runtime-primitives/std",
 	"sr-std/std",
 	"sr-io/std",
 	"srml-support/std",

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -47,13 +47,13 @@ extern crate parity_codec as codec;
 extern crate srml_support as runtime_support;
 
 extern crate sr_io as io;
-extern crate sr_primitives as primitives;
+extern crate runtime_primitives;
 extern crate srml_system as system;
-extern crate substrate_primitives;
+extern crate primitives;
 
 use runtime_support::rstd::prelude::*;
 use runtime_support::{dispatch::Result, StorageMap};
-use substrate_primitives::uint::U256;
+use primitives::uint::U256;
 use system::ensure_signed;
 
 pub trait Trait: system::Trait {

--- a/prml/generic-asset/Cargo.toml
+++ b/prml/generic-asset/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", optional = true }
 parity-codec = { version = "3.1", default-features = false, features = ["derive"] }
-substrate-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
-primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+primitives = { package = "substrate-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+runtime-primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 rstd = { package = "sr-std", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 runtime_io = { package = "sr-io", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 support = { package="srml-support", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
@@ -19,10 +19,10 @@ default = ["std"]
 std =[
 	"serde",
     "parity-codec/std",
-    "substrate-primitives/std",
+    "primitives/std",
     "rstd/std",
     "runtime_io/std",
-    "primitives/std",
+    "runtime-primitives/std",
     "support/std",
     "system/std",
 ]

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -147,7 +147,7 @@
 
 use parity_codec::{Decode, Encode, HasCompact};
 
-use primitives::traits::{
+use runtime_primitives::traits::{
 	As, CheckedAdd, CheckedSub, MaybeSerializeDebug, Member, One, Saturating, SimpleArithmetic, Zero,
 };
 
@@ -434,7 +434,7 @@ decl_storage! {
 		config(initial_balance): T::Balance;
 		config(endowed_accounts): Vec<T::AccountId>;
 
-		build(|storage: &mut primitives::StorageOverlay, _: &mut primitives::ChildrenStorageOverlay, config: &GenesisConfig<T>| {
+		build(|storage: &mut runtime_primitives::StorageOverlay, _: &mut runtime_primitives::ChildrenStorageOverlay, config: &GenesisConfig<T>| {
 			config.assets.iter().for_each(|asset_id| {
 				config.endowed_accounts.iter().for_each(|account_id| {
 					storage.insert(

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -18,13 +18,13 @@
 #![cfg(test)]
 
 use parity_codec::{Decode, Encode};
-use primitives::{
+use runtime_primitives::{
 	testing::{Digest, DigestItem, Header},
 	traits::{BlakeTwo256, IdentityLookup, Lazy, Verify},
 	BuildStorage,
 };
 use serde::{Deserialize, Serialize};
-use substrate_primitives::{Blake2Hasher, H256};
+use primitives::{Blake2Hasher, H256};
 use support::{impl_outer_event, impl_outer_origin};
 
 use super::*;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 integer-sqrt = { version = "0.1.2" }
 safe-mix = { version = "1.0", default-features = false }
 parity-codec = { version = "3.1", default-features = false, features = ["derive"] }
-substrate-primitives = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
+primitives = { package = "substrate-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 substrate-client = { git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 rstd = { package = "sr-std", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
 runtime-primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
@@ -52,7 +52,7 @@ core = [
 ]
 std = [
 	"parity-codec/std",
-	"substrate-primitives/std",
+	"primitives/std",
 	"rstd/std",
 	"runtime-primitives/std",
 	"support/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -38,7 +38,7 @@ use substrate_client::{
 	block_builder::api::{self as block_builder_api, CheckInherentsResult, InherentData},
 	runtime_api as client_api,
 };
-use substrate_primitives::OpaqueMetadata;
+use primitives::OpaqueMetadata;
 use support::construct_runtime;
 use support::traits::Currency;
 

--- a/runtime/tests/fee.rs
+++ b/runtime/tests/fee.rs
@@ -20,13 +20,13 @@ use cennznet_primitives::CheckedCennznetExtrinsic;
 use cennznet_runtime::{Call, ExtrinsicFeePayment, Fee, Runtime};
 use runtime_io::with_externalities;
 use runtime_primitives::BuildStorage;
-use substrate_primitives::{sr25519::Public, Blake2Hasher};
+use primitives::{sr25519::Public, Blake2Hasher};
 use support::{additional_traits::ChargeExtrinsicFee, assert_err, assert_ok};
 
 // A default address for ChargeExtrinsicFee `transactor`
 const DEFAULT_TRANSACTOR: Public = Public([0u8; 32]);
 
-type MockCheckedExtrinsic = CheckedCennznetExtrinsic<substrate_primitives::sr25519::Public, u64, Call, u128>;
+type MockCheckedExtrinsic = CheckedCennznetExtrinsic<primitives::sr25519::Public, u64, Call, u128>;
 type System = system::Module<Runtime>;
 type Fees = fees::Module<Runtime>;
 


### PR DESCRIPTION
Closes #18 

The following code is used in `Cargo.toml` where possible:
```
primitives = { package = "substrate-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
runtime-primitives = { package = "sr-primitives", git = "https://github.com/cennznet/plug-blockchain", default-features = false }
```

Because `-` and `_` are interchangeable in `Cargo.toml`, some files still use `_`.