### PR TITLE
Add transaction factory module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cennznet-transaction-factory"
+version = "1.0.0"
+dependencies = [
+ "log 0.4.8",
+ "parity-scale-codec",
+ "sc-cli",
+ "sc-client",
+ "sc-client-api",
+ "sc-service",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "cennznut"
 version = "0.3.0"
 source = "git+https://github.com/cennznet/cennznut-rs?branch=0.3.0#f0452fff499a57096da315953926dfcca8cf7b8f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
 	"rpc-client",
 	"runtime",
 	"testing",
+	"transaction-factory",
 ]
 
 [badges]

--- a/transaction-factory/Cargo.toml
+++ b/transaction-factory/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cennznet-transaction-factory"
+version = "1.0.0"
+authors = ["Centrality Developers <support@centrality.ai>"]
+edition = "2018"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+log = "0.4.8"
+sc-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sc-client-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sc-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sp-block-builder = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sp-consensus = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sc-service = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }

--- a/transaction-factory/src/complex_mode.rs
+++ b/transaction-factory/src/complex_mode.rs
@@ -1,0 +1,157 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+/// This module implements the `MasterToNToM` mode:
+///
+/// Manufacture `num` transactions from the master account to `num`
+/// randomly created accounts. From each of these randomly created
+/// accounts manufacture a transaction to another randomly created
+/// account.
+/// Repeat this round `rounds` times. If `rounds` = 1 the behavior
+/// is the same as `MasterToN`.
+///
+///   A -> B
+///   A -> C
+///   A -> D
+///   ... x `num`
+///
+///   B -> E
+///   C -> F
+///   D -> G
+///   ...
+///   E -> H
+///   F -> I
+///   G -> J
+///   ...
+///   ... x `rounds`
+
+use std::sync::Arc;
+
+use log::info;
+use sc_client::Client;
+use sp_block_builder::BlockBuilder;
+use sp_api::{ConstructRuntimeApi, ProvideRuntimeApi};
+use sp_runtime::generic::BlockId;
+use sp_runtime::traits::{Block as BlockT, One, Zero};
+
+use crate::{RuntimeAdapter, create_block};
+
+pub fn next<RA, Backend, Exec, Block, RtApi>(
+	factory_state: &mut RA,
+	client: &Arc<Client<Backend, Exec, Block, RtApi>>,
+	version: u32,
+	genesis_hash: <RA::Block as BlockT>::Hash,
+	prior_block_hash: <RA::Block as BlockT>::Hash,
+	prior_block_id: BlockId<Block>,
+) -> Option<Block>
+where
+	Block: BlockT,
+	Exec: sc_client::CallExecutor<Block, Backend = Backend> + Send + Sync + Clone,
+	Backend: sc_client_api::backend::Backend<Block> + Send,
+	Client<Backend, Exec, Block, RtApi>: ProvideRuntimeApi<Block>,
+	<Client<Backend, Exec, Block, RtApi> as ProvideRuntimeApi<Block>>::Api:
+		BlockBuilder<Block, Error = sp_blockchain::Error> +
+		sp_api::ApiExt<Block, StateBackend = Backend::State>,
+	RtApi: ConstructRuntimeApi<Block, Client<Backend, Exec, Block, RtApi>> + Send + Sync,
+	RA: RuntimeAdapter,
+{
+	let total = factory_state.start_number() + factory_state.num() * factory_state.rounds();
+
+	if factory_state.block_no() >= total || factory_state.round() >= factory_state.rounds() {
+		return None;
+	}
+
+	info!(
+		"Round {}: Creating {} transactions in total, {} per round. {} rounds in total.",
+		factory_state.round() + RA::Number::one(),
+		factory_state.num() * factory_state.rounds(),
+		factory_state.num(),
+		factory_state.rounds(),
+	);
+
+	let from = from::<RA>(factory_state);
+
+	let seed = factory_state.start_number() + factory_state.block_no();
+	let to = RA::gen_random_account_id(&seed);
+
+	let rounds_left = factory_state.rounds() - factory_state.round();
+	let amount = RA::minimum_balance() * rounds_left.into();
+
+	let transfer = factory_state.transfer_extrinsic(
+		&from.0,
+		&from.1,
+		&to,
+		&amount,
+		version,
+		&genesis_hash,
+		&prior_block_hash,
+	);
+
+	let inherents = factory_state.inherent_extrinsics();
+	let inherents = client.runtime_api().inherent_extrinsics(&prior_block_id, inherents)
+		.expect("Failed to create inherent extrinsics");
+
+	let block = create_block::<RA, _, _, _, _>(&client, transfer, inherents);
+	info!(
+		"Created block {} with hash {}. Transferring {} from {} to {}.",
+		factory_state.block_no() + RA::Number::one(),
+		prior_block_hash,
+		amount,
+		from.0,
+		to
+	);
+
+	factory_state.set_block_no(factory_state.block_no() + RA::Number::one());
+
+	let new_round = factory_state.block_no() > RA::Number::zero()
+		&& factory_state.block_no() % factory_state.num() == RA::Number::zero();
+	if new_round {
+		factory_state.set_round(factory_state.round() + RA::Number::one());
+		factory_state.set_block_in_round(RA::Number::zero());
+	} else {
+		factory_state.set_block_in_round(factory_state.block_in_round() + RA::Number::one());
+	}
+
+	Some(block)
+}
+
+/// Return the account which received tokens at this point in the previous round.
+fn from<RA>(
+	factory_state: &mut RA
+) -> (<RA as RuntimeAdapter>::AccountId, <RA as RuntimeAdapter>::Secret)
+where RA: RuntimeAdapter
+{
+	let is_first_round = factory_state.round() == RA::Number::zero();
+	match is_first_round {
+		true => {
+			// first round always uses master account
+			(RA::master_account_id(), RA::master_account_secret())
+		},
+		_ => {
+			// the account to which was sent in the last round
+			let is_round_one = factory_state.round() == RA::Number::one();
+			let seed = match is_round_one {
+				true => factory_state.start_number() + factory_state.block_in_round(),
+				_ => {
+					let block_no_in_prior_round =
+						factory_state.num() * (factory_state.round() - RA::Number::one()) + factory_state.block_in_round();
+					factory_state.start_number() + block_no_in_prior_round
+				}
+			};
+			(RA::gen_random_account_id(&seed), RA::gen_random_account_secret(&seed))
+		},
+	}
+}

