### PR TITLE
publish image with -hotfix tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,9 +88,8 @@ jobs:
             else
               DOCKER_TAG="${CIRCLE_TAG}"
             fi
-            docker build --pull -t cennznet/cennznet:latest -t cennznet/cennznet:$DOCKER_TAG -f docker/Dockerfile .
-            docker push cennznet/cennznet:$DOCKER_TAG
-            docker push cennznet/cennznet:latest
+            docker build --pull -t cennznet/cennznet:$DOCKER_TAG-hotfix -f docker/Dockerfile .
+            docker push cennznet/cennznet:$DOCKER_TAG-hotfix
           no_output_timeout: 60m
 workflows:
   version: 2


### PR DESCRIPTION
Task list:
- [x] docker image is published as `cennznet/cennznet: 0.9.25-beta-<commit_hash>-hotfix`
- [ ] relevant crates are pointed to the `cennznet/plug-blockchain/hotfix` branch

Closes #69 