### PR TITLE
Optimise circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,10 @@ workflows:
     jobs:
       - build-bin
       - build-test-and-run
-      - build-docker-and-publish
+      - build-docker-and-publish:
+          filters:
+            branches:
+              only: master
       - build:
           requires:
             - build-bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     steps:
-      - run: echo "successfully build and tested"
+      - run: echo "successfully built and tested"
   build-bin:
     machine:
       image: ubuntu-1604:201903-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,11 @@ commands:
           no_output_timeout: 60m
 
 jobs:
+  build:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - run: echo "successfully build and tested"
   build-bin:
     machine:
       image: ubuntu-1604:201903-01
@@ -141,3 +146,8 @@ workflows:
           filters:
             branches:
               only: develop
+      - build:
+          requires:
+            - build-bin
+            - build-test-and-run
+            - build-docker-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,10 +144,7 @@ workflows:
     jobs:
       - build-bin
       - build-test-and-run
-      - build-docker-and-publish:
-          filters:
-            branches:
-              only: develop
+      - build-docker-and-publish
       - build:
           requires:
             - build-bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,9 @@ workflows:
       - build-docker-and-publish:
           filters:
             branches:
-              only: master
+              only:
+                - develop
+                - /^[0-9]+[.][0-9]+[.][0-9](-rc.+)?$/
       - build:
           requires:
             - build-bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
           key: target-cache-{{ arch }}-{{ checksum ".circleci/RUST_VERSION" }}-{{ .Environment.CIRCLE_BRANCH }}
 
 jobs:
-  build:
+  build-bin:
     machine:
       image: ubuntu-1604:201903-01
     environment:
@@ -82,6 +82,20 @@ jobs:
           no_output_timeout: 30m
       - save-cache
       - save-target-cache
+  build-test:
+    machine:
+      image: ubuntu-1604:201903-01
+    environment:
+      BASH_ENV: ~/.cargo/env
+      RUST_VERSION: nightly-2019-10-14
+      RUSTC_WRAPPER: sccache
+      SCCACHE_CACHE_SIZE: 10G
+    steps:
+      - checkout
+      - install-rust
+      - install-sccache
+      - restore-cache
+      - restore-target-cache
       - run:
           name: Build tests
           command: |
@@ -92,3 +106,10 @@ jobs:
           name: Run tests
           command: |
             cargo test --all
+
+workflows:
+  version: 2
+  build-test:
+    jobs:
+      - build-bin
+      - build-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,30 @@ commands:
       - restore_cache:
           name: Restore target cache
           key: target-cache-{{ arch }}-{{ checksum ".circleci/RUST_VERSION" }}-{{ .Environment.CIRCLE_BRANCH }}
+  cargo-check:
+    - run:
+        name: Build
+        command: |
+          cargo check
+        no_output_timeout: 30m
+  cargo-build-test:
+    - run:
+        name: Build tests
+        command: |
+          cargo test --no-run --all
+  cargo-run-test:
+    - run:
+        name: Run tests
+        command: |
+          cargo test --all
+  docker-build-and-publish:
+    - run:
+        name: Build and publish Docker image
+        command: |
+          docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+          docker build --pull -t cennznet/cennznet:dev -f docker/Dockerfile .
+          docker push cennznet/cennznet:dev
+        no_output_timeout: 60m
 
 jobs:
   build-bin:
@@ -75,14 +99,10 @@ jobs:
       - install-sccache
       - restore-cache
       - restore-target-cache
-      - run:
-          name: Build
-          command: |
-            cargo check
-          no_output_timeout: 30m
+      - cargo-check
       - save-cache
       - save-target-cache
-  build-test:
+  build-test-and-run:
     machine:
       image: ubuntu-1604:201903-01
     environment:
@@ -96,20 +116,24 @@ jobs:
       - install-sccache
       - restore-cache
       - restore-target-cache
-      - run:
-          name: Build tests
-          command: |
-            cargo test --no-run --all
+      - cargo-build-test
       - save-cache
       - save-target-cache
-      - run:
-          name: Run tests
-          command: |
-            cargo test --all
+      - cargo-run-test
+  build-docker-and-publish:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - docker-build-and-publish
 
 workflows:
   version: 2
-  build-test:
+  build-test-publish:
     jobs:
       - build-bin
-      - build-test
+      - build-test-and-run
+      - build-docker-and-publish:
+          filters:
+            branches:
+              only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ commands:
             IMAGE_TAG="${CIRCLE_BRANCH////-}-${CIRCLE_SHA1:0:7}"
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
             docker build --pull -t $IMAGE_NAME:$IMAGE_TAG -f docker/Dockerfile .
-            docker push cennznet/cennznet:dev
+            docker push $IMAGE_NAME:$IMAGE_TAG
           no_output_timeout: 60m
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,10 @@ commands:
       - run:
           name: Build and publish Docker image
           command: |