--- a/transaction-factory/src/lib.rs
+++ b/transaction-factory/src/lib.rs
@@ -1,0 +1,211 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Simple transaction factory which distributes tokens from a master
+//! account to a specified number of newly created accounts.
+//!
+//! The factory currently only works on an empty database!
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::cmp::PartialOrd;
+use std::fmt::Display;
+
+use log::info;
+
+use sc_client::Client;
+use sp_block_builder::BlockBuilder;
+use sp_api::{ConstructRuntimeApi, ProvideRuntimeApi, ApiExt};
+use sp_consensus::{
+	BlockOrigin, BlockImportParams, InherentData, ForkChoiceStrategy,
+	SelectChain
+};
+use sp_consensus::block_import::BlockImport;
+use codec::{Decode, Encode};
+use sp_runtime::generic::BlockId;
+use sp_runtime::traits::{
+	Block as BlockT, Header as HeaderT, SimpleArithmetic, One, Zero,
+};
+pub use crate::modes::Mode;
+
+pub mod modes;
+mod complex_mode;
+mod simple_modes;
+
+pub trait RuntimeAdapter {
+	type AccountId: Display;
+	type Balance: Display + SimpleArithmetic + From<Self::Number>;
+	type Block: BlockT;
+	type Index: Copy;
+	type Number: Display + PartialOrd + SimpleArithmetic + Zero + One;
+	type Phase: Copy;
+	type Secret;
+
+	fn new(mode: Mode, rounds: u64, start_number: u64) -> Self;
+
+	fn block_no(&self) -> Self::Number;
+	fn block_in_round(&self) -> Self::Number;
+	fn mode(&self) -> &Mode;
+	fn num(&self) -> Self::Number;
+	fn rounds(&self) -> Self::Number;
+	fn round(&self) -> Self::Number;
+	fn start_number(&self) -> Self::Number;
+
+	fn set_block_in_round(&mut self, val: Self::Number);
+	fn set_block_no(&mut self, val: Self::Number);
+	fn set_round(&mut self, val: Self::Number);
+
+	fn transfer_extrinsic(
+		&self,
+		sender: &Self::AccountId,
+		key: &Self::Secret,
+		destination: &Self::AccountId,
+		amount: &Self::Balance,
+		version: u32,
+		genesis_hash: &<Self::Block as BlockT>::Hash,
+		prior_block_hash: &<Self::Block as BlockT>::Hash,
+	) -> <Self::Block as BlockT>::Extrinsic;
+
+	fn inherent_extrinsics(&self) -> InherentData;
+
+	fn minimum_balance() -> Self::Balance;
+	fn master_account_id() -> Self::AccountId;
+	fn master_account_secret() -> Self::Secret;
+	fn extract_index(&self, account_id: &Self::AccountId, block_hash: &<Self::Block as BlockT>::Hash) -> Self::Index;
+	fn extract_phase(&self, block_hash: <Self::Block as BlockT>::Hash) -> Self::Phase;
+	fn gen_random_account_id(seed: &Self::Number) -> Self::AccountId;
+	fn gen_random_account_secret(seed: &Self::Number) -> Self::Secret;
+}
+
+/// Manufactures transactions. The exact amount depends on
+/// `mode`, `num` and `rounds`.
+pub fn factory<RA, Backend, Exec, Block, RtApi, Sc>(
+	mut factory_state: RA,
+	client: &Arc<Client<Backend, Exec, Block, RtApi>>,
+	select_chain: &Sc,
+) -> sc_cli::error::Result<()>
+where
+	Block: BlockT,
+	Exec: sc_client::CallExecutor<Block, Backend = Backend> + Send + Sync + Clone,
+	Backend: sc_client_api::backend::Backend<Block> + Send,
+	Client<Backend, Exec, Block, RtApi>: ProvideRuntimeApi<Block>,
+	<Client<Backend, Exec, Block, RtApi> as ProvideRuntimeApi<Block>>::Api:
+		BlockBuilder<Block, Error = sp_blockchain::Error> +
+		ApiExt<Block, StateBackend = Backend::State>,
+	RtApi: ConstructRuntimeApi<Block, Client<Backend, Exec, Block, RtApi>> + Send + Sync,
+	Sc: SelectChain<Block>,
+	RA: RuntimeAdapter<Block = Block>,
+	Block::Hash: From<sp_core::H256>,
+{
+	if *factory_state.mode() != Mode::MasterToNToM && factory_state.rounds() > RA::Number::one() {
+		let msg = "The factory can only be used with rounds set to 1 in this mode.".into();
+		return Err(sc_cli::error::Error::Input(msg));
+	}
+
+	let best_header: Result<<Block as BlockT>::Header, sc_cli::error::Error> =
+		select_chain.best_chain().map_err(|e| format!("{:?}", e).into());
+	let mut best_hash = best_header?.hash();
+	let mut best_block_id = BlockId::<Block>::hash(best_hash);
+	let version = client.runtime_version_at(&best_block_id)?.spec_version;
+	let genesis_hash = client.block_hash(Zero::zero())?
+		.expect("Genesis block always exists; qed").into();
+
+	while let Some(block) = match factory_state.mode() {
+		Mode::MasterToNToM => complex_mode::next::<RA, _, _, _, _>(
+			&mut factory_state,
+			&client,
+			version,
+			genesis_hash,
+			best_hash.into(),
+			best_block_id,
+		),
+		_ => simple_modes::next::<RA, _, _, _, _>(
+			&mut factory_state,
+			&client,
+			version,
+			genesis_hash,
+			best_hash.into(),
+			best_block_id,
+		),
+	} {
+		best_hash = block.header().hash();
+		best_block_id = BlockId::<Block>::hash(best_hash);
+		import_block(client.clone(), block);
+
+		info!("Imported block at {}", factory_state.block_no());
+	}
+
+	Ok(())
+}
+
+/// Create a baked block from a transfer extrinsic and timestamp inherent.
+pub fn create_block<RA, Backend, Exec, Block, RtApi>(
+	client: &Arc<Client<Backend, Exec, Block, RtApi>>,
+	transfer: <RA::Block as BlockT>::Extrinsic,
+	inherent_extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+) -> Block
+where
+	Block: BlockT,
+	Exec: sc_client::CallExecutor<Block, Backend = Backend> + Send + Sync + Clone,
+	Backend: sc_client_api::backend::Backend<Block> + Send,
+	Client<Backend, Exec, Block, RtApi>: ProvideRuntimeApi<Block>,
+	RtApi: ConstructRuntimeApi<Block, Client<Backend, Exec, Block, RtApi>> + Send + Sync,
+	<Client<Backend, Exec, Block, RtApi> as ProvideRuntimeApi<Block>>::Api:
+		BlockBuilder<Block, Error = sp_blockchain::Error> +
+		ApiExt<Block, StateBackend = Backend::State>,
+	RA: RuntimeAdapter,
+{
+	let mut block = client.new_block(Default::default()).expect("Failed to create new block");
+	block.push(
+		Decode::decode(&mut &transfer.encode()[..])
+			.expect("Failed to decode transfer extrinsic")
+	).expect("Failed to push transfer extrinsic into block");
+
+	for inherent in inherent_extrinsics {
+		block.push(inherent).expect("Failed ...");
+	}
+
+	block.build().expect("Failed to bake block").block
+}
+
+fn import_block<Backend, Exec, Block, RtApi>(
+	mut client: Arc<Client<Backend, Exec, Block, RtApi>>,
+	block: Block
+) -> () where
+	Block: BlockT,
+	Exec: sc_client::CallExecutor<Block> + Send + Sync + Clone,
+	Backend: sc_client_api::backend::Backend<Block> + Send,
+	Client<Backend, Exec, Block, RtApi>: ProvideRuntimeApi<Block>,
+	<Client<Backend, Exec, Block, RtApi> as ProvideRuntimeApi<Block>>::Api:
+		sp_api::Core<Block, Error = sp_blockchain::Error> +
+		ApiExt<Block, StateBackend = Backend::State>,
+{
+	let import = BlockImportParams {
+		origin: BlockOrigin::File,
+		header: block.header().clone(),
+		post_digests: Vec::new(),
+		body: Some(block.extrinsics().to_vec()),
+		storage_changes: None,
+		finalized: false,
+		justification: None,
+		auxiliary: Vec::new(),
+		intermediates: Default::default(),
+		fork_choice: Some(ForkChoiceStrategy::LongestChain),
+		allow_missing_state: false,
+		import_existing: false,
+	};
+	client.import_block(import, HashMap::new()).expect("Failed to import block");
+}

