### PR TITLE
Bugfix/109 module name

### DIFF
--- a/runtime/src/doughnut.rs
+++ b/runtime/src/doughnut.rs
@@ -112,4 +112,34 @@ mod test {
 			"error during module name segmentation"
 		);
 	}
+
+	#[test]
+	fn it_fails_when_prefix_is_empty() {
+		let cennznut = make_cennznut("attestation", "attest");
+		let doughnut = make_doughnut("cennznet", cennznut.encode());
+		assert_err!(
+			verify_dispatch(&doughnut, "-attestation", "attest"),
+			"error during module name segmentation"
+		);
+	}
+
+	#[test]
+	fn it_fails_when_module_name_is_empty() {
+		let cennznut = make_cennznut("attestation", "attest");
+		let doughnut = make_doughnut("cennznet", cennznut.encode());
+		assert_err!(
+			verify_dispatch(&doughnut, "trml-", "attest"),
+			"error during module name segmentation"
+		);
+	}
+
+	#[test]
+	fn it_fails_when_module_name_and_prefix_are_empty() {
+		let cennznut = make_cennznut("attestation", "attest");
+		let doughnut = make_doughnut("cennznet", cennznut.encode());
+		assert_err!(
+			verify_dispatch(&doughnut, "-", "attest"),
+			"error during module name segmentation"
+		);
+	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -521,6 +521,9 @@ impl additional_traits::DelegatedDispatchVerifier<CennznetDoughnut> for Runtime 
 
 		// Extract Module name from <prefix>-<Module_name>
 		let module_offset = module.find('-').ok_or("error during module name segmentation")? + 1;
+		if module_offset <= 1 || module_offset >= module.len() {
+			return Err("error during module name segmentation")
+		}
 		match cennznut.validate(&module[module_offset..], method, &[]) {
 			Ok(r) => Ok(r),
 			Err(ValidationErr::ConstraintsInterpretation) => Err("error while interpreting constraints"),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -522,7 +522,7 @@ impl additional_traits::DelegatedDispatchVerifier<CennznetDoughnut> for Runtime 
 		// Extract Module name from <prefix>-<Module_name>
 		let module_offset = module.find('-').ok_or("error during module name segmentation")? + 1;
 		if module_offset <= 1 || module_offset >= module.len() {
-			return Err("error during module name segmentation")
+			return Err("error during module name segmentation");
 		}
 		match cennznut.validate(&module[module_offset..], method, &[]) {
 			Ok(r) => Ok(r),


### PR DESCRIPTION
#109 Module name segmentation with invalid input

Added logic to handle cases when the module name is not valid
Added tests for when the module name/prefix are empty

Closes #109 