### PR TITLE
Feature/bt 154 treasury reward

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
+ "pallet-balances",
  "pallet-collective",
  "pallet-contracts",
  "pallet-contracts-rpc-runtime-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,6 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
  "pallet-collective",
  "pallet-contracts",
  "pallet-contracts-rpc-runtime-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
 name = "cennznet-runtime"
 version = "1.0.0"
 dependencies = [
+ "cennznet-cli",
  "cennznet-primitives",
  "cennznet-testing",
  "cennznut",

--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -46,19 +46,22 @@ pub mod rimu;
 
 type AccountPublic = <Signature as Verify>::Signer;
 
+/// A type contains authority keys
+pub type AuthorityKeys = (
+	AccountId,
+	AccountId,
+	GrandpaId,
+	BabeId,
+	ImOnlineId,
+	AuthorityDiscoveryId,
+);
+
 /// A type to hold keys used in CENNZnet node in SS58 format.
 pub struct NetworkKeys {
 	/// Endowed account address (SS58 format).
 	pub endowed_accounts: Vec<AccountId>,
 	/// List of authority keys
-	pub initial_authorities: Vec<(
-		AccountId,
-		AccountId,
-		GrandpaId,
-		BabeId,
-		ImOnlineId,
-		AuthorityDiscoveryId,
-	)>,
+	pub initial_authorities: Vec<AuthorityKeys>,
 	/// Sudo account address (SS58 format).
 	pub root_key: AccountId,
 }
@@ -112,13 +115,9 @@ pub fn get_authority_keys_from_seed(
 	)
 }
 
