### PR TITLE
Changed the way module names prefixes are removed

### DIFF
--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -23,7 +23,7 @@ use cennznet_runtime::{
 	ElectionsConfig, GenericAssetConfig, GrandpaConfig, ImOnlineConfig, IndicesConfig, SessionConfig, SessionKeys,
 	StakerStatus, StakingConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig, WASM_BINARY,
 };
-use cennznet_runtime::{Block, FeeRate, PerMillion, PerMilli};
+use cennznet_runtime::{Block, FeeRate, PerMilli, PerMillion};
 use chain_spec::ChainSpecExtension;
 use core::convert::TryFrom;
 use grandpa_primitives::AuthorityId as GrandpaId;

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -25,7 +25,7 @@ mod tests;
 mod impls;
 mod types;
 pub use impls::{ExchangeAddressFor, ExchangeAddressGenerator};
-pub use types::{Error, FeeRate, HighPrecisionUnsigned, LowPrecisionUnsigned, PerMillion, PerMilli};
+pub use types::{Error, FeeRate, HighPrecisionUnsigned, LowPrecisionUnsigned, PerMilli, PerMillion};
 
 #[macro_use]
 extern crate support;

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -20,7 +20,7 @@
 use crate::{
 	impls::{ExchangeAddressFor, ExchangeAddressGenerator},
 	mock::{self, CORE_ASSET_ID, TRADE_ASSET_A_ID, TRADE_ASSET_B_ID},
-	types::{FeeRate, LowPrecisionUnsigned, PerMillion, PerMilli},
+	types::{FeeRate, LowPrecisionUnsigned, PerMilli, PerMillion},
 	Call, CoreAssetId, DefaultFeeRate, GenesisConfig, Module, Trait,
 };
 use core::convert::TryFrom;
@@ -457,8 +457,8 @@ fn make_asset_to_core_swap_output() {
 				&trader, // buyer
 				&trader, // recipient
 				&resolve_asset_id!(TradeAssetCurrencyA),
-				5,                                                                       // buy_amount: T::Balance,
-				1400,                                                                    // max_sale: T::Balance,
+				5,                                                                          // buy_amount: T::Balance,
+				1400,                                                                       // max_sale: T::Balance,
 				FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(), // fee_rate
 			),
 			1004
@@ -603,8 +603,8 @@ fn make_core_to_asset_output() {
 				&buyer,
 				&recipient,
 				&resolve_asset_id!(TradeAssetCurrencyA),
-				5,                                                                       // buy_amount: T::Balance,
-				1400,                                                                    // max_sale: T::Balance,
+				5,                                                                          // buy_amount: T::Balance,
+				1400,                                                                       // max_sale: T::Balance,
 				FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(), // fee_rate
 			),
 			1004

--- a/runtime/src/doughnut.rs
+++ b/runtime/src/doughnut.rs
@@ -109,7 +109,7 @@ mod test {
 		let doughnut = make_doughnut("cennznet", cennznut.encode());
 		assert_err!(
 			verify_dispatch(&doughnut, "trmlattestation", "attest"),
-			"error during Module name segmentation"
+			"error during module name segmentation"
 		);
 	}
 }

--- a/runtime/src/doughnut.rs
+++ b/runtime/src/doughnut.rs
@@ -52,6 +52,20 @@ mod test {
 	}
 
 	#[test]
