### PR TITLE
enable cennznut/std for std

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -88,4 +88,5 @@ std = [
 	"generic-asset/std",
 	"fees/std",
 	"rewards/std",
+	"cennznut/std",
 ]


### PR DESCRIPTION
otherwise stable rust build will fail