### PR TITLE
Add gas payment integration tests

### DIFF
--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -36,7 +36,10 @@ pub mod asset {
 pub mod currency {
 	use cennznet_primitives::types::Balance;
 
-	pub const MILLICENTS: Balance = 1_000_000_000;
+	pub const PICOCENTS: Balance = 1;
+	pub const NANOCENTS: Balance = 1_000 * PICOCENTS;
+	pub const MICROCENTS: Balance = 1_000 * NANOCENTS;
+	pub const MILLICENTS: Balance = 1_000 * MICROCENTS;
 	pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
 	pub const DOLLARS: Balance = 100 * CENTS;
 }

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -240,6 +240,14 @@ where
 					T::Balance::unique_saturated_from(used_gas_cost.saturated_into()),
 					&exchange_op,
 				);
+				let imbalance = T::Currency::withdraw(
+					transactor,
+					used_gas_cost,
+					WithdrawReason::Fee.into(),
+					ExistenceRequirement::KeepAlive,
+				)
+				.expect("Used gas cost could not be withdrawn");
+				T::GasPayment::on_unbalanced(imbalance);
 			}
 		} else {
 			// Refund remaining gas by minting it as CENNZnet fee currency

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -418,15 +418,16 @@ impl pallet_treasury::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const ContractTransferFee: Balance = 1 * CENTS;
-	pub const ContractCreationFee: Balance = 1 * CENTS;
-	pub const ContractTransactionBaseFee: Balance = 1 * CENTS;
-	pub const ContractTransactionByteFee: Balance = 10 * MILLICENTS;
+	pub const ContractTransferFee: Balance = 1 * NANOCENTS;
+	pub const ContractCreationFee: Balance = 1 * MICROCENTS;
+	pub const ContractTransactionBaseFee: Balance = 1 * NANOCENTS;
+	pub const ContractTransactionByteFee: Balance = 10 * MICROCENTS;
 	pub const ContractFee: Balance = 1 * CENTS;
 	pub const TombstoneDeposit: Balance = 1 * DOLLARS;
 	pub const RentByteFee: Balance = 1 * DOLLARS;
 	pub const RentDepositOffset: Balance = 1000 * DOLLARS;
 	pub const SurchargeReward: Balance = 150 * DOLLARS;
+	pub const BlockGasLimit: u64 = 100 * DOLLARS as u64;
 }
 
 impl pallet_contracts::Trait for Runtime {
@@ -456,7 +457,7 @@ impl pallet_contracts::Trait for Runtime {
 	type InstantiateBaseFee = pallet_contracts::DefaultInstantiateBaseFee;
 	type MaxDepth = pallet_contracts::DefaultMaxDepth;
 	type MaxValueSize = pallet_contracts::DefaultMaxValueSize;
-	type BlockGasLimit = pallet_contracts::DefaultBlockGasLimit;
+	type BlockGasLimit = BlockGasLimit;
 }
 
 impl pallet_sudo::Trait for Runtime {

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -19,6 +19,7 @@ use cennznet_runtime::{constants::asset::*, Runtime, VERSION};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
 use crml_cennzx_spot::{FeeRate, PerMilli, PerMillion};
+use pallet_contracts::{Gas, Schedule};
 
 pub const GENESIS_HASH: [u8; 32] = [69u8; 32];
 pub const SPEC_VERSION: u32 = VERSION.spec_version;
@@ -27,6 +28,9 @@ pub const SPEC_VERSION: u32 = VERSION.spec_version;
 pub struct ExtBuilder {
 	initial_balance: u128,
 	gas_price: u128,
+	// Configurable prices for certain gas metered operations
+	gas_sandbox_data_read_cost: Gas,
+	gas_regular_op_cost: Gas,
 }
 
 impl ExtBuilder {
@@ -36,6 +40,14 @@ impl ExtBuilder {
 	}
 	pub fn gas_price(mut self, gas_price: u128) -> Self {
 		self.gas_price = gas_price;
+		self
+	}
+	pub fn gas_sandbox_data_read_cost<T: Into<Gas>>(mut self, cost: T) -> Self {
+		self.gas_sandbox_data_read_cost = cost.into();
+		self
+	}
+	pub fn gas_regular_op_cost<T: Into<Gas>>(mut self, cost: T) -> Self {
+		self.gas_regular_op_cost = cost.into();
 		self
 	}
 	pub fn build(self) -> sp_io::TestExternalities {
@@ -48,8 +60,14 @@ impl ExtBuilder {
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();
+
+		// Configure the gas schedule
+		let mut gas_price_schedule = Schedule::default();
+		gas_price_schedule.sandbox_data_read_cost = self.gas_sandbox_data_read_cost;
+		gas_price_schedule.regular_op_cost = self.gas_regular_op_cost;
+
 		pallet_contracts::GenesisConfig::<Runtime> {
-			current_schedule: Default::default(),
+			current_schedule: gas_price_schedule,
 			gas_price: self.gas_price,
 		}
 		.assimilate_storage(&mut t)
@@ -73,4 +91,54 @@ impl ExtBuilder {
 		.unwrap();
 		t.into()
 	}
+}
+
+/// Test contracts
+pub mod contracts {
+
+	/// Contract WABT for reading 32 bytes from memory
+	pub const CONTRACT_READ_32_BYTES: &str = r#"
+	(module
+		(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
+		(import "env" "memory" (memory 1 1))
+		(func (export "deploy"))
+		(func (export "call")
+			(call $ext_scratch_read
+				(i32.const 0)
+				(i32.const 0)
+				(i32.const 4)
+			)
+		)
+
+		;; 32 bytes for reading
+		(data (i32.const 4)
+			"\09\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+		)
+	)"#;
+
+	/// Contract WABT for a contract which will fail during execution
+	pub const CONTRACT_WITH_TRAP: &str = r#"
+	(module
+		(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
+		(import "env" "memory" (memory 1 1))
+		(func (export "deploy"))
+		(func (export "call")
+			unreachable
+		)
+	)"#;
+
+	/// Contract WABT for a contract which dispatches a generic asset transfer of CENNZ to charlie
+	pub const CONTRACT_WITH_GA_TRANSFER: &str = r#"
+	(module
+		(import "env" "ext_dispatch_call" (func $ext_dispatch_call (param i32 i32)))
+		(import "env" "memory" (memory 1 1))
+		(func (export "call")
+			(call $ext_dispatch_call
+				(i32.const 8) ;; Pointer to the start of encoded call buffer
+				(i32.const 42) ;; Length of the buffer
+			)
+		)
+		(func (export "deploy"))
+		(data (i32.const 8) "\06\01\01\FA\90\B5\AB\20\5C\69\74\C9\EA\84\1B\E6\88\86\46\33\DC\9C\A8\A3\57\84\3E\EA\CF\23\14\64\99\65\FE\22\07\00\10\A5\D4\E8")
+	)"#;
 }

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -14,17 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with CENNZnet.  If not, see <http://www.gnu.org/licenses/>.
 
-use cennznet_primitives::types::{Balance, FeeExchange, FeeExchangeV1};
+use cennznet_primitives::types::{AccountId, Balance, FeeExchange, FeeExchangeV1};
 use cennznet_runtime::{
-	constants::asset::*, Call, CennzxSpot, CheckedExtrinsic, Executive, GenericAsset, Origin, Runtime,
+	constants::{asset::*, currency::*},
+	Call, CennzxSpot, CheckedExtrinsic, ContractTransactionBaseFee, Event, Executive, GenericAsset, Origin, Runtime,
 	TransactionBaseFee, TransactionByteFee, TransactionPayment, UncheckedExtrinsic,
 };
 use cennznet_testing::keyring::*;
 use codec::Encode;
-use frame_support::{additional_traits::MultiCurrencyAccounting, traits::Imbalance, weights::GetDispatchInfo};
+use frame_support::{
+	additional_traits::MultiCurrencyAccounting,
+	traits::Imbalance,
+	weights::{DispatchClass, DispatchInfo, GetDispatchInfo},
+};
+use frame_system::{EventRecord, Phase};
+use pallet_contracts::{ContractAddressFor, RawEvent};
 use sp_runtime::{
 	testing::Digest,
-	traits::{Convert, Header},
+	traits::{Convert, Hash, Header},
 	transaction_validity::InvalidTransaction,
 	Fixed64,
 };
@@ -35,6 +42,68 @@ use mock::ExtBuilder;
 
 const GENESIS_HASH: [u8; 32] = [69u8; 32];
 const VERSION: u32 = cennznet_runtime::VERSION.spec_version;
+
+fn initialize_block() {
+	Executive::initialize_block(&Header::new(
+		1,                        // block number
+		sp_core::H256::default(), // extrinsics_root
+		sp_core::H256::default(), // state_root
+		GENESIS_HASH.into(),      // parent_hash
+		Digest::default(),        // digest
+	));
+}
+
+/// Setup a contract on-chain, return it's deployed address
+/// This does the `put_code` and `instantiate` steps
+/// Note: It will also initialize the block and requires `TestExternalities` to succeed
+/// `contract_wabt` is the contract WABT to be deployed
+/// `contract_deployer` is the account which will send the extrinsic to deploy the contract (IRL the contract developer)
+fn setup_contract(
+	contract_wabt: &'static str,
+	contract_deployer: AccountId,
+) -> (AccountId, <<Runtime as frame_system::Trait>::Hashing as Hash>::Output) {
+	// Contract itself fails
+	let wasm = wabt::wat2wasm(contract_wabt).unwrap();
+	let code_hash = <Runtime as frame_system::Trait>::Hashing::hash(&wasm);
+
+	initialize_block();
+
+	let put_code_call = Call::Contracts(pallet_contracts::Call::put_code(50_000_000, wasm));
+	let put_code_extrinsic = sign(CheckedExtrinsic {
+		signed: Some((contract_deployer.clone(), signed_extra(0, 0, None, None))),
+		function: put_code_call,
+	});
+	let r = Executive::apply_extrinsic(put_code_extrinsic);
+	println!(
+		"{:?}, CPAY Balance: {:?}",
+		r,
+		<GenericAsset as MultiCurrencyAccounting>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID))
+	);
+	assert!(r.is_ok());
+
+	let instantiate_call = Call::Contracts(pallet_contracts::Call::instantiate(
+		0,                   // endowment
+		100_000_000_000_000, // gas limit
+		code_hash.into(),
+		vec![], // data
+	));
+	let instantiate_extrinsic = sign(CheckedExtrinsic {
+		signed: Some((contract_deployer, signed_extra(1, 0, None, None))),
+		function: instantiate_call,
+	});
+	let r2 = Executive::apply_extrinsic(instantiate_extrinsic);
+	println!(
+		"{:?}, CPAY Balance: {:?}",
+		r2,
+		<GenericAsset as MultiCurrencyAccounting>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID))
+	);
+	assert!(r2.is_ok());
+
+	(
+		<Runtime as pallet_contracts::Trait>::DetermineContractAddress::contract_address_for(&code_hash, &[], &alice()),
+		code_hash,
+	)
+}
 
 fn sign(xt: CheckedExtrinsic) -> UncheckedExtrinsic {
 	cennznet_testing::keyring::sign(xt, VERSION, GENESIS_HASH)
@@ -48,16 +117,6 @@ fn transfer_fee<E: Encode>(extrinsic: &E, fee_multiplier: Fixed64, runtime_call:
 
 	let base_fee = TransactionBaseFee::get();
 	base_fee + fee_multiplier.saturated_multiply_accumulate(length_fee + weight_fee)
-}
-
-fn initialize_block() {
-	Executive::initialize_block(&Header::new(
-		1,                        // block number
-		sp_core::H256::default(), // extrinsics_root
-		sp_core::H256::default(), // state_root
-		GENESIS_HASH.into(),      // parent_hash
-		Digest::default(),        // digest
-	));
 }
 
 #[test]
@@ -80,11 +139,11 @@ fn runtime_mock_setup_works() {
 			CERTI_ASSET_ID,
 			ARDA_ASSET_ID,
 		];
-		for (account, balance) in tests.clone() {
-			for asset in assets.clone() {
+		for (account, balance) in &tests {
+			for asset in &assets {
 				assert_eq!(
-					<GenericAsset as MultiCurrencyAccounting>::free_balance(&account, Some(asset)),
-					balance,
+					<GenericAsset as MultiCurrencyAccounting>::free_balance(&account, Some(*asset)),
+					*balance,
 				);
 				assert_eq!(
 					<GenericAsset as MultiCurrencyAccounting>::free_balance(&account, Some(123)),
@@ -222,35 +281,442 @@ fn generic_asset_transfer_works_with_fee_exchange() {
 
 #[test]
 fn contract_fails() {
-	// Contract itself fails
+	ExtBuilder::default()
+		.initial_balance(1_000_000 * TransactionBaseFee::get())
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			let (contract_address, _) = setup_contract(mock::contracts::CONTRACT_WITH_TRAP, dave());
+
+			// Call the newly instantiated contract. The contract is expected to dispatch a call
+			// and then trap.
+			let contract_call = Call::Contracts(pallet_contracts::Call::call(
+				contract_address, // newly created contract address
+				0,                // transfer value in
+				1_000_000,        // gas limit
+				vec![],
+			));
+			let contract_call_extrinsic = sign(CheckedExtrinsic {
+				signed: Some((bob(), signed_extra(2, 0, None, None))),
+				function: contract_call,
+			});
+
+			assert!(Executive::apply_extrinsic(contract_call_extrinsic).is_err());
+		});
+}
+
+// Scenario:
+// - Extrinsic made with a contract call and fee payment in CENNZ
+// - Contract will dispatch a runtime call to move the callers CENNZ funds which should be used for payment
+// This must fail!
+#[test]
+fn contract_dispatches_runtime_call_funds_are_safu() {
+	ExtBuilder::default()
+		.initial_balance(1_000_000_000_000 * DOLLARS)
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			// Setup lots of CENNZ / CPAY liquidity
+			assert!(CennzxSpot::add_liquidity(
+				Origin::signed(dave()),
+				CENNZ_ASSET_ID,
+				1_000_000_000 * DOLLARS,
+				1_000_000_000 * DOLLARS,
+				1_000_000_000 * DOLLARS,
+			)
+			.is_ok());
+
+			let bob_max_funds = 10 * CENTS;
+			// We use an encoded call in the contract
+			// if the test fails here the runtime encoding has changed so the contract WABT needs an update
+			assert_eq!(
+				Call::GenericAsset(pallet_generic_asset::Call::transfer(
+					CENNZ_ASSET_ID,
+					charlie(),
+					bob_max_funds
+				))
+				.encode()
+				.as_slice(),
+				vec![
+					6, 1, 1, 250, 144, 181, 171, 32, 92, 105, 116, 201, 234, 132, 27, 230, 136, 134, 70, 51, 220, 156,
+					168, 163, 87, 132, 62, 234, 207, 35, 20, 100, 153, 101, 254, 34, 11, 0, 160, 114, 78, 24, 9
+				]
+				.as_slice()
+			);
+			let (contract_address, code_hash) = setup_contract(mock::contracts::CONTRACT_WITH_GA_TRANSFER, alice());
+
+			// Call the newly instantiated contract. The contract is expected to dispatch a call
+			// and then trap.
+			let contract_call = Call::Contracts(pallet_contracts::Call::call(
+				contract_address.clone(), // newly created contract address
+				0,                        // transfer value in
+				5_000_000_000,            // gas limit
+				vec![],
+			));
+			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
+				asset_id: CENNZ_ASSET_ID,
+				max_payment: bob_max_funds,
+			});
+			let contract_call_extrinsic = sign(CheckedExtrinsic {
+				signed: Some((bob(), signed_extra(0, 0, None, Some(fee_exchange)))),
+				function: contract_call,
+			});
+
+			// This only shows transaction fee payment success, not gas payment success
+			assert!(Executive::apply_extrinsic(contract_call_extrinsic).is_ok());
+
+			let block_events = frame_system::Module::<Runtime>::events();
+			let events = vec![
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(0),
+					event: Event::pallet_contracts(RawEvent::CodeStored(code_hash.into())),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(0),
+					event: Event::system(frame_system::Event::ExtrinsicSuccess(DispatchInfo {
+						weight: 10000,
+						class: DispatchClass::Normal,
+						pays_fee: true,
+					})),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(1),
+					event: Event::pallet_contracts(RawEvent::Transfer(alice(), contract_address.clone(), 0)),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(1),
+					event: Event::pallet_contracts(RawEvent::Instantiated(alice(), contract_address.clone())),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(1),
+					event: Event::system(frame_system::Event::ExtrinsicSuccess(DispatchInfo {
+						weight: 10000,
+						class: DispatchClass::Normal,
+						pays_fee: true,
+					})),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(2),
+					event: Event::crml_cennzx_spot(crml_cennzx_spot::RawEvent::AssetPurchase(
+						CENNZ_ASSET_ID,
+						CENTRAPAY_ASSET_ID,
+						bob(),
+						2_587_750_030_067,
+						2_580_010_000_000,
+					)),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(2),
+					event: Event::crml_cennzx_spot(crml_cennzx_spot::RawEvent::AssetPurchase(
+						CENNZ_ASSET_ID,
+						CENTRAPAY_ASSET_ID,
+						bob(),
+						421_261_139,
+						420_001_135,
+					)),
+					topics: vec![],
+				},
+				// This event shows the generic asset transfer contract has failed with result = false
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(2),
+					event: Event::pallet_contracts(RawEvent::Dispatched(contract_address.clone(), false)),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(2),
+					event: Event::system(frame_system::Event::ExtrinsicSuccess(DispatchInfo {
+						weight: 10000,
+						class: DispatchClass::Normal,
+						pays_fee: true,
+					})),
+					topics: vec![],
+				},
+			];
+			assert_eq!(block_events, events);
+		});
 }
 
 #[test]
-fn contract_fails_with_insufficient_gas() {
-	// Not enough gas to run contract
+fn contract_call_fails_with_insufficient_gas_without_fee_exchange() {
+	ExtBuilder::default()
+		.initial_balance(100)
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			initialize_block();
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((alice(), signed_extra(0, 0, None, None))),
+				function: Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+					bob(),
+					10,
+					10 * ContractTransactionBaseFee::get() as u64,
+					vec![],
+				)),
+			});
+			assert_eq!(Executive::apply_extrinsic(xt), Err(InvalidTransaction::Payment.into()));
+		});
+}
+
+#[test]
+fn contract_call_fails_with_insufficient_gas_with_fee_exchange() {
+	ExtBuilder::default()
+		.initial_balance(100)
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			// Add more funds to charlie's account so he can create an exchange
+			let balance_amount = 10_000 * TransactionBaseFee::get();
+			let _ = GenericAsset::deposit_creating(&charlie(), Some(CENTRAPAY_ASSET_ID), balance_amount);
+			let _ = GenericAsset::deposit_creating(&charlie(), Some(CENNZ_ASSET_ID), balance_amount);
+			assert_eq!(
+				GenericAsset::free_balance(&CENTRAPAY_ASSET_ID, &charlie()),
+				balance_amount + 100
+			);
+			assert_eq!(
+				GenericAsset::free_balance(&CENNZ_ASSET_ID, &charlie()),
+				balance_amount + 100
+			);
+
+			let liquidity_core_amount = 100 * TransactionBaseFee::get();
+			let liquidity_asset_amount = 200 * TransactionBaseFee::get();
+
+			let _ = CennzxSpot::add_liquidity(
+				Origin::signed(charlie()),
+				CENNZ_ASSET_ID,
+				10, // min_liquidity
+				liquidity_asset_amount,
+				liquidity_core_amount,
+			);
+			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
+			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &charlie()), liquidity_core_amount);
+
+			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
+				asset_id: CENNZ_ASSET_ID,
+				max_payment: 100_000_000,
+			});
+
+			initialize_block();
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((alice(), signed_extra(0, 0, None, Some(fee_exchange)))),
+				function: Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+					bob(),
+					10,
+					10 * ContractTransactionBaseFee::get() as u64,
+					vec![],
+				)),
+			});
+			assert_eq!(Executive::apply_extrinsic(xt), Err(InvalidTransaction::Payment.into()));
+		});
 }
 
 #[test]
 fn contract_call_works_without_fee_exchange() {
-	// Happy case with no fee exchange
-	// Contract changes users account assets
+	let balance_amount = 10_000 * TransactionBaseFee::get();
+	let transfer_amount = 50;
+	let gas_limit_amount = 10 * ContractTransactionBaseFee::get();
+	let contract_call = Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+		bob(),
+		transfer_amount,
+		gas_limit_amount as u64,
+		vec![],
+	));
+
+	ExtBuilder::default()
+		.initial_balance(balance_amount)
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((alice(), signed_extra(0, 0, None, None))),
+				function: contract_call,
+			});
+			initialize_block();
+			let r = Executive::apply_extrinsic(xt);
+			assert!(r.is_ok());
+
+			assert_eq!(
+				<GenericAsset as MultiCurrencyAccounting>::free_balance(&bob(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount + transfer_amount,
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrencyAccounting>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount - 2_440_010_001_185,
+			);
+		});
 }
 
 #[test]
 fn contract_call_works_with_fee_exchange() {
-	// Happy case with fee exchange (with/without excess funds)
-	// Fee exchange is asking for CPay
-	// Contract makes an extrinsic to the exchange
-	// Contract changes users account assets
+	let balance_amount = 10_000 * TransactionBaseFee::get();
+	let transfer_amount = 50;
+	let gas_limit_amount = 10 * ContractTransactionBaseFee::get();
+	let contract_call = Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+		bob(),
+		transfer_amount,
+		gas_limit_amount as u64,
+		vec![],
+	));
+
+	ExtBuilder::default()
+		.initial_balance(balance_amount)
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			let liquidity_core_amount = 100 * TransactionBaseFee::get();
+			let liquidity_asset_amount = 10 * TransactionBaseFee::get();
+			let _ = CennzxSpot::add_liquidity(
+				Origin::signed(charlie()),
+				CENNZ_ASSET_ID,
+				10, // min_liquidity
+				liquidity_asset_amount,
+				liquidity_core_amount,
+			);
+			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
+			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &charlie()), liquidity_core_amount);
+
+			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
+				asset_id: CENNZ_ASSET_ID,
+				max_payment: 100_000_000 * gas_limit_amount,
+			});
+
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((alice(), signed_extra(0, 0, None, Some(fee_exchange)))),
+				function: contract_call,
+			});
+			initialize_block();
+			let r = Executive::apply_extrinsic(xt);
+			assert!(r.is_ok());
+
+			assert_eq!(
+				<GenericAsset as MultiCurrencyAccounting>::free_balance(&bob(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount + transfer_amount,
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrencyAccounting>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount - transfer_amount,
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrencyAccounting>::free_balance(&alice(), Some(CENNZ_ASSET_ID)),
+				balance_amount - 260_346_803_274,
+			);
+		});
 }
 
 #[test]
 fn contract_call_fails_when_fee_exchange_is_not_enough_for_gas() {
-	// Fee exchange not enough to pay for gas
-	// validate() should early terminate?
+	let contract_call = Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+		bob(),
+		50,
+		10 * ContractTransactionBaseFee::get() as u64,
+		vec![],
+	));
+
+	ExtBuilder::default()
+		.initial_balance(10_000 * TransactionBaseFee::get())
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			let liquidity_core_amount = 100 * TransactionBaseFee::get();
+			let liquidity_asset_amount = 10 * TransactionBaseFee::get();
+			let _ = CennzxSpot::add_liquidity(
+				Origin::signed(charlie()),
+				CENNZ_ASSET_ID,
+				10, // min_liquidity
+				liquidity_asset_amount,
+				liquidity_core_amount,
+			);
+			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
+			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &charlie()), liquidity_core_amount);
+
+			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
+				asset_id: CENNZ_ASSET_ID,
+				max_payment: 1,
+			});
+
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((alice(), signed_extra(0, 0, None, Some(fee_exchange)))),
+				function: contract_call,
+			});
+			initialize_block();
+			let r = Executive::apply_extrinsic(xt);
+			assert_eq!(r, Err(InvalidTransaction::Payment.into()));
+		});
 }
 
 #[test]
 fn contract_call_fails_when_exchange_liquidity_is_low() {
-	// Exchange doesn’t have sufficient liquidity
+	let gas_limit_amount = 10 * ContractTransactionBaseFee::get();
+	let contract_call = Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+		bob(),
+		50,
+		gas_limit_amount as u64,
+		vec![],
+	));
+
+	ExtBuilder::default()
+		.initial_balance(10_000 * TransactionBaseFee::get())
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			let liquidity_core_amount = 100;
+			let liquidity_asset_amount = 100;
+			let _ = CennzxSpot::add_liquidity(
+				Origin::signed(charlie()),
+				CENNZ_ASSET_ID,
+				10, // min_liquidity
+				liquidity_asset_amount,
+				liquidity_core_amount,
+			);
+			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
+			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &charlie()), liquidity_core_amount);
+
+			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
+				asset_id: CENNZ_ASSET_ID,
+				max_payment: 100_000_000 * gas_limit_amount,
+			});
+
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((alice(), signed_extra(0, 0, None, Some(fee_exchange)))),
+				function: contract_call,
+			});
+			initialize_block();
+			let r = Executive::apply_extrinsic(xt);
+			assert_eq!(r, Err(InvalidTransaction::Payment.into()));
+		});
+}
+
+#[test]
+fn contract_call_fails_when_cpay_is_used_for_fee_exchange() {
+	let gas_limit_amount = 10 * ContractTransactionBaseFee::get();
+	let contract_call = Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+		bob(),
+		50,
+		gas_limit_amount as u64,
+		vec![],
+	));
+
+	ExtBuilder::default()
+		.initial_balance(10_000 * TransactionBaseFee::get())
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
+				asset_id: CENTRAPAY_ASSET_ID,
+				max_payment: 100 * gas_limit_amount,
+			});
+
+			initialize_block();
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((alice(), signed_extra(0, 0, None, Some(fee_exchange)))),
+				function: contract_call,
+			});
+			let r = Executive::apply_extrinsic(xt);
+			assert_eq!(r, Err(InvalidTransaction::Payment.into()));
+		});
 }


### PR DESCRIPTION
Added:
- more units for the currency in `constants.rs`
- `fn contract_fails`
- `fn contract_call_fails_with_insufficient_gas_without_fee_exchange`
- `fn contract_call_fails_with_insufficient_gas_with_fee_exchange`
- `fn contract_call_works_without_fee_exchange`
- `fn contract_call_works_with_fee_exchange`
- `fn contract_call_fails_when_fee_exchange_is_not_enough_for_gas`
- `fn contract_call_fails_when_exchange_liquidity_is_low`
- `fn contract_call_with_cpay_fee_exchange_does_not_use_exchange`