### PR TITLE
Add post contract execution logic to handle gas payment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "pretty_assertions",
  "sp-core",
  "sp-runtime",
+ "sp-serializer",
 ]
 
 [[package]]

--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -106,11 +106,14 @@ pub(crate) mod impl_tests {
 			let fee_rate = 3_000; // fee is 0.3%
 			let fee_rate_factor = scale_factor + fee_rate; // 1_000_000 + 3_000
 
-			assert_ok!(<CennzXSpot as BuyFeeAsset>::buy_fee_asset(
-				&user,
-				target_fee,
-				&TestFeeExchange::new_v1(TRADE_ASSET_A_ID, 2_000_000)
-			));
+			assert_ok!(
+				<CennzXSpot as BuyFeeAsset>::buy_fee_asset(
+					&user,
+					target_fee,
+					&TestFeeExchange::new_v1(TRADE_ASSET_A_ID, 2_000_000)
+				),
+				571
+			);
 
 			// For more detail, see `fn get_output_price` in lib.rs
 			let core_asset_price = {

--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -18,9 +18,8 @@
 //!
 use super::Trait;
 use crate::Module;
-use cennznet_primitives::{traits::BuyFeeAsset, types::FeeExchange};
-use core::convert::TryInto;
-use frame_support::dispatch::{DispatchError, DispatchResult};
+use cennznet_primitives::traits::{BuyFeeAsset, FeeExchange};
+use frame_support::dispatch::DispatchError;
 use sp_core::crypto::{UncheckedFrom, UncheckedInto};
 use sp_runtime::traits::Hash;
 use sp_std::{marker::PhantomData, prelude::*};
@@ -53,31 +52,29 @@ fn u64_to_bytes(x: u64) -> [u8; 8] {
 	x.to_le_bytes()
 }
 
-impl<T: Trait> BuyFeeAsset<T::AccountId, T::Balance> for Module<T> {
-	type FeeExchange = FeeExchange;
-	/// Use the CENNZX-Spot exchange to seamlessly buy fee asset
-	fn buy_fee_asset(who: &T::AccountId, amount: T::Balance, exchange_op: &Self::FeeExchange) -> DispatchResult {
-		let fee_exchange = match exchange_op {
-			FeeExchange::V1(ex) => ex,
-		};
+impl<T: Trait> BuyFeeAsset for Module<T> {
+	type AccountId = T::AccountId;
+	type AssetId = T::AssetId;
+	type Balance = T::Balance;
 
+	/// Use the CENNZX-Spot exchange to seamlessly buy fee asset
+	fn buy_fee_asset(
+		who: &T::AccountId,
+		amount: T::Balance,
+		exchange_op: &FeeExchange<Self>,
+	) -> Result<T::Balance, DispatchError> {
 		// TODO: Hard coded to use spending asset ID
-		let fee_asset_id: T::AssetId = <pallet_generic_asset::Module<T>>::spending_asset_id();
-		let max_payment = fee_exchange
-			.max_payment
-			.try_into()
-			.map_err(|_| DispatchError::Other("Failed to convert max payment to balance type"))?;
+		let fee_asset_id = <pallet_generic_asset::Module<T>>::spending_asset_id();
 
 		Self::make_asset_swap_output(
 			&who,
 			&who,
-			&T::AssetId::from(fee_exchange.asset_id),
+			&exchange_op.get_asset_id(),
 			&fee_asset_id,
 			amount,
-			max_payment,
+			exchange_op.get_balance(),
 			Self::fee_rate(),
 		)
-		.map(|_| ())
 		.map_err(|_| DispatchError::Other("Failed to charge transaction fees during conversion"))
 	}
 }
@@ -89,13 +86,13 @@ pub(crate) mod impl_tests {
 		mock::{self, CORE_ASSET_ID, FEE_ASSET_ID, TRADE_ASSET_A_ID},
 		tests::{CennzXSpot, ExtBuilder, Test},
 	};
-	use cennznet_primitives::types::FeeExchangeV1;
 	use frame_support::traits::Currency;
 	use sp_core::H256;
 
 	type CoreAssetCurrency = mock::CoreAssetCurrency<Test>;
 	type TradeAssetCurrencyA = mock::TradeAssetCurrencyA<Test>;
 	type FeeAssetCurrency = mock::FeeAssetCurrency<Test>;
+	type TestFeeExchange = FeeExchange<CennzXSpot>;
 
 	#[test]
 	fn buy_fee_asset() {
@@ -109,10 +106,10 @@ pub(crate) mod impl_tests {
 			let fee_rate = 3_000; // fee is 0.3%
 			let fee_rate_factor = scale_factor + fee_rate; // 1_000_000 + 3_000
 
-			assert_ok!(<CennzXSpot as BuyFeeAsset<_, _>>::buy_fee_asset(
+			assert_ok!(<CennzXSpot as BuyFeeAsset>::buy_fee_asset(
 				&user,
 				target_fee,
-				&FeeExchange::V1(FeeExchangeV1::new(TRADE_ASSET_A_ID, 2_000_000)),
+				&TestFeeExchange::new_v1(TRADE_ASSET_A_ID, 2_000_000)
 			));
 
 			// For more detail, see `fn get_output_price` in lib.rs
@@ -167,10 +164,10 @@ pub(crate) mod impl_tests {
 			let user = with_account!(CoreAssetCurrency => 0, TradeAssetCurrencyA => 10);
 
 			assert_err!(
-				<CennzXSpot as BuyFeeAsset<_, _>>::buy_fee_asset(
+				<CennzXSpot as BuyFeeAsset>::buy_fee_asset(
 					&user,
 					51,
-					&FeeExchange::V1(FeeExchangeV1::new(TRADE_ASSET_A_ID, 2_000_000)),
+					&TestFeeExchange::new_v1(TRADE_ASSET_A_ID, 2_000_000),
 				),
 				"Failed to charge transaction fees during conversion"
 			);

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -431,7 +431,7 @@ mod tests {
 	}
 
 	impl Trait for Runtime {
-		type Balance = u64;
+		type Balance = u128;
 		type AssetId = u32;
 		type Currency = pallet_balances::Module<Runtime>;
 		type OnTransactionPayment = ();

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -243,6 +243,9 @@ where
 		info: Self::DispatchInfo,
 		len: usize,
 	) -> TransactionValidity {
+		// A cautionary measure to ensure the storage of previous transactions wouldn't extend beyond them.
+		unhashed::kill(&GAS_FEE_EXCHANGE_KEY);
+
 		let tip = self.tip;
 
 		// pay any fees.
@@ -280,7 +283,6 @@ where
 			T::OnTransactionPayment::on_unbalanced(imbalance);
 		}
 
-		unhashed::kill(&GAS_FEE_EXCHANGE_KEY);
 		if let Some(exchange) = exchange_op {
 			unhashed::put::<TransactionFeeExchange<T>>(&GAS_FEE_EXCHANGE_KEY, &exchange);
 		}

--- a/primitives/src/impls.rs
+++ b/primitives/src/impls.rs
@@ -16,11 +16,35 @@
 
 //! Common implementation used by CENNZnet node.
 
-use crate::types::{AssetId, Balance, FeeExchangeV1};
+use crate::types::{FeeExchange, FeeExchangeV1};
 
-impl FeeExchangeV1 {
+impl<AssetId, Balance> FeeExchangeV1<AssetId, Balance> {
 	/// Create a new FeeExchange
 	pub fn new(asset_id: AssetId, max_payment: Balance) -> Self {
 		Self { asset_id, max_payment }
+	}
+}
+
+impl<AssetId: Clone, Balance: Clone> FeeExchange<AssetId, Balance> {
+	/// Make and return a v1 FeeExchange
+	pub fn new_v1(id: AssetId, balance: Balance) -> Self {
+		FeeExchange::V1(FeeExchangeV1 {
+			asset_id: id,
+			max_payment: balance,
+		})
+	}
+
+	/// Return the specified asset id
+	pub fn get_asset_id(&self) -> AssetId {
+		match self {
+			FeeExchange::V1(x) => x.asset_id.clone(),
+		}
+	}
+
+	/// Return the specified balance/max_payment for the fee exchange
+	pub fn get_balance(&self) -> Balance {
+		match self {
+			FeeExchange::V1(x) => x.max_payment.clone(),
+		}
 	}
 }

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -16,14 +16,30 @@
 
 //! Common traits used by CENNZnet node.
 
-use frame_support::dispatch::DispatchResult;
+use frame_support::dispatch::DispatchError;
+
+/// FeeExchange that is used for BuyFeeAsset
+pub type FeeExchange<T> = crate::types::FeeExchange<<T as BuyFeeAsset>::AssetId, <T as BuyFeeAsset>::Balance>;
 
 /// A trait which enables buying some fee asset using another asset.
 /// It is targeted at the CENNZX Spot exchange and the CennznetExtrinsic format.
-pub trait BuyFeeAsset<AccountId, Balance> {
-	/// A type to handle fee and asset exchange.
-	type FeeExchange;
+pub trait BuyFeeAsset {
+	/// The user account identifier
+	type AccountId;
+
+	/// The arithmetic type of asset identifier.
+	type AssetId;
+
+	/// The units in which we record balances.
+	type Balance;
+
 	/// Buy `amount` of fee asset for `who` using asset info from `fee_exchange.
+	/// If the purchase has been successful, return Ok with sold amount
+	/// deducting the actual fee in the users's specified asset id, otherwise return Err.
 	/// Note: It does not charge the fee asset, that is left to a `ChargeFee` implementation
-	fn buy_fee_asset(who: &AccountId, amount: Balance, fee_exchange: &Self::FeeExchange) -> DispatchResult;
+	fn buy_fee_asset(
+		who: &Self::AccountId,
+		amount: Self::Balance,
+		fee_exchange: &FeeExchange<Self>,
+	) -> Result<Self::Balance, DispatchError>;
 }

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -71,19 +71,19 @@ pub type BlockId = generic::BlockId<Block>;
 
 /// The outer `FeeExchange` type. It is versioned to provide flexbility for future iterations
 /// while maintaining backward compatability.
-#[derive(PartialEq, Eq, Clone, Encode, Decode)]
-pub enum FeeExchange {
+#[derive(PartialEq, Eq, Clone, Encode, Decode, Debug)]
+pub enum FeeExchange<AssetId, Balance> {
 	/// A V1 FeeExchange
 	#[codec(compact)]
-	V1(FeeExchangeV1),
+	V1(FeeExchangeV1<AssetId, Balance>),
 }
 
 /// A v1 FeeExchange
 /// Signals a fee payment requiring the CENNZX-Spot exchange. It is intended to
 /// embed within CENNZnet extrinsic payload.
 /// It specifies input asset ID and the max. limit of input asset to pay
-#[derive(PartialEq, Eq, Clone, Encode, Decode)]
-pub struct FeeExchangeV1 {
+#[derive(PartialEq, Eq, Clone, Encode, Decode, Debug)]
+pub struct FeeExchangeV1<AssetId, Balance> {
 	/// The Asset ID to exchange for network fee asset
 	#[codec(compact)]
 	pub asset_id: AssetId,

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -32,11 +32,6 @@ pub mod asset {
 	pub const SPENDING_ASSET_ID: AssetId = CENTRAPAY_ASSET_ID;
 }
 
-/// Contract.
-pub mod contract {
-	pub const GAS_FEE_EXCHANGE_KEY: &[u8] = b"gas-fee-exchange-key";
-}
-
 /// Money matters.
 pub mod currency {
 	use cennznet_primitives::types::Balance;

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -32,6 +32,11 @@ pub mod asset {
 	pub const SPENDING_ASSET_ID: AssetId = CENTRAPAY_ASSET_ID;
 }
 
+/// Contract.
+pub mod contract {
+	pub const GAS_FEE_EXCHANGE_KEY: &[u8] = b"gas-fee-exchange-key";
+}
+
 /// Money matters.
 pub mod currency {
 	use cennznet_primitives::types::Balance;

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -158,7 +158,7 @@ where
 		if let Some(exchange_op) = unhashed::take::<FeeExchange<T::AssetId, T::Balance>>(&GAS_FEE_EXCHANGE_KEY) {
 			asset_id = exchange_op.get_asset_id();
 
-			let exchanged_cost = CennzxModule::<T>::get_core_to_asset_input_price(
+			let exchanged_cost = CennzxModule::<T>::get_asset_to_core_output_price(
 				&asset_id,
 				cost.clone(),
 				CennzxModule::<T>::fee_rate(),

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -155,7 +155,7 @@ where
 		let cost = UnsignedToBalance::<T>::from(cost_lpu).into();
 
 		let amount: T::Balance;
-		if let Some(exchange_op) = unhashed::take::<FeeExchange<T::AssetId, T::Balance>>(&GAS_FEE_EXCHANGE_KEY) {
+		if let Some(exchange_op) = unhashed::get::<FeeExchange<T::AssetId, T::Balance>>(&GAS_FEE_EXCHANGE_KEY) {
 			asset_id = exchange_op.get_asset_id();
 
 			let exchanged_cost = CennzxModule::<T>::get_asset_to_core_output_price(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -78,7 +78,7 @@ use impls::{CurrencyToVoteHandler, FeeMultiplierUpdateHandler, LinearWeightToFee
 
 /// Constant values used within the runtime.
 pub mod constants;
-use constants::{currency::*, time::*};
+use constants::{contract::GAS_FEE_EXCHANGE_KEY, currency::*, time::*};
 
 mod doughnut;
 
@@ -595,16 +595,14 @@ where
 	T: pallet_contracts::Trait + pallet_generic_asset::Trait + crml_cennzx_spot::Trait + Decode,
 {
 	fn empty_unused_gas(transactor: &T::AccountId, gas_meter: GasMeter<T>) {
-		let key = &b"cennzx-spot"[..];
-
-		// The take() function ensures the entry is "killed" after access.
+		// The take() function ensures the entry is `killed` after access.
 		// Note: if there's no entry (ie, None), it means we handled an edge case of
 		// CPAY in FeeExchange, ie, gas is already paid in CPAY.
-		if let Some(exchange_op) = unhashed::take::<FeeExchange>(&key) {
+		if let Some(exchange_op) = unhashed::take::<FeeExchange>(&GAS_FEE_EXCHANGE_KEY) {
 			let gas_spent = gas_meter.spent();
 
 			// Fee exchange can never fail as conditions such as having enough liquidity
-			// are checked early (before FeeExchange is put into database)
+			// are checked early (before FeeExchange is put into storage)
 			let _ = <crml_cennzx_spot::Module<T> as BuyFeeAsset<_, _>>::buy_fee_asset(
 				transactor,
 				gas_spent.saturated_into(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,14 +21,18 @@
 #![recursion_limit = "256"]
 #![allow(array_into_iter)]
 
-use cennznet_primitives::types::{
-	AccountId, AccountIndex, AssetId, Balance, BlockNumber, Hash, Index, Moment, Signature,
+use cennznet_primitives::{
+	traits::BuyFeeAsset,
+	types::{AccountId, AccountIndex, AssetId, Balance, BlockNumber, FeeExchange, Hash, Index, Moment, Signature},
 };
 use cennznut::{CENNZnut, Domain, Validate, ValidationErr};
 use codec::Decode;
-use frame_support::weights::Weight;
-use frame_support::{additional_traits, construct_runtime, debug, parameter_types, traits::Randomness};
+use frame_support::{
+	additional_traits, construct_runtime, debug, parameter_types, storage::unhashed, traits::Randomness,
+	weights::Weight,
+};
 use frame_system::offchain::TransactionSubmitter;
+use pallet_contracts::GasMeter;
 use pallet_contracts_rpc_runtime_api::ContractExecResult;
 use pallet_generic_asset::{SpendingAssetCurrency, StakingAssetCurrency};
 use pallet_grandpa::fg_primitives;
@@ -581,6 +585,32 @@ impl additional_traits::DelegatedDispatchVerifier for Runtime {
 			Err(ValidationErr::NoPermission(Domain::MethodArguments)) => {
 				Err("CENNZnut does not grant permission for method arguments")
 			}
+		}
+	}
+}
+
+/// Handles gas payment post contract execution (before deferring runtime calls) via CENNZX-Spot exchange.
+impl<T> pallet_contracts::GasHandler<T> for Runtime
+where
+	T: pallet_contracts::Trait + pallet_generic_asset::Trait + crml_cennzx_spot::Trait + Decode,
+{
+	fn empty_unused_gas(transactor: &T::AccountId, gas_meter: GasMeter<T>) {
+		let key = &b"cennzx-spot"[..];
+
+		// The take() function ensures the entry is "killed" after access.
+		// Note: if there's no entry (ie, None), it means we handled an edge case of
+		// CPAY in FeeExchange, ie, gas is already paid in CPAY.
+		if let Some(exchange_op) = unhashed::take::<FeeExchange>(&key) {
+			let gas_spent = gas_meter.spent();
+
+			// Fee exchange can never fail as conditions such as having enough liquidity
+			// are checked early (before FeeExchange is put into database)
+			let _ = <crml_cennzx_spot::Module<T> as BuyFeeAsset<_, _>>::buy_fee_asset(
+				transactor,
+				gas_spent.saturated_into(),
+				&exchange_op,
+			)
+			.unwrap();
 		}
 	}
 }


### PR DESCRIPTION
Implement `GasHandler` trait for Runtime as the post contract execution. It tries to access storage with `cennzx-spot` as key to get FeeExchange, which is consumed at `buy_fee_exchange`.