+            IMAGE_NAME="cennznet/cennznet"
+            IMAGE_TAG="${CIRCLE_BRANCH}-${CIRCLE_SHA1:0:7}"
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-            docker build --pull -t cennznet/cennznet:dev -f docker/Dockerfile .
+            docker build --pull -t $IMAGE_NAME:$IMAGE_TAG -f docker/Dockerfile .
             docker push cennznet/cennznet:dev
           no_output_timeout: 60m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
           name: Build and publish Docker image
           command: |
             IMAGE_NAME="cennznet/cennznet"
-            IMAGE_TAG="${CIRCLE_BRANCH}-${CIRCLE_SHA1:0:7}"
+            IMAGE_TAG="${CIRCLE_BRANCH////-}-${CIRCLE_SHA1:0:7}"
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
             docker build --pull -t $IMAGE_NAME:$IMAGE_TAG -f docker/Dockerfile .
             docker push cennznet/cennznet:dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ commands:
             IMAGE_NAME="cennznet/cennznet"
             IMAGE_TAG="${CIRCLE_BRANCH////-}-${CIRCLE_SHA1:0:7}"
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-            docker build --pull -t $IMAGE_NAME:$IMAGE_TAG -f docker/Dockerfile .
+            docker build --pull -t $IMAGE_NAME:$IMAGE_TAG -f ./Dockerfile .
             docker push $IMAGE_NAME:$IMAGE_TAG
           no_output_timeout: 60m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,11 @@ commands:
           name: Build and publish Docker image
           command: |
             IMAGE_NAME="cennznet/cennznet"
-            IMAGE_TAG="${CIRCLE_BRANCH////-}-${CIRCLE_SHA1:0:7}"
+            if [ "${CIRCLE_BRANCH}" == "develop" ]; then
+              IMAGE_TAG="latest"
+            else
+              IMAGE_TAG="${CIRCLE_BRANCH////-}-${CIRCLE_SHA1:0:7}"
+            fi
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
             docker build --pull -t $IMAGE_NAME:$IMAGE_TAG -f ./Dockerfile .
             docker push $IMAGE_NAME:$IMAGE_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,29 +60,33 @@ commands:
           name: Restore target cache
           key: target-cache-{{ arch }}-{{ checksum ".circleci/RUST_VERSION" }}-{{ .Environment.CIRCLE_BRANCH }}
   cargo-check:
-    - run:
-        name: Build
-        command: |
-          cargo check
-        no_output_timeout: 30m
+    steps:
+      - run:
+          name: Build
+          command: |
+            cargo check
+          no_output_timeout: 30m
   cargo-build-test:
-    - run:
-        name: Build tests
-        command: |
-          cargo test --no-run --all
+    steps:
+      - run:
+          name: Build tests
+          command: |
+            cargo test --no-run --all
   cargo-run-test:
-    - run:
-        name: Run tests
-        command: |
-          cargo test --all
+    steps:
+      - run:
+          name: Run tests
+          command: |
+            cargo test --all
   docker-build-and-publish:
-    - run:
-        name: Build and publish Docker image
-        command: |
-          docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-          docker build --pull -t cennznet/cennznet:dev -f docker/Dockerfile .
-          docker push cennznet/cennznet:dev
-        no_output_timeout: 60m
+    steps:
+      - run:
+          name: Build and publish Docker image
+          command: |
+            docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+            docker build --pull -t cennznet/cennznet:dev -f docker/Dockerfile .
+            docker push cennznet/cennznet:dev
+          no_output_timeout: 60m
 
 jobs:
   build-bin:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM  rustlang/rust:nightly AS builder
+WORKDIR /cennznet
+COPY . /cennznet
+
+ENV RUST_VERSION nightly-2019-10-14
+RUN apt-get update && \
+    apt-get -y install apt-utils cmake pkg-config libssl-dev git clang libclang-dev && \
+    rustup install $RUST_VERSION && \
+    rustup default $RUST_VERSION && \
+    rustup target add --toolchain $RUST_VERSION wasm32-unknown-unknown && \
+    rustup target add --toolchain $RUST_VERSION x86_64-unknown-linux-musl && \
+    mkdir -p /cennznet/.cargo
+ENV CARGO_HOME=/cennznet/.cargo
+RUN cargo build --release
+
+FROM debian:stretch-slim
+LABEL maintainer="support@centrality.ai"
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates openssl && \
+    mkdir -p /root/.local/share/cennznet && \
+    ln -s /root/.local/share/cennznet /data
+
+COPY --from=0 /cennznet/target/release/cennznet /usr/local/bin
+EXPOSE 30333 9933 9944
+VOLUME ["/data"]
+ENTRYPOINT ["/usr/local/bin/cennznet"]


### PR DESCRIPTION
Changes:
- divide building binary (only runs `cargo check`) and tests into jobs (so that they can run in parallel in a workflow)
- refactor inline `run` into `commands`
- added `build-docker-and-publish` job to deploy with `dev` tag for now
- added `build` job to make ci pass (circleci requires `build` job to pass)
