### PR TITLE
Use decl_error in cennzx-spot

### DIFF
--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -17,7 +17,7 @@
 //! Extra CENNZX-Spot traits + implementations
 //!
 use super::Trait;
-use crate::Module;
+use crate::{Module};
 use cennznet_primitives::{traits::BuyFeeAsset, types::FeeExchange};
 use core::convert::TryInto;
 use frame_support::dispatch::{DispatchError, DispatchResult};

--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -17,7 +17,7 @@
 //! Extra CENNZX-Spot traits + implementations
 //!
 use super::Trait;
-use crate::{Module};
+use crate::Module;
 use cennznet_primitives::{traits::BuyFeeAsset, types::FeeExchange};
 use core::convert::TryInto;
 use frame_support::dispatch::{DispatchError, DispatchResult};

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -330,7 +330,7 @@ fn get_output_price_should_fail_with_max_reserve_and_max_amount() {
 				LowPrecisionUnsigned::max_value(),
 				DefaultFeeRate::get()
 			),
-			"Overflow"
+			Error::<Test>::Overflow
 		);
 	});
 }

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -565,7 +565,7 @@ fn asset_swap_output_exceed_max_sale() {
 				50, // buy_amount
 				0,  // max_sale,
 			),
-			"Amount of core asset sold would exceed the specified max. limit"
+			Error::<Test>::CoreToAssetPriceAboveMaxLimit
 		);
 	});
 }
@@ -666,7 +666,7 @@ fn remove_liquidity_fails_min_core_asset_limit() {
 				4,  //`min_asset_withdraw` - The minimum trade asset withdrawn
 				14  //`min_core_withdraw` -  The minimum core asset withdrawn
 			),
-			"Minimum core asset is required"
+			Error::<Test>::MinimumCoreAssetIsRequired
 		);
 		assert_exchange_balance_eq!(CoreAssetCurrency => 10, TradeAssetCurrencyA => 15);
 		assert_balance_eq!(investor, TradeAssetCurrencyA => 85);
@@ -696,7 +696,7 @@ fn remove_liquidity_fails_min_trade_asset_limit() {
 				18, //`min_asset_withdraw` - The minimum trade asset withdrawn
 				4   //`min_core_withdraw` -  The minimum core asset withdrawn
 			),
-			"Minimum trade asset is required"
+			Error::<Test>::MinimumTradeAssetIsRequired
 		);
 		assert_exchange_balance_eq!(CoreAssetCurrency => 10, TradeAssetCurrencyA => 15);
 		assert_balance_eq!(investor, TradeAssetCurrencyA => 85);
@@ -726,7 +726,7 @@ fn remove_liquidity_fails_on_overdraw_liquidity() {
 				18, //`min_asset_withdraw` - The minimum trade asset withdrawn
 				4   //`min_core_withdraw` -  The minimum core asset withdrawn
 			),
-			"Tried to overdraw liquidity"
+			Error::<Test>::LiquidityTooLow
 		);
 		assert_exchange_balance_eq!(CoreAssetCurrency => 10, TradeAssetCurrencyA => 15);
 		assert_balance_eq!(investor, TradeAssetCurrencyA => 85);
@@ -867,7 +867,7 @@ fn asset_swap_input_zero_sell_amount() {
 				0,
 				DefaultFeeRate::get()
 			),
-			"Sell amount must be a positive value"
+			Error::<Test>::AssetToCoreSellAmountNotAboveZero
 		);
 		assert_err!(
 			CennzXSpot::get_core_to_asset_input_price(
@@ -875,7 +875,7 @@ fn asset_swap_input_zero_sell_amount() {
 				0,
 				DefaultFeeRate::get()
 			),
-			"Sell amount must be a positive value"
+			Error::<Test>::CoreToAssetSellAmountNotAboveZero
 		);
 	});
 }
@@ -1018,7 +1018,7 @@ fn asset_swap_input_zero_asset_sold() {
 				0,   // sell amount
 				100, // min buy,
 			),
