### PR TITLE
Add FeeExchange and pay tx fee with CENNZX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,13 +800,11 @@ name = "crml-transaction-payment"
 version = "1.0.0"
 dependencies = [
  "cennznet-primitives",
- "crml-cennzx-spot",
  "parity-scale-codec",
  "sr-io",
  "sr-primitives",
  "sr-std",
  "srml-balances",
- "srml-generic-asset",
  "srml-support",
  "srml-system",
  "substrate-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ name = "crml-transaction-payment"
 version = "1.0.0"
 dependencies = [
  "cennznet-primitives",
+ "crml-cennzx-spot",
  "parity-scale-codec",
  "sr-io",
  "sr-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
 name = "cennznet-primitives"
 version = "1.0.0"
 dependencies = [
+ "parity-scale-codec",
  "pretty_assertions",
  "sr-primitives",
  "srml-support",
@@ -804,6 +805,7 @@ dependencies = [
  "sr-primitives",
  "sr-std",
  "srml-balances",
+ "srml-generic-asset",
  "srml-support",
  "srml-system",
  "substrate-primitives",

--- a/cli/src/factory_impl.rs
+++ b/cli/src/factory_impl.rs
@@ -60,7 +60,7 @@ impl<Number> FactoryState<Number> {
 			system::CheckEra::from(Era::mortal(256, phase)),
 			system::CheckNonce::from(index),
 			system::CheckWeight::new(),
-			transaction_payment::ChargeTransactionPayment::from(0),
+			transaction_payment::ChargeTransactionPayment::from(0, None),
 			Default::default(),
 		)
 	}

--- a/cli/src/service.rs
+++ b/cli/src/service.rs
@@ -525,7 +525,7 @@ mod tests {
 				let check_era = system::CheckEra::from(Era::Immortal);
 				let check_nonce = system::CheckNonce::from(index);
 				let check_weight = system::CheckWeight::new();
-				let payment = transaction_payment::ChargeTransactionPayment::from(0);
+				let payment = transaction_payment::ChargeTransactionPayment::from(0, None);
 				let extra = (
 					None,
 					check_version,

--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -17,8 +17,8 @@
 //! Extra CENNZX-Spot traits + implementations
 //!
 use super::Trait;
-use crate::{types::FeeExchange, Module};
-use cennznet_primitives::traits::BuyFeeAsset;
+use crate::Module;
+use cennznet_primitives::{traits::BuyFeeAsset, types::FeeExchangeV1 as FeeExchange};
 use primitives::crypto::{UncheckedFrom, UncheckedInto};
 use rstd::{marker::PhantomData, prelude::*};
 use runtime_primitives::traits::Hash;
@@ -78,8 +78,8 @@ pub(crate) mod impl_tests {
 	use crate::{
 		mock::{self, CORE_ASSET_ID, FEE_ASSET_ID, TRADE_ASSET_A_ID},
 		tests::{CennzXSpot, ExtBuilder, Test},
-		types::FeeExchange,
 	};
+	use cennznet_primitives::types::FeeExchangeV1 as FeeExchange;
 	use primitives::H256;
 	use support::traits::Currency;
 

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -16,7 +16,6 @@
 //!
 //! CENNZX-SPOT Types
 //!
-use cennznet_primitives::types::AssetId;
 use core::convert::TryInto;
 use uint::construct_uint;
 construct_uint! {
@@ -29,7 +28,7 @@ construct_uint! {
 	pub struct U256(4);
 }
 
-use codec::{Compact, CompactAs, Decode, Encode, HasCompact};
+use codec::{Compact, CompactAs, Decode, Encode};
 
 /// FeeRate S.F precision
 const SCALE_FACTOR: u128 = 1_000_000;
@@ -98,25 +97,6 @@ impl CompactAs for FeeRate {
 impl From<Compact<FeeRate>> for FeeRate {
 	fn from(x: Compact<FeeRate>) -> FeeRate {
 		x.0
-	}
-}
-
-#[derive(PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug))]
-pub struct FeeExchange<Balance: HasCompact> {
-	/// The asset ID to pay in exchange for fee asset
-	#[codec(compact)]
-	pub asset_id: AssetId,
-	/// The max. amount of `asset_id` to pay for the needed fee amount.
-	/// The operation should fail otherwise.
-	#[codec(compact)]
-	pub max_payment: Balance,
-}
-
-impl<Balance: HasCompact> FeeExchange<Balance> {
-	/// Create a new FeeExchange
-	pub fn new(asset_id: AssetId, max_payment: Balance) -> Self {
-		Self { asset_id, max_payment }
 	}
 }
 

--- a/crml/transaction-payment/Cargo.toml
+++ b/crml/transaction-payment/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 cennznet-primitives = { path = "../../primitives", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+generic-asset = { package = "srml-generic-asset", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
 rstd = { package = "sr-std", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
 sr-primitives = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
 support = { package = "srml-support", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
@@ -22,6 +23,7 @@ default = ["std"]
 std = [
 	"cennznet-primitives/std",
 	"codec/std",
+	"generic-asset/std",
 	"rstd/std",
 	"sr-primitives/std",
 	"support/std",

--- a/crml/transaction-payment/Cargo.toml
+++ b/crml/transaction-payment/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 cennznet-primitives = { path = "../../primitives", default-features = false }
+cennzx-spot = { package = "crml-cennzx-spot", path = "../cennzx-spot", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 generic-asset = { package = "srml-generic-asset", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
 rstd = { package = "sr-std", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
@@ -22,6 +23,7 @@ balances = { package = "srml-balances", git = "https://github.com/plugblockchain
 default = ["std"]
 std = [
 	"cennznet-primitives/std",
+	"cennzx-spot/std",
 	"codec/std",
 	"generic-asset/std",
 	"rstd/std",

--- a/crml/transaction-payment/Cargo.toml
+++ b/crml/transaction-payment/Cargo.toml
@@ -6,9 +6,7 @@ edition = "2018"
 
 [dependencies]
 cennznet-primitives = { path = "../../primitives", default-features = false }
-cennzx-spot = { package = "crml-cennzx-spot", path = "../cennzx-spot", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
-generic-asset = { package = "srml-generic-asset", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
 rstd = { package = "sr-std", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
 sr-primitives = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
 support = { package = "srml-support", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc1", default-features = false }
@@ -23,9 +21,7 @@ balances = { package = "srml-balances", git = "https://github.com/plugblockchain
 default = ["std"]
 std = [
 	"cennznet-primitives/std",
-	"cennzx-spot/std",
 	"codec/std",
-	"generic-asset/std",
 	"rstd/std",
 	"sr-primitives/std",
 	"support/std",

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -193,7 +193,7 @@ where
 		// pay any fees.
 		let fee = Self::compute_fee(len, info, self.tip);
 		if let Some(fee_exchange) = &self.fee_exchange {
-			if let Err(_) = T::BuyFeeAsset::buy_fee_asset(who, fee, fee_exchange) {
+			if T::BuyFeeAsset::buy_fee_asset(who, fee, fee_exchange).is_err() {
 				return InvalidTransaction::Payment.into();
 			}
 		}

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -33,9 +33,12 @@
 
 use cennznet_primitives::types::FeeExchangeV1 as FeeExchange;
 use codec::{Decode, Encode};
-use rstd::prelude::*;
+use rstd::{fmt::Debug, prelude::*};
 use sr_primitives::{
-	traits::{Convert, SaturatedConversion, Saturating, SignedExtension, Zero},
+	traits::{
+		Convert, MaybeSerializeDeserialize, Member, SaturatedConversion, Saturating, SignedExtension, SimpleArithmetic,
+		Zero,
+	},
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionValidity, TransactionValidityError, ValidTransaction,
 	},
@@ -45,13 +48,20 @@ use sr_primitives::{
 use support::{
 	decl_module, decl_storage,
 	traits::{Currency, ExistenceRequirement, Get, OnUnbalanced, WithdrawReason},
+	Parameter,
 };
 
 type Multiplier = Fixed64;
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance;
 type NegativeImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::NegativeImbalance;
 
-pub trait Trait: system::Trait + generic_asset::Trait {
+pub trait Trait: system::Trait {
+	/// The units in which we record balances.
+	type Balance: Parameter + Member + SimpleArithmetic + Default + Copy + MaybeSerializeDeserialize + Debug;
+
+	/// The arithmetic type of asset identifier.
+	type AssetId: Parameter + Member + SimpleArithmetic + Default + Copy;
+
 	/// The currency type in which fees will be paid.
 	type Currency: Currency<Self::AccountId>;
 
@@ -304,6 +314,8 @@ mod tests {
 	}
 
 	impl Trait for Runtime {
+		type Balance = u128;
+		type AssetId = u32;
 		type Currency = balances::Module<Runtime>;
 		type OnTransactionPayment = ();
 		type TransactionBaseFee = TransactionBaseFee;

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -288,12 +288,6 @@ mod tests {
 		type CreationFee = CreationFee;
 	}
 
-	impl generic_asset::Trait for Runtime {
-		type Balance = u128;
-		type AssetId = u32;
-		type Event = ();
-	}
-
 	thread_local! {
 		static TRANSACTION_BASE_FEE: RefCell<u64> = RefCell::new(0);
 		static TRANSACTION_BYTE_FEE: RefCell<u64> = RefCell::new(1);

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 primitives = { package = "substrate-primitives", git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc1" }
 sr-primitives = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc1" }
 support = { package = "srml-support", git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc1" }
@@ -16,6 +17,7 @@ pretty_assertions = "0.6.1"
 [features]
 default = ["std"]
 std = [
+	"codec/std",
 	"primitives/std",
 	"sr-primitives/std",
 	"support/std",

--- a/primitives/src/impls.rs
+++ b/primitives/src/impls.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Parity Technologies (UK) Ltd. and Centrality Investments Ltd.
+// Copyright 2018-2019 Centrality Investments Ltd.
 // This file is part of Substrate.
 
 // Substrate is free software: you can redistribute it and/or modify
@@ -14,11 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Common types and traits used by CENNZnet node.
+//! Common implementaiton used by CENNZnet node.
 
-#![warn(missing_docs)]
-#![cfg_attr(not(feature = "std"), no_std)]
+use crate::types::{AssetId, FeeExchangeV1};
 
-mod impls;
-pub mod traits;
-pub mod types;
+impl<T> FeeExchangeV1<T> {
+	/// Create a new FeeExchange
+	pub fn new(asset_id: AssetId, max_payment: T) -> Self {
+		Self { asset_id, max_payment }
+	}
+}

--- a/primitives/src/impls.rs
+++ b/primitives/src/impls.rs
@@ -14,13 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Common implementaiton used by CENNZnet node.
+//! Common implementation used by CENNZnet node.
 
-use crate::types::{AssetId, FeeExchangeV1};
+use crate::types::{AssetId, Balance, FeeExchangeV1};
 
-impl<T> FeeExchangeV1<T> {
+impl FeeExchangeV1 {
 	/// Create a new FeeExchange
-	pub fn new(asset_id: AssetId, max_payment: T) -> Self {
+	pub fn new(asset_id: AssetId, max_payment: Balance) -> Self {
 		Self { asset_id, max_payment }
 	}
 }

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -16,6 +16,7 @@
 
 //! Low-level types used by CENNZnet node.
 
+use codec::{Encode, Decode};
 use sr_primitives::{
 	generic,
 	traits::{BlakeTwo256, Verify},
@@ -70,8 +71,10 @@ pub type BlockId = generic::BlockId<Block>;
 
 /// The outer `FeeExchange` type. It is versioned to provide flexbility for future iterations
 /// while maintaining backward compatability.
+#[derive(PartialEq, Eq, Clone, Encode, Decode)]
 pub enum FeeExchange<T> {
 	/// A V1 FeeExchange, it may be `None` meaning no fee exchange is required
+	#[codec(compact)]
 	V1(FeeExchangeV1<T>),
 }
 
@@ -79,10 +82,13 @@ pub enum FeeExchange<T> {
 /// Signals a fee payment requiring the CENNZX-Spot exchange. It is intended to
 /// embed within CENNZnet extrinsic payload.
 /// It specifies input asset ID and the max. limit of input asset to pay
+#[derive(PartialEq, Eq, Clone, Encode, Decode)]
 pub struct FeeExchangeV1<T> {
 	/// The Asset ID to exchange for network fee asset
+	#[codec(compact)]
 	pub asset_id: AssetId,
 	/// The maximum `asset_id` to pay, given the exchange rate
+	#[codec(compact)]
 	pub max_payment: T,
 }
 

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -72,10 +72,10 @@ pub type BlockId = generic::BlockId<Block>;
 /// The outer `FeeExchange` type. It is versioned to provide flexbility for future iterations
 /// while maintaining backward compatability.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
-pub enum FeeExchange<T> {
+pub enum FeeExchange {
 	/// A V1 FeeExchange, it may be `None` meaning no fee exchange is required
 	#[codec(compact)]
-	V1(FeeExchangeV1<T>),
+	V1(FeeExchangeV1),
 }
 
 /// A v1 FeeExchange
@@ -83,11 +83,11 @@ pub enum FeeExchange<T> {
 /// embed within CENNZnet extrinsic payload.
 /// It specifies input asset ID and the max. limit of input asset to pay
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
-pub struct FeeExchangeV1<T> {
+pub struct FeeExchangeV1 {
 	/// The Asset ID to exchange for network fee asset
 	#[codec(compact)]
 	pub asset_id: AssetId,
 	/// The maximum `asset_id` to pay, given the exchange rate
 	#[codec(compact)]
-	pub max_payment: T,
+	pub max_payment: Balance,
 }

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -91,10 +91,3 @@ pub struct FeeExchangeV1<T> {
 	#[codec(compact)]
 	pub max_payment: T,
 }
-
-impl<T> FeeExchangeV1<T> {
-	/// Create a new FeeExchange
-	pub fn new(asset_id: AssetId, max_payment: T) -> Self {
-		Self { asset_id, max_payment }
-	}
-}

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -73,7 +73,7 @@ pub type BlockId = generic::BlockId<Block>;
 /// while maintaining backward compatability.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
 pub enum FeeExchange {
-	/// A V1 FeeExchange, it may be `None` meaning no fee exchange is required
+	/// A V1 FeeExchange
 	#[codec(compact)]
 	V1(FeeExchangeV1),
 }

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -16,7 +16,7 @@
 
 //! Low-level types used by CENNZnet node.
 
-use codec::{Encode, Decode};
+use codec::{Decode, Encode};
 use sr_primitives::{
 	generic,
 	traits::{BlakeTwo256, Verify},

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -67,3 +67,28 @@ pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, OpaqueExtrinsic>;
 /// Block ID.
 pub type BlockId = generic::BlockId<Block>;
+
+/// The outer `FeeExchange` type. It is versioned to provide flexbility for future iterations
+/// while maintaining backward compatability.
+pub enum FeeExchange<T> {
+	/// A V1 FeeExchange, it may be `None` meaning no fee exchange is required
+	V1(FeeExchangeV1<T>),
+}
+
+/// A v1 FeeExchange
+/// Signals a fee payment requiring the CENNZX-Spot exchange. It is intended to
+/// embed within CENNZnet extrinsic payload.
+/// It specifies input asset ID and the max. limit of input asset to pay
+pub struct FeeExchangeV1<T> {
+	/// The Asset ID to exchange for network fee asset
+	pub asset_id: AssetId,
+	/// The maximum `asset_id` to pay, given the exchange rate
+	pub max_payment: T,
+}
+
+impl<T> FeeExchangeV1<T> {
+	/// Create a new FeeExchange
+	pub fn new(asset_id: AssetId, max_payment: T) -> Self {
+		Self { asset_id, max_payment }
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -496,7 +496,7 @@ impl system::offchain::CreateTransaction<Runtime, UncheckedExtrinsic> for Runtim
 			system::CheckEra::<Runtime>::from(generic::Era::mortal(period, current_block)),
 			system::CheckNonce::<Runtime>::from(index),
 			system::CheckWeight::<Runtime>::new(),
-			transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+			transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip, None),
 			Default::default(),
 		);
 		let raw_payload = SignedPayload::new(call, extra).ok()?;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,7 +207,7 @@ impl transaction_payment::Trait for Runtime {
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = WeightToFee;
 	type FeeMultiplierUpdate = FeeMultiplierUpdateHandler;
-	type BuyFeeAsset = ();
+	type BuyFeeAsset = CennzxSpot;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -199,6 +199,8 @@ parameter_types! {
 }
 
 impl transaction_payment::Trait for Runtime {
+	type Balance = Balance;
+	type AssetId = AssetId;
 	type Currency = SpendingAssetCurrency<Self>;
 	type OnTransactionPayment = ();
 	type TransactionBaseFee = TransactionBaseFee;

--- a/testing/src/keyring.rs
+++ b/testing/src/keyring.rs
@@ -70,7 +70,7 @@ pub fn signed_extra(nonce: Index, extra_fee: Balance) -> SignedExtra {
 		system::CheckEra::from(Era::mortal(256, 0)),
 		system::CheckNonce::from(nonce),
 		system::CheckWeight::new(),
-		transaction_payment::ChargeTransactionPayment::from(extra_fee),
+		transaction_payment::ChargeTransactionPayment::from(extra_fee, None),
 		Default::default(),
 	)
 }


### PR DESCRIPTION
Changes:
- pulled FeeExchange as versioned enum  from `cennzx-spot` into `cennznet-primitives`
- changed ChargeTransactionPayment from tuple -> named struct with optional fee_exchange
- added Balance and AssetId to transaction-payment module Trait
- tidy up & refactor tests (decoupled some unit tests)
- pulled impl out from `primitives/src/types.rs` into `primitives/src/impls.rs`

Closes #88 