+	fn it_works_with_arbitrary_prefix_short() {
+		let cennznut = make_cennznut("attestation", "attest");
+		let doughnut = make_doughnut("cennznet", cennznut.encode());
+		assert_ok!(verify_dispatch(&doughnut, "t-attestation", "attest"));
+	}
+
+	#[test]
+	fn it_works_with_arbitrary_prefix_long() {
+		let cennznut = make_cennznut("attestation", "attest");
+		let doughnut = make_doughnut("cennznet", cennznut.encode());
+		assert_ok!(verify_dispatch(&doughnut, "trmlcrml-attestation", "attest"));
+	}
+
+	#[test]
 	fn it_fails_when_not_using_the_cennznet_domain() {
 		let doughnut = make_doughnut("test", Default::default());
 		assert_err!(
@@ -86,6 +100,16 @@ mod test {
 		assert_err!(
 			verify_dispatch(&doughnut, "trml-attestation", "remove"),
 			"CENNZnut does not grant permission for method"
+		);
+	}
+
+	#[test]
+	fn it_fails_when_module_name_is_invalid() {
+		let cennznut = make_cennznut("attestation", "attest");
+		let doughnut = make_doughnut("cennznet", cennznut.encode());
+		assert_err!(
+			verify_dispatch(&doughnut, "trmlattestation", "attest"),
+			"error during Module name segmentation"
 		);
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -520,14 +520,8 @@ impl additional_traits::DelegatedDispatchVerifier<CennznetDoughnut> for Runtime 
 		let cennznut: CENNZnut = Decode::decode(&mut domain).map_err(|_| "Bad CENNZnut encoding")?;
 
 		// Extract Module name from <prefix>-<Module_name>
-		let dash_pos;
-		match module.find('-') {
-			Some(p) => {
-				dash_pos = p;
-			}
-			None => return Err("error during Module name segmentation"),
-		};
-		match cennznut.validate(&module[(dash_pos + 1)..], method, &[]) {
+		let module_offset = module.find('-').ok_or("error during module name segmentation")? + 1;
+		match cennznut.validate(&module[module_offset..], method, &[]) {
 			Ok(r) => Ok(r),
 			Err(ValidationErr::ConstraintsInterpretation) => Err("error while interpreting constraints"),
 			Err(ValidationErr::NoPermission(Domain::Method)) => Err("CENNZnut does not grant permission for method"),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -51,7 +51,7 @@ use system::offchain::TransactionSubmitter;
 use version::NativeVersion;
 use version::RuntimeVersion;
 
-pub use cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMillion, PerMilli};
+pub use cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMilli, PerMillion};
 pub use contracts::Gas;
 pub use generic_asset::Call as GenericAssetCall;
 
@@ -519,8 +519,15 @@ impl additional_traits::DelegatedDispatchVerifier<CennznetDoughnut> for Runtime 
 			.ok_or("CENNZnut does not grant permission for cennznet domain")?;
 		let cennznut: CENNZnut = Decode::decode(&mut domain).map_err(|_| "Bad CENNZnut encoding")?;
 
-		// Strips [c|p|s]rml- prefix
-		match cennznut.validate(&module[5..], method, &[]) {
+		// Extract Module name from <prefix>-<Module_name>
+		let dash_pos;
+		match module.find('-') {
+			Some(p) => {
+				dash_pos = p;
+			}
+			None => return Err("error during Module name segmentation"),
+		};
+		match cennznut.validate(&module[(dash_pos + 1)..], method, &[]) {
 			Ok(r) => Ok(r),
 			Err(ValidationErr::ConstraintsInterpretation) => Err("error while interpreting constraints"),
 			Err(ValidationErr::NoPermission(Domain::Method)) => Err("CENNZnut does not grant permission for method"),

--- a/testing/src/genesis.rs
+++ b/testing/src/genesis.rs
@@ -19,7 +19,7 @@
 use crate::keyring::*;
 use cennznet_runtime::{
 	constants::{asset::*, currency::*},
-	FeeRate, PerMillion, PerMilli,
+	FeeRate, PerMilli, PerMillion,
 };
 use cennznet_runtime::{
 	CennzxSpotConfig, ContractsConfig, GenericAssetConfig, GenesisConfig, GrandpaConfig, IndicesConfig, SessionConfig,


### PR DESCRIPTION
#107 Changed the way module names prefixes are removed

We now allow module names prefixes with arbitrary length, instead of
hardcoding it to a length of 4, as long as the module input is in the format:
\<prefix\>-<module_name>

Also fixed some formatting issue with "cargo fmt"