-			"Sell amount must be a positive value"
+			Error::<Test>::AssetToCoreSellAmountNotAboveZero
 		);
 		// core to asset swap input
 		assert_err!(
@@ -1030,7 +1030,7 @@ fn asset_swap_input_zero_asset_sold() {
 				0,   // sell amount
 				100, // min buy,
 			),
-			"Sell amount must be a positive value"
+			Error::<Test>::CoreToAssetSellAmountNotAboveZero
 		);
 	});
 }
@@ -1266,7 +1266,7 @@ fn asset_to_asset_swap_input_zero_asset_sold() {
 				0,                                      // sell_amount
 				100,                                    // min buy limit for asset B
 			),
-			"Sell amount must be a positive value"
+			Error::<Test>::AssetToCoreSellAmountNotAboveZero
 		);
 	});
 }
@@ -1308,7 +1308,7 @@ fn asset_to_asset_swap_input_less_than_min_sale() {
 				156,                                    // sell_amount
 				200,                                    // min buy limit for asset B
 			),
-			"The sale value of input is less than the required min"
+			Error::<Test>::InsufficientSellAssetForRequiredMinimumBuyAsset
 		);
 	});
 }

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -21,7 +21,7 @@ use crate::{
 	impls::{ExchangeAddressFor, ExchangeAddressGenerator},
 	mock::{self, CORE_ASSET_ID, TRADE_ASSET_A_ID, TRADE_ASSET_B_ID},
 	types::{FeeRate, LowPrecisionUnsigned, PerMilli, PerMillion},
-	Call, CoreAssetId, DefaultFeeRate, GenesisConfig, Module, Trait,
+	Call, CoreAssetId, DefaultFeeRate, GenesisConfig, Module, Trait, Error
 };
 use core::convert::TryFrom;
 use frame_support::{additional_traits::DummyDispatchVerifier, impl_outer_origin, traits::Currency, StorageValue};
@@ -268,12 +268,12 @@ fn get_output_price_zero_cases() {
 
 		assert_err!(
 			CennzXSpot::get_output_price(100, 0, 10, DefaultFeeRate::get()),
-			"EmptyPool"
+			Error::<Test>::EmptyExchangePool
 		);
 
 		assert_err!(
 			CennzXSpot::get_output_price(100, 10, 0, DefaultFeeRate::get()),
-			"EmptyPool"
+			Error::<Test>::EmptyExchangePool
 		);
 	});
 }
@@ -388,7 +388,7 @@ fn asset_swap_output_zero_buy_amount() {
 				0,
 				DefaultFeeRate::get()
 			),
-			"Buy amount must be a positive value"
+			Error::<Test>::BuyAmountNotPositive
 		);
 		assert_err!(
 			CennzXSpot::get_asset_to_core_output_price(
@@ -396,7 +396,7 @@ fn asset_swap_output_zero_buy_amount() {
 				0,
 				DefaultFeeRate::get()
 			),
-			"Buy amount must be a positive value"
+			Error::<Test>::BuyAmountNotPositive
 		);
 	});
 }
@@ -412,7 +412,7 @@ fn asset_swap_output_insufficient_reserve() {
 				1001, // amount_bought
 				DefaultFeeRate::get()
 			),
-			"Insufficient core asset reserve in exchange"
+			Error::<Test>::InsufficientCoreAssetReserve
 		);
 
 		assert_err!(
@@ -421,7 +421,7 @@ fn asset_swap_output_insufficient_reserve() {
 				1001, // amount_bought
 				DefaultFeeRate::get()
 			),
-			"Insufficient asset reserve in exchange"
+			Error::<Test>::InsufficientTradeAssetReserve
 		);
 	});
 }
@@ -486,7 +486,7 @@ fn asset_swap_output_zero_asset_sold() {
 				0,   // buy_amount
 				100, // max_sale,
 			),
