### PR TITLE
Bump up rust version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM  rustlang/rust:nightly AS builder
 WORKDIR /cennznet
 COPY . /cennznet
 
-ENV RUST_VERSION nightly-2019-10-14
+ENV RUST_VERSION nightly-2019-12-19
 RUN apt-get update && \
     apt-get -y install apt-utils cmake pkg-config libssl-dev git clang libclang-dev && \
     rustup install $RUST_VERSION && \


### PR DESCRIPTION
Bump up the Rust version to match with circleci config.
To fix this error: https://circleci.com/gh/cennznet/cennznet/821?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link