### PR TITLE
tidy up circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,19 +13,21 @@ commands:
             source ~/.cargo/env
             rustup install $RUST_VERSION
             rustup default $RUST_VERSION
-            rustup target add wasm32-unknown-unknown --toolchain=$RUST_VERSION
-            export RUSTC_WRAPPER=""
-            command -v wasm-gc || cargo install --git https://github.com/alexcrichton/wasm-gc --force
-            rustup target add x86_64-unknown-linux-musl --toolchain=$RUST_VERSION
+            rustup target add --toolchain=$RUST_VERSION wasm32-unknown-unknown
+            rustup target add --toolchain=$RUST_VERSION x86_64-unknown-linux-musl
             rustc --version; cargo --version; rustup --version
   install-sccache:
     steps:
       - run:
           name: Install sccache
           command: |
-            curl -L https://github.com/mozilla/sccache/releases/download/0.2.10/sccache-0.2.10-x86_64-unknown-linux-musl.tar.gz | tar -xz
-            chmod +x sccache-0.2.10-x86_64-unknown-linux-musl/sccache
-            mv sccache-0.2.10-x86_64-unknown-linux-musl/sccache ~/.cargo/bin/sccache
+            SCCACHE_VERSION=0.2.10
+            SCCACHE="sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl"
+            SCCACHE_ARCHIVE="${SCCACHE}.tar.gz"
+            SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+            curl -L "${SCCACHE_URL}" | tar -xz
+            chmod +x $SCCACHE/sccache
+            mv $SCCACHE/sccache ~/.cargo/bin/sccache
             sccache --version
   restore-cache:
     steps:


### PR DESCRIPTION
Changes:
- removed `wasm-gc ` stuff because rustc natively supports it now
- variablise install-sccache step so we can easily bump versions later, with reference to [this](https://github.com/mozilla/application-services/blob/master/.circleci/config.yml) ci config
---
Notes:
- steps cannot run in parallel, only jobs can:
  + tried to run checkout, install-rust and install-sccache steps in parallel, which wasn't possible
  + a solution to reduce time installing rust, etc. is to (1) create a base image building repo, (2) publish to docker hub with our specific needs and (3) use that image in this repo as base