-			"Buy amount must be a positive value"
+			Error::<Test>::BuyAmountNotPositive
 		);
 		// core to asset swap output
 		assert_err!(
@@ -498,7 +498,7 @@ fn asset_swap_output_zero_asset_sold() {
 				0,   // buy_amount
 				100, // max_sale,
 			),
-			"Buy amount must be a positive value"
+			Error::<Test>::BuyAmountNotPositive
 		);
 	});
 }
@@ -519,7 +519,7 @@ fn asset_swap_output_insufficient_balance() {
 				51,  // buy_amount
 				500, // max_sale,
 			),
-			"Insufficient asset balance in buyer account"
+			Error::<Test>::InsufficientBuyerTradeAssetBalance
 		);
 		// core to asset swap output
 		assert_err!(
@@ -531,7 +531,7 @@ fn asset_swap_output_insufficient_balance() {
 				101, // buy_amount
 				500, // max_sale,
 			),
-			"Insufficient core asset balance in buyer account"
+			Error::<Test>::InsufficientBuyerCoreAssetBalance
 		);
 	});
 }
@@ -552,7 +552,7 @@ fn asset_swap_output_exceed_max_sale() {
 				50, // buy_amount
 				0,  // max_sale,
 			),
-			"Amount of asset sold would exceed the specified max. limit"
+			Error::<Test>::AssetToCorePriceAboveMaxLimit
 		);
 
 		// core to asset swap output
@@ -895,7 +895,7 @@ fn asset_swap_input_insufficient_balance() {
 				100,   // min buy limit
 				DefaultFeeRate::get()
 			),
-			"Insufficient asset balance in seller account"
+			Error::<Test>::InsufficientSellerTradeAssetBalance
 		);
 
 		assert_err!(
@@ -907,7 +907,7 @@ fn asset_swap_input_insufficient_balance() {
 				100,   // min buy limit
 				DefaultFeeRate::get()
 			),
-			"Insufficient core asset balance in seller account"
+			Error::<Test>::InsufficientSellerCoreAssetBalance
 		);
 	});
 }
@@ -1051,7 +1051,7 @@ fn asset_swap_input_less_than_min_sale() {
 				50,  // sell_amount
 				100, // min buy,
 			),
-			"The sale value of input is less than the required min."
+			Error::<Test>::SaleValueBelowRequiredMinimum
 		);
 		// core to asset swap input
 		assert_err!(
@@ -1063,7 +1063,7 @@ fn asset_swap_input_less_than_min_sale() {
 				50,  // sell_amount
 				100, // min buy,
 			),
-			"The sale value of input is less than the required min."
+			Error::<Test>::SaleValueBelowRequiredMinimum
 		);
 	});
 }
@@ -1154,7 +1154,7 @@ fn asset_to_asset_swap_output_zero_asset_sold() {
 				0,                                      // buy_amount
 				300,                                    // maximum asset A to sell
 			),
-			"Buy amount must be a positive value"
+			Error::<Test>::BuyAmountNotPositive
 		);
 	});
 }
@@ -1175,7 +1175,7 @@ fn asset_to_asset_swap_output_insufficient_balance() {
 				51,                                     // buy_amount
 				400,                                    // maximum asset A to sell
 			),
-			"Insufficient asset balance in buyer account"
+			Error::<Test>::InsufficientBuyerTradeAssetBalance
 		);
 	});
 }
@@ -1196,7 +1196,7 @@ fn asset_to_asset_swap_output_exceed_max_sale() {
 				156,                                    // buy_amount
 				100,                                    // maximum asset A to sell
 			),
-			"Amount of asset sold would exceed the specified max. limit"
+			Error::<Test>::AssetToAssetPriceAboveMaxLimit
 		);
 	});
 }
@@ -1287,7 +1287,7 @@ fn asset_to_asset_swap_input_insufficient_balance() {
 				51,                                     // sell_amount
 				100,                                    // min buy limit for asset B
 			),