-/// Helper function to generate session keys
-fn session_keys(
-	grandpa: GrandpaId,
-	babe: BabeId,
-	im_online: ImOnlineId,
-	authority_discovery: AuthorityDiscoveryId,
-) -> SessionKeys {
+/// Helper function to generate session keys with authority keys
+pub fn session_keys(authority_keys: AuthorityKeys) -> SessionKeys {
+	let (_, _, grandpa, babe, im_online, authority_discovery) = authority_keys;
 	SessionKeys {
 		grandpa,
 		babe,
@@ -143,12 +142,7 @@ pub fn config_genesis(network_keys: NetworkKeys, enable_println: bool) -> Genesi
 		pallet_session: Some(SessionConfig {
 			keys: initial_authorities
 				.iter()
-				.map(|x| {
-					(
-						x.0.clone(),
-						session_keys(x.2.clone(), x.3.clone(), x.4.clone(), x.5.clone()),
-					)
-				})
+				.map(|x| (x.0.clone(), session_keys(x.clone())))
 				.collect::<Vec<_>>(),
 		}),
 		pallet_staking: Some(StakingConfig {

--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -48,17 +48,17 @@ type AccountPublic = <Signature as Verify>::Signer;
 
 /// A type contains authority keys
 pub type AuthorityKeys = (
-	/// stash account ID
+	// stash account ID
 	AccountId,
-	/// controller account ID
+	// controller account ID
 	AccountId,
-	/// Grandpa ID
+	// Grandpa ID
 	GrandpaId,
-	/// Babe ID
+	// Babe ID
 	BabeId,
-	/// ImOnline ID
+	// ImOnline ID
 	ImOnlineId,
-	/// Authority Discovery ID
+	// Authority Discovery ID
 	AuthorityDiscoveryId,
 );
 

--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -48,11 +48,17 @@ type AccountPublic = <Signature as Verify>::Signer;
 
 /// A type contains authority keys
 pub type AuthorityKeys = (
+	/// stash account ID
 	AccountId,
+	/// controller account ID
 	AccountId,
+	/// Grandpa ID
 	GrandpaId,
+	/// Babe ID
 	BabeId,
+	/// ImOnline ID
 	ImOnlineId,
+	/// Authority Discovery ID
 	AuthorityDiscoveryId,
 );
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -75,7 +75,6 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 cennznet-testing = { path = "../testing"}
 cennznet-cli = { path = "../cli" }
 sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
-crml-sylo = { path = "../crml/sylo", default-features = false }
 hex = "0.4.0"
 hex-literal = "0.2.1"
 wabt = "0.9.2"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -47,7 +47,6 @@ frame-executive = { git = "https://github.com/plugblockchain/plug-blockchain", d
 pallet-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-authorship = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-babe = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
-pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-collective = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-contracts-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -74,7 +74,9 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 
 [dev-dependencies]
 cennznet-testing = { path = "../testing"}
+cennznet-cli = { path = "../cli" }
 sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc2" }
+crml-sylo = { path = "../crml/sylo", default-features = false }
 hex = "0.4.0"
 hex-literal = "0.2.1"
 wabt = "0.9.2"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -47,6 +47,7 @@ frame-executive = { git = "https://github.com/plugblockchain/plug-blockchain", d
 pallet-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-authorship = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-babe = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
+pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-collective = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }
 pallet-contracts-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc2" }

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -62,7 +62,9 @@ impl OnUnbalanced<NegativeImbalance> for SplitToAllValidators {
 		for validator in &validators {
 			let dest = Staking::<Runtime>::payee(validator);
 			let reward_destination_account_id = match dest {
-				RewardDestination::Controller => Staking::<Runtime>::bonded(validator).unwrap_or_else(||validator.clone()),
+				RewardDestination::Controller => {
+					Staking::<Runtime>::bonded(validator).unwrap_or_else(|| validator.clone())
+				}
 				RewardDestination::Stash | RewardDestination::Staked => validator.clone(),
 			};
 

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -17,9 +17,9 @@
 //! Some configurable implementations as associated type for the substrate runtime.
 
 use crate::constants::fee::TARGET_BLOCK_FULLNESS;
-use crate::{BuyFeeAsset, Call, MaximumBlockWeight, Runtime};
+use crate::{Call, MaximumBlockWeight, Runtime};
 use cennznet_primitives::{
-	traits::IsGasMeteredCall,
+	traits::{BuyFeeAsset, IsGasMeteredCall},
 	types::{Balance, FeeExchange},
 };
 use crml_transaction_payment::GAS_FEE_EXCHANGE_KEY;

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -62,7 +62,7 @@ impl OnUnbalanced<NegativeImbalance> for SplitToAllValidators {
 		for validator in &validators {
 			let dest = Staking::<Runtime>::payee(validator);
 			let reward_destination_account_id = match dest {
-				RewardDestination::Controller => Staking::<Runtime>::bonded(validator).unwrap(),
+				RewardDestination::Controller => Staking::<Runtime>::bonded(validator).unwrap_or_else(||validator.clone()),
 				RewardDestination::Stash | RewardDestination::Staked => validator.clone(),
 			};
 

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -56,7 +56,7 @@ pub struct SplitToAllValidators;
 impl OnUnbalanced<NegativeImbalance> for SplitToAllValidators {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance) {
 		let validators = Staking::<Runtime>::current_elected();
-		if validators.len() > 0 || amount.peek().is_zero(){
+		if validators.len() > 0 || amount.peek().is_zero() {
 			// Get a list of elected validators
 			let per_validator_reward: Balance = amount.peek() / (validators.len() as Balance);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -24,13 +24,17 @@
 use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash, Index, Moment, Signature};
 use cennznut::{CENNZnut, Domain, Validate, ValidationErr};
 use codec::Decode;
+pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMilli, PerMillion};
 use frame_support::{
-	additional_traits::{self, MultiCurrencyAccounting}, construct_runtime, debug, parameter_types,
+	additional_traits::{self, MultiCurrencyAccounting},
+	construct_runtime, debug, parameter_types,
 	traits::{Randomness, SplitTwoWays},
 	weights::Weight,
 };
 use frame_system::offchain::TransactionSubmitter;
+pub use pallet_contracts::Gas;
 use pallet_contracts_rpc_runtime_api::ContractExecResult;
+pub use pallet_generic_asset::Call as GenericAssetCall;
 use pallet_generic_asset::{SpendingAssetCurrency, StakingAssetCurrency};
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::AuthorityList as GrandpaAuthorityList;
@@ -51,9 +55,6 @@ use sp_std::prelude::*;
 #[cfg(any(feature = "std", test))]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMilli, PerMillion};
-pub use pallet_contracts::Gas;
-pub use pallet_generic_asset::Call as GenericAssetCall;
 
 pub use frame_support::StorageValue;
 pub use pallet_staking::StakerStatus;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -72,7 +72,7 @@ pub use crml_sylo::vault as sylo_vault;
 
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
-use impls::{CurrencyToVoteHandler, FeeMultiplierUpdateHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee, Validators};
+use impls::{CurrencyToVoteHandler, FeeMultiplierUpdateHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee, SplitToAllValidators};
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -214,7 +214,7 @@ pub type DealWithFees = SplitTwoWays<
 	Balance,
 	NegativeImbalance,
 	_0,	Treasury,
-	_1,	Validators // 100% goes to elected validators
+	_1,	SplitToAllValidators // 100% goes to elected validators
 >;
 
 impl crml_transaction_payment::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -25,9 +25,8 @@ use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash,
 use cennznut::{CENNZnut, Domain, Validate, ValidationErr};
 use codec::Decode;
 use frame_support::{
-	additional_traits::self,
-	construct_runtime, debug, parameter_types,
-	traits::{Currency, Randomness, SplitTwoWays},
+	additional_traits, construct_runtime, debug, parameter_types,
+	traits::{Randomness, SplitTwoWays},
 	weights::Weight,
 };
 use frame_system::offchain::TransactionSubmitter;
@@ -72,7 +71,10 @@ pub use crml_sylo::vault as sylo_vault;
 
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
-use impls::{CurrencyToVoteHandler, FeeMultiplierUpdateHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee, SplitToAllValidators};
+use impls::{
+	CurrencyToVoteHandler, FeeMultiplierUpdateHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee,
+	NegativeImbalance, SplitToAllValidators,
+};
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -206,15 +208,13 @@ parameter_types! {
 	pub const WeightFeeCoefficient: Balance = 1_000;
 }
 
-type NegativeImbalance = <<Runtime as crml_transaction_payment::Trait>::Currency as Currency<
-	<Runtime as frame_system::Trait>::AccountId,
->>::NegativeImbalance;
-
 pub type DealWithFees = SplitTwoWays<
 	Balance,
 	NegativeImbalance,
-	_0,	Treasury,
-	_1,	SplitToAllValidators // 100% goes to elected validators
+	_0,
+	Treasury,
+	_1,
+	SplitToAllValidators, // 100% goes to elected validators
 >;
 
 impl crml_transaction_payment::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -25,7 +25,7 @@ use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash,
 use cennznut::{CENNZnut, Domain, Validate, ValidationErr};
 use codec::Decode;
 use frame_support::{
-	additional_traits, construct_runtime, debug, parameter_types,
+	additional_traits::{self, MultiCurrencyAccounting}, construct_runtime, debug, parameter_types,
 	traits::{Randomness, SplitTwoWays},
 	weights::Weight,
 };
@@ -51,7 +51,6 @@ use sp_std::prelude::*;
 #[cfg(any(feature = "std", test))]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-
 pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMilli, PerMillion};
 pub use pallet_contracts::Gas;
 pub use pallet_generic_asset::Call as GenericAssetCall;
@@ -73,7 +72,7 @@ pub use crml_sylo::vault as sylo_vault;
 pub mod impls;
 use impls::{
 	CurrencyToVoteHandler, FeeMultiplierUpdateHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee,
-	NegativeImbalance, SplitToAllValidators,
+	SplitToAllValidators,
 };
 
 /// Constant values used within the runtime.
@@ -207,6 +206,9 @@ parameter_types! {
 	// setting this to zero will disable the weight fee.
 	pub const WeightFeeCoefficient: Balance = 1_000;
 }
+
+pub type PositiveImbalance = <GenericAsset as MultiCurrencyAccounting>::PositiveImbalance;
+pub type NegativeImbalance = <GenericAsset as MultiCurrencyAccounting>::NegativeImbalance;
 
 pub type DealWithFees = SplitTwoWays<
 	Balance,

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -28,11 +28,9 @@ pub const GENESIS_HASH: [u8; 32] = [69u8; 32];
 pub const SPEC_VERSION: u32 = VERSION.spec_version;
 
 pub fn generate_initial_authorities(n: usize) -> Vec<AuthorityKeys> {
-	let (accounts, mut authority_keys) = (vec!["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie"], vec![]);
-	for i in 0..n as usize {
-		authority_keys.push(get_authority_keys_from_seed(accounts[i]))
-	}
-	authority_keys
+let accounts = vec!["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie"];
+accounts[..n].map(|s| get_authority_keys_from_seed(s)).collect()
+
 }
 
 // get all validators (stash account , controller account)

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -16,6 +16,7 @@
 
 #![allow(dead_code)]
 use cennznet_cli::chain_spec::{get_authority_keys_from_seed, session_keys, AuthorityKeys};
+use cennznet_primitives::types::{AccountId, Balance};
 use cennznet_runtime::{constants::asset::*, Runtime, StakerStatus, VERSION};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
@@ -26,28 +27,33 @@ use sp_runtime::Perbill;
 pub const GENESIS_HASH: [u8; 32] = [69u8; 32];
 pub const SPEC_VERSION: u32 = VERSION.spec_version;
 
-fn generate_initial_authorities() -> Vec<AuthorityKeys> {
+pub fn generate_initial_authorities() -> Vec<AuthorityKeys> {
 	vec![
 		get_authority_keys_from_seed("Alice"),
 		get_authority_keys_from_seed("Bob"),
 	]
 }
 
+// get all validators (slash account , controller account)
+pub fn validators() -> Vec<(AccountId, AccountId)> {
+	generate_initial_authorities().iter().map(|x| (x.0.clone(), x.1.clone())).collect()
+}
+
 #[derive(Default)]
 pub struct ExtBuilder {
-	initial_balance: u128,
-	gas_price: u128,
+	initial_balance: Balance,
+	gas_price: Balance,
 	// Configurable prices for certain gas metered operations
 	gas_sandbox_data_read_cost: Gas,
 	gas_regular_op_cost: Gas,
 }
 
 impl ExtBuilder {
-	pub fn initial_balance(mut self, initial_balance: u128) -> Self {
+	pub fn initial_balance(mut self, initial_balance: Balance) -> Self {
 		self.initial_balance = initial_balance;
 		self
 	}
-	pub fn gas_price(mut self, gas_price: u128) -> Self {
+	pub fn gas_price(mut self, gas_price: Balance) -> Self {
 		self.gas_price = gas_price;
 		self
 	}
@@ -100,12 +106,9 @@ impl ExtBuilder {
 				dave(),
 				eve(),
 				ferdie(),
-				initial_authorities[0].0.clone(),
-				initial_authorities[1].0.clone(),
+				validators()[0].0.clone(),
+				validators()[1].0.clone(), // FIXME:
 			],
-			// .iter() // FIXME:
-			// .chain(initial_authorities.iter().map(|x| x.0.clone()).cloned())
-			// .collect(),
 			next_asset_id: NEXT_ASSET_ID,
 			staking_asset_id: STAKING_ASSET_ID,
 			spending_asset_id: SPENDING_ASSET_ID,

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -37,7 +37,10 @@ pub fn generate_initial_authorities() -> Vec<AuthorityKeys> {
 
 // get all validators (stash account , controller account)
 pub fn validators() -> Vec<(AccountId, AccountId)> {
-	generate_initial_authorities().iter().map(|x| (x.0.clone(), x.1.clone())).collect()
+	generate_initial_authorities()
+		.iter()
+		.map(|x| (x.0.clone(), x.1.clone()))
+		.collect()
 }
 
 #[derive(Default)]

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -27,9 +27,10 @@ use sp_runtime::Perbill;
 pub const GENESIS_HASH: [u8; 32] = [69u8; 32];
 pub const SPEC_VERSION: u32 = VERSION.spec_version;
 
-pub fn generate_initial_authorities(n: usize) -> Vec<AuthorityKeys> {
+fn generate_initial_authorities(n: usize) -> Vec<AuthorityKeys> {
+	assert!(n > 0 && n < 7); // because there are 6 pre-defined accounts
 	let accounts = vec!["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie"];
-	accounts[..n].map(|s| get_authority_keys_from_seed(s)).collect()
+	accounts[..n].iter().map(|s| get_authority_keys_from_seed(s)).collect()
 }
 
 // get all validators (stash account , controller account)

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -35,7 +35,7 @@ pub fn generate_initial_authorities() -> Vec<AuthorityKeys> {
 	]
 }
 
-// get all validators (slash account , controller account)
+// get all validators (stash account , controller account)
 pub fn validators() -> Vec<(AccountId, AccountId)> {
 	generate_initial_authorities().iter().map(|x| (x.0.clone(), x.1.clone())).collect()
 }
@@ -47,6 +47,7 @@ pub struct ExtBuilder {
 	// Configurable prices for certain gas metered operations
 	gas_sandbox_data_read_cost: Gas,
 	gas_regular_op_cost: Gas,
+	stash: Balance,
 }
 
 impl ExtBuilder {
@@ -64,6 +65,10 @@ impl ExtBuilder {
 	}
 	pub fn gas_regular_op_cost<T: Into<Gas>>(mut self, cost: T) -> Self {
 		self.gas_regular_op_cost = cost.into();
+		self
+	}
+	pub fn stash(mut self, stash: Balance) -> Self {
+		self.stash = stash;
 		self
 	}
 	pub fn build(self) -> sp_io::TestExternalities {
@@ -118,14 +123,13 @@ impl ExtBuilder {
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		let stash = self.initial_balance / 5;
 		pallet_staking::GenesisConfig::<Runtime> {
 			current_era: 0,
 			validator_count: initial_authorities.len() as u32 * 2,
 			minimum_validator_count: initial_authorities.len() as u32,
 			stakers: initial_authorities
 				.iter()
-				.map(|x| (x.0.clone(), x.1.clone(), stash, StakerStatus::Validator))
+				.map(|x| (x.0.clone(), x.1.clone(), self.stash, StakerStatus::Validator))
 				.collect(),
 			slash_reward_fraction: Perbill::from_percent(10),
 			..Default::default()

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -28,9 +28,8 @@ pub const GENESIS_HASH: [u8; 32] = [69u8; 32];
 pub const SPEC_VERSION: u32 = VERSION.spec_version;
 
 pub fn generate_initial_authorities(n: usize) -> Vec<AuthorityKeys> {
-let accounts = vec!["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie"];
-accounts[..n].map(|s| get_authority_keys_from_seed(s)).collect()
-
+	let accounts = vec!["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie"];
+	accounts[..n].map(|s| get_authority_keys_from_seed(s)).collect()
 }
 
 // get all validators (stash account , controller account)

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -31,6 +31,7 @@ pub fn generate_initial_authorities() -> Vec<AuthorityKeys> {
 	vec![
 		get_authority_keys_from_seed("Alice"),
 		get_authority_keys_from_seed("Bob"),
+		get_authority_keys_from_seed("Charlie"),
 	]
 }
 
@@ -107,7 +108,8 @@ impl ExtBuilder {
 				eve(),
 				ferdie(),
 				validators()[0].0.clone(),
-				validators()[1].0.clone(), // FIXME:
+				validators()[1].0.clone(),
+				validators()[2].0.clone(),
 			],
 			next_asset_id: NEXT_ASSET_ID,
 			staking_asset_id: STAKING_ASSET_ID,

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -124,14 +124,14 @@ fn transfer_fee<E: Encode>(extrinsic: &E, fee_multiplier: Fixed64, runtime_call:
 #[test]
 fn staking_genesis_config_works() {
 	let balance_amount = 10_000 * TransactionBaseFee::get();
+	let staked_amount = balance_amount / 5;
 	ExtBuilder::default()
 		.initial_balance(balance_amount)
+		.stash(staked_amount)
 		.build()
 		.execute_with(|| {
 			for validator in validators() {
 				let (stash, controller) = validator;
-				let staked_amount = balance_amount / 5;
-
 				// Check validator is included in currect elelcted accounts
 				assert!(Staking::current_elected().contains(&stash));
 				// Check that RewardDestination is Staked (default)

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -25,7 +25,6 @@ use frame_support::{additional_traits::MultiCurrencyAccounting, traits::Imbalanc
 use sp_runtime::{
 	testing::Digest,
 	traits::{Convert, Header},
-	transaction_validity::InvalidTransaction,
 	Fixed64,
 };
 

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -187,7 +187,6 @@ fn staking_validators_should_received_equal_transaction_fee_reward() {
 			assert!(r.is_ok());
 
 			// Check total_issurance is adjusted
-			// FIXME: total_issurance is not adjusted
 			assert_eq!(
 				GenericAsset::total_issuance(&CENTRAPAY_ASSET_ID),
 				previous_total_issuance - remainder

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -173,11 +173,22 @@ fn staking_validators_should_received_equal_transaction_fee_reward() {
 	
 			let fm = TransactionPayment::next_fee_multiplier();
 			let fee = transfer_fee(&xt, fm, &runtime_call);
-			let fee_reward = fee / validators().len() as Balance;
+			let validator_count = validators().len() as Balance;
+			let fee_reward = fee / validator_count;
+			let remainder = fee % validator_count;
+
+			let previous_total_issuance = GenericAsset::total_issuance(&CENTRAPAY_ASSET_ID);
 
 			initialize_block();
 			let r = Executive::apply_extrinsic(xt);
 			assert!(r.is_ok());
+
+			// Check total_issurance is adjusted
+			// FIXME: total_issurance is not adjusted
+			assert_eq!(
+				GenericAsset::total_issuance(&CENTRAPAY_ASSET_ID),
+				previous_total_issuance - remainder
+			);
 
 			for validator in validators() {
 				// Check tx fee reward went to the stash account of validator

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -17,8 +17,8 @@
 use cennznet_primitives::types::{AccountId, Balance, FeeExchange, FeeExchangeV1};
 use cennznet_runtime::{
 	constants::{asset::*, currency::*},
-	Call, CennzxSpot, CheckedExtrinsic, ContractTransactionBaseFee, Event, Executive, GenericAsset, Staking, Origin, Runtime,
-	TransactionBaseFee, TransactionByteFee, TransactionPayment, UncheckedExtrinsic,
+	Call, CennzxSpot, CheckedExtrinsic, ContractTransactionBaseFee, Event, Executive, GenericAsset, Origin, Runtime,
+	Staking, TransactionBaseFee, TransactionByteFee, TransactionPayment, UncheckedExtrinsic,
 };
 use cennznet_testing::keyring::*;
 use codec::Encode;
@@ -30,13 +30,13 @@ use frame_support::{
 };
 use frame_system::{EventRecord, Phase};
 use pallet_contracts::{ContractAddressFor, RawEvent};
+use pallet_staking::{RewardDestination, StakingLedger};
 use sp_runtime::{
 	testing::Digest,
 	traits::{Convert, Hash, Header},
 	transaction_validity::InvalidTransaction,
 	Fixed64,
 };
-use pallet_staking::{StakingLedger, RewardDestination};
 
 mod doughnut;
 mod mock;
@@ -135,19 +135,22 @@ fn staking_genesis_config_works() {
 				// Check validator is included in currect elelcted accounts
 				assert!(Staking::current_elected().contains(&stash));
 				// Check that RewardDestination is Staked (default)
-				assert_eq!(Staking::payee(&stash), RewardDestination::Staked);				
+				assert_eq!(Staking::payee(&stash), RewardDestination::Staked);
 				// Check validator free balance
 				assert_eq!(
 					<GenericAsset as MultiCurrencyAccounting>::free_balance(&stash, Some(CENTRAPAY_ASSET_ID)),
 					balance_amount
 				);
 				// Check how much is at stake
-				assert_eq!(Staking::ledger(controller), Some(StakingLedger {
-					stash,
-					total: staked_amount,
-					active: staked_amount,
-					unlocking: vec![],
-				}));
+				assert_eq!(
+					Staking::ledger(controller),
+					Some(StakingLedger {
+						stash,
+						total: staked_amount,
+						active: staked_amount,
+						unlocking: vec![],
+					})
+				);
 			}
 		});
 }
@@ -170,7 +173,7 @@ fn staking_validators_should_received_equal_transaction_fee_reward() {
 				signed: Some((alice(), signed_extra(0, 0, None, None))),
 				function: runtime_call.clone(),
 			});
-	
+
 			let fm = TransactionPayment::next_fee_multiplier();
 			let fee = transfer_fee(&xt, fm, &runtime_call);
 			let validator_count = validators().len() as Balance;

--- a/testing/src/keyring.rs
+++ b/testing/src/keyring.rs
@@ -16,7 +16,7 @@
 
 //! Test accounts.
 
-use cennznet_primitives::types::{AccountId, Balance, FeeExchange, Index};
+use cennznet_primitives::types::{AccountId, Balance, FeeExchange, Index, AssetId};
 use cennznet_runtime::{CennznetDoughnut, CheckedExtrinsic, SessionKeys, SignedExtra, UncheckedExtrinsic};
 use codec::Encode;
 use sp_keyring::{AccountKeyring, Ed25519Keyring, Sr25519Keyring};
@@ -67,7 +67,7 @@ pub fn signed_extra(
 	nonce: Index,
 	extra_fee: Balance,
 	doughnut: Option<CennznetDoughnut>,
-	fee_exchange: Option<FeeExchange>,
+	fee_exchange: Option<FeeExchange<AssetId, Balance>>,
 ) -> SignedExtra {
 	(
 		doughnut,


### PR DESCRIPTION
### Award all transaction fee equal to all validators

#### Implementation:

* Rewards are `SplitTwoWays` by 0 part to the treasury and 1 part to the validators 
* Reward is then divided by the currently elected validators
* Each validator are rewarded their share with `deposit_creating`

#### Test cases:

*  Add gensis config for `staking` and  `session` modules in `mock.rs`
*  Test case: `staking_genesis_config_works`
*  Test case : `validators_received_equal_tx_fee_reward`