### PR TITLE
Fix cennznet primitive types

### DIFF
--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -36,7 +36,7 @@ native_executor_instance!(
 #[cfg(test)]
 mod tests {
 	use super::Executor;
-	use cennznet_primitives::{Balance, BlockNumber, Hash};
+	use cennznet_primitives::{Balance, BlockNumber, Hash, Index, Timestamp};
 	use cennznet_runtime::{
 		constants::currency::*, impls::WeightToFee, Balances, Block, BuildStorage, Call, CheckedExtrinsic, Event,
 		Header, Runtime, System, TransactionBaseFee, TransactionByteFee, TransactionPayment, TransferFee,
@@ -463,7 +463,7 @@ mod tests {
 		(block1, block2)
 	}
 
-	fn block_with_size(time: u64, nonce: u32, size: usize) -> (Vec<u8>, Hash) {
+	fn block_with_size(time: Timestamp, nonce: Index, size: usize) -> (Vec<u8>, Hash) {
 		construct_block(
 			&mut new_test_ext(COMPACT_CODE, false),
 			1,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -42,14 +42,17 @@ pub type AccountIndex = u32;
 /// Balance of an account.
 pub type Balance = u128;
 
-/// The runtime supported proof of delegation format
+/// Asset ID for generic asset module.
+pub type AssetId = u32;
+
+/// The runtime supported proof of delegation format.
 pub type Doughnut = DoughnutV0;
 
 /// Type used for expressing timestamp.
 pub type Moment = u64;
 
 /// Index of a transaction in the chain.
-pub type Index = u32;
+pub type Index = u64;
 
 /// A hash of some data used by the chain.
 pub type Hash = primitives::H256;


### PR DESCRIPTION
- use consistent primitive types for transaction index
- add AssetId type to be used in generic-asset module

(to be updated with Wilfred's response)