-			"Insufficient asset balance in seller account"
+			Error::<Test>::InsufficientSellerTradeAssetBalance
 		);
 	});
 }

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -53,18 +53,18 @@ impl Scaled for PerCent {
 
 // TODO: refactor below to use frame_support::decl_error!
 #[derive(Debug)]
-pub enum Error {
+pub enum FeeRateError {
 	Overflow,
 	DivideByZero,
 	EmptyPool,
 }
 
-impl Into<&'static str> for Error {
+impl Into<&'static str> for FeeRateError {
 	fn into(self) -> &'static str {
 		match self {
-			Error::Overflow => "Overflow",
-			Error::DivideByZero => "DivideByZero",
-			Error::EmptyPool => "EmptyPool",
+			FeeRateError::Overflow => "Overflow",
+			FeeRateError::DivideByZero => "DivideByZero",
+			FeeRateError::EmptyPool => "EmptyPool",
 		}
 	}
 }
@@ -81,33 +81,33 @@ impl<S: Scaled> Default for FeeRate<S> {
 }
 
 impl<S: Scaled> TryFrom<HighPrecisionUnsigned> for FeeRate<S> {
-	type Error = Error;
+	type Error = FeeRateError;
 	fn try_from(h: HighPrecisionUnsigned) -> Result<Self, Self::Error> {
 		match LowPrecisionUnsigned::try_from(h) {
 			Ok(l) => Ok(FeeRate::<S>::from(l)),
-			Err(_) => Err(Error::Overflow),
+			Err(_) => Err(Self::Error::Overflow),
 		}
 	}
 }
 
 impl TryFrom<FeeRate<PerMilli>> for FeeRate<PerMillion> {
-	type Error = Error;
+	type Error = FeeRateError;
 	fn try_from(f: FeeRate<PerMilli>) -> Result<Self, Self::Error> {
 		let rate = PerMillion::SCALE / PerMilli::SCALE;
 		match f.0.checked_mul(rate) {
 			Some(x) => Ok(FeeRate::<PerMillion>::from(x)),
-			None => Err(Error::Overflow),
+			None => Err(Self::Error::Overflow),
 		}
 	}
 }
 
 impl TryFrom<FeeRate<PerCent>> for FeeRate<PerMillion> {
-	type Error = Error;
+	type Error = FeeRateError;
 	fn try_from(f: FeeRate<PerCent>) -> Result<Self, Self::Error> {
 		let rate = PerMillion::SCALE / PerCent::SCALE;
 		match f.0.checked_mul(rate) {
 			Some(x) => Ok(FeeRate::<PerMillion>::from(x)),
-			None => Err(Error::Overflow),
+			None => Err(Self::Error::Overflow),
 		}
 	}
 }

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -51,18 +51,15 @@ impl Scaled for PerCent {
 	const SCALE: LowPrecisionUnsigned = 100;
 }
 
-// TODO: refactor below to use frame_support::decl_error!
 #[derive(Debug)]
 pub enum FeeRateError {
 	Overflow,
-	DivideByZero,
 }
 
 impl Into<&'static str> for FeeRateError {
 	fn into(self) -> &'static str {
 		match self {
 			FeeRateError::Overflow => "Overflow",
-			FeeRateError::DivideByZero => "DivideByZero",
 		}
 	}
 }

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -56,7 +56,6 @@ impl Scaled for PerCent {
 pub enum FeeRateError {
 	Overflow,
 	DivideByZero,
-	EmptyPool,
 }
 
 impl Into<&'static str> for FeeRateError {
@@ -64,7 +63,6 @@ impl Into<&'static str> for FeeRateError {
 		match self {
 			FeeRateError::Overflow => "Overflow",
 			FeeRateError::DivideByZero => "DivideByZero",
-			FeeRateError::EmptyPool => "EmptyPool",
 		}
 	}
 }


### PR DESCRIPTION
- Change all Cennzx spot module errors into decl_error enum
- Decouple Cennzx Spot FeeRate Error type from Cennzx spot module