### PR TITLE
Add FeeExchange and pay tx fee with CENNZX

### DIFF
--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -17,7 +17,7 @@
 //! Extra CENNZX-Spot traits + implementations
 //!
 use super::Trait;
-use crate::{types::FeeExchange, Module};
+use crate::{types::FeeExchangeV1, Module};
 use cennznet_primitives::traits::BuyFeeAsset;
 use primitives::crypto::{UncheckedFrom, UncheckedInto};
 use rstd::{marker::PhantomData, prelude::*};
@@ -53,7 +53,7 @@ fn u64_to_bytes(x: u64) -> [u8; 8] {
 }
 
 impl<T: Trait> BuyFeeAsset<T::AccountId, T::Balance> for Module<T> {
-	type FeeExchange = FeeExchange<T::Balance>;
+	type FeeExchange = FeeExchangeV1<T::Balance>;
 	/// Use the CENNZX-Spot exchange to seamlessly buy fee asset
 	fn buy_fee_asset(who: &T::AccountId, amount: T::Balance, exchange_op: &Self::FeeExchange) -> Result {
 		// TODO: Hard coded to use spending asset ID
@@ -78,7 +78,7 @@ pub(crate) mod impl_tests {
 	use crate::{
 		mock::{self, CORE_ASSET_ID, FEE_ASSET_ID, TRADE_ASSET_A_ID},
 		tests::{CennzXSpot, ExtBuilder, Test},
-		types::FeeExchange,
+		types::FeeExchangeV1,
 	};
 	use primitives::H256;
 	use support::traits::Currency;
@@ -102,7 +102,7 @@ pub(crate) mod impl_tests {
 			assert_ok!(<CennzXSpot as BuyFeeAsset<_, _>>::buy_fee_asset(
 				&user,
 				target_fee,
-				&FeeExchange::new(TRADE_ASSET_A_ID, 2_000_000),
+				&FeeExchangeV1::new(0, TRADE_ASSET_A_ID, 2_000_000),
 			));
 
 			// For more detail, see `fn get_output_price` in lib.rs
@@ -160,7 +160,7 @@ pub(crate) mod impl_tests {
 				<CennzXSpot as BuyFeeAsset<_, _>>::buy_fee_asset(
 					&user,
 					51,
-					&FeeExchange::new(TRADE_ASSET_A_ID, 1_000_000)
+					&FeeExchangeV1::new(0, TRADE_ASSET_A_ID, 1_000_000)
 				),
 				"Failed to charge transaction fees during conversion"
 			);

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -101,22 +101,37 @@ impl From<Compact<FeeRate>> for FeeRate {
 	}
 }
 
+/// The outer `FeeExchange` type. It is versioned to provide flexbility for future iterations
+/// while maintaining backward compatability.
+#[derive(Encode, Decode)]
+pub enum FeeExchange<T: HasCompact> {
+	// A V1 FeeExchange, it may be `None` meaning no fee exchange is required
+	#[codec(compact)]
+	V1(Option<FeeExchangeV1<T>>),
+}
+
+/// A v1 FeeExchange
+/// Signals a fee payment requiring the CENNZX-Spot exchange. It is intended to
+/// embed within CENNZnet extrinsic payload.
+/// It specifies input asset ID and the max. limit of input asset to pay
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct FeeExchange<Balance: HasCompact> {
+pub struct FeeExchangeV1<Balance: HasCompact> {
+	/// An optional tip to increase transaction priority
+	#[codec(compact)]
+	pub tip: Balance,
 	/// The asset ID to pay in exchange for fee asset
 	#[codec(compact)]
 	pub asset_id: AssetId,
-	/// The max. amount of `asset_id` to pay for the needed fee amount.
-	/// The operation should fail otherwise.
+	/// The maximum `asset_id` to pay, given the exchange rate
 	#[codec(compact)]
 	pub max_payment: Balance,
 }
 
-impl<Balance: HasCompact> FeeExchange<Balance> {
+impl<Balance: HasCompact> FeeExchangeV1<Balance> {
 	/// Create a new FeeExchange
-	pub fn new(asset_id: AssetId, max_payment: Balance) -> Self {
-		Self { asset_id, max_payment }
+	pub fn new(tip: Balance, asset_id: AssetId, max_payment: Balance) -> Self {
+		Self { tip, asset_id, max_payment }
 	}
 }
 


### PR DESCRIPTION
Changes:
- added FeeExchangeV1 struct with `tip` field
- changed FeeExchange to enum, which takes the above (versioned) struct
- more to come...

Closes #88 