--- a/transaction-factory/src/modes.rs
+++ b/transaction-factory/src/modes.rs
@@ -1,0 +1,40 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The transaction factory can operate in different modes. See
+//! the `simple_mode` and `complex_mode` modules for details.
+
+use std::str::FromStr;
+
+/// Token distribution modes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Mode {
+	MasterToN,
+	MasterTo1,
+	MasterToNToM
+}
+
+impl FromStr for Mode {
+	type Err = String;
+	fn from_str(mode: &str) -> Result<Self, Self::Err> {
+		match mode {
+			"MasterToN" => Ok(Mode::MasterToN),
+			"MasterTo1" => Ok(Mode::MasterTo1),
+			"MasterToNToM" => Ok(Mode::MasterToNToM),
+			_ => Err(format!("Invalid mode: {}", mode)),
+		}
+	}
+}

--- a/transaction-factory/src/simple_modes.rs
+++ b/transaction-factory/src/simple_modes.rs
@@ -1,0 +1,112 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+/// This module implements two manufacturing modes:
+///
+/// # MasterToN
+/// Manufacture `num` transactions from the master account
+/// to `num` randomly created accounts, one each.
+///
+///   A -> B
+///   A -> C
+///   ... x `num`
+///
+///
+/// # MasterTo1
+/// Manufacture `num` transactions from the master account
+/// to exactly one other randomly created account.
+///
+///   A -> B
+///   A -> B
+///   ... x `num`
+
+use std::sync::Arc;
+
+use log::info;
+use sc_client::Client;
+use sp_block_builder::BlockBuilder;
+use sp_api::{ConstructRuntimeApi, ProvideRuntimeApi};
+use sp_runtime::traits::{Block as BlockT, One};
+use sp_runtime::generic::BlockId;
+
+use crate::{Mode, RuntimeAdapter, create_block};
+
+pub fn next<RA, Backend, Exec, Block, RtApi>(
+	factory_state: &mut RA,
+	client: &Arc<Client<Backend, Exec, Block, RtApi>>,
+	version: u32,
+	genesis_hash: <RA::Block as BlockT>::Hash,
+	prior_block_hash: <RA::Block as BlockT>::Hash,
+	prior_block_id: BlockId<Block>,
+) -> Option<Block>
+where
+	Block: BlockT,
+	Exec: sc_client::CallExecutor<Block, Backend = Backend> + Send + Sync + Clone,
+	Backend: sc_client_api::backend::Backend<Block> + Send,
+	Client<Backend, Exec, Block, RtApi>: ProvideRuntimeApi<Block>,
+	<Client<Backend, Exec, Block, RtApi> as ProvideRuntimeApi<Block>>::Api:
+		BlockBuilder<Block, Error = sp_blockchain::Error> +
+		sp_api::ApiExt<Block, StateBackend = Backend::State>,
+	RtApi: ConstructRuntimeApi<Block, Client<Backend, Exec, Block, RtApi>> + Send + Sync,
+	RA: RuntimeAdapter,
+{
+	if factory_state.block_no() >= factory_state.num() {
+		return None;
+	}
+
+	let from = (RA::master_account_id(), RA::master_account_secret());
+
+	let seed = match factory_state.mode() {
+		// choose the same receiver for all transactions
+		Mode::MasterTo1 => factory_state.start_number(),
+
+		// different receiver for each transaction
+		Mode::MasterToN => factory_state.start_number() + factory_state.block_no(),
+		_ => unreachable!("Mode not covered!"),
+	};
+	let to = RA::gen_random_account_id(&seed);
+
+	let amount = RA::minimum_balance();
+
+	let transfer = factory_state.transfer_extrinsic(
+		&from.0,
+		&from.1,
+		&to,
+		&amount,
+		version,
+		&genesis_hash,
+		&prior_block_hash,
+	);
+
+	let inherents = RA::inherent_extrinsics(&factory_state);
+	let inherents = client.runtime_api().inherent_extrinsics(&prior_block_id, inherents)
+		.expect("Failed to create inherent extrinsics");
+
+	let block = create_block::<RA, _, _, _, _>(&client, transfer, inherents);
+
+	factory_state.set_block_no(factory_state.block_no() + RA::Number::one());
+
+	info!(
+		"Created block {} with hash {}. Transferring {} from {} to {}.",
+		factory_state.block_no(),
+		prior_block_hash,
+		amount,
+		from.0,
+		to
+	);
+
+	Some(block)
+}


### PR DESCRIPTION
- `transaction-factory` module is moved from `test-utils` -> `bin/node`. I guess the reason is so that it can be made node-specific.
- `1.0.0-rc1/test-utils/transaction-factory` and `1.0.0-rc2/node/transaction-factory` are very similar with small refactoring
- the module is referenced in `cli`

https://github.com/plugblockchain/plug-blockchain/tree/1.0.0-rc1/test-utils/transaction-factory
https://github.com/plugblockchain/plug-blockchain/tree/develop/bin/node/transaction-factory