### PR TITLE
Amortised validator reward payouts

### DIFF
--- a/crml/staking/reward-curve/tests/test.rs
+++ b/crml/staking/reward-curve/tests/test.rs
@@ -17,6 +17,8 @@
 //! Test crate for crml-staking-reward-curve. Allows to test for procedural macro.
 //! See tests directory.
 
+#![allow(array_into_iter)]
+
 mod test_small_falloff {
 	crml_staking_reward_curve::build! {
 		const REWARD_CURVE: sp_runtime::curve::PiecewiseLinear<'static> = curve!(

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1359,6 +1359,11 @@ impl<T: Trait> Module<T> {
 		imbalance
 	}
 
+	#[cfg(any(feature = "std", test))]
+	pub fn get_current_era_transaction_fee_reward() -> BalanceOf<T> {
+		CurrentEraTransactionRewards::<T>::get()
+	}
+
 	pub fn set_current_era_transaction_fee_reward(amount: BalanceOf<T>) {
 		CurrentEraTransactionRewards::<T>::mutate(|reward| {
 			*reward = amount;

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1419,8 +1419,6 @@ impl<T: Trait> Module<T> {
 	/// NOTE: This always happens immediately before a session change to ensure that new validators
 	/// get a chance to set their session keys.
 	fn new_era(start_session_index: SessionIndex) -> Option<Vec<T::AccountId>> {
-		// Payout
-		let points = CurrentEraPointsEarned::take();
 		let now = T::Time::now();
 		let previous_era_start = <CurrentEraStart<T>>::mutate(|v| sp_std::mem::replace(v, now));
 		let era_duration = now - previous_era_start;
@@ -1431,7 +1429,6 @@ impl<T: Trait> Module<T> {
 			let total_rewarded_stake = Self::slot_stake() * validator_len;
 
 			// Pay the accumulated tx fee as rewards to all validators
-			let validators = Self::current_elected();
 			let total_tx_fee_reward = CurrentEraTransactionRewards::<T>::take();
 			Self::split_rewards_evenly_to_all(&validators, total_tx_fee_reward);
 
@@ -1445,6 +1442,7 @@ impl<T: Trait> Module<T> {
 
 			let mut total_imbalance = <RewardPositiveImbalanceOf<T>>::zero();
 
+			let points = CurrentEraPointsEarned::take();
 			for (v, p) in validators.iter().zip(points.individual.into_iter()) {
 				if p != 0 {
 					let reward = Perbill::from_rational_approximation(p, points.total) * total_payout;

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -270,8 +270,8 @@ use pallet_session::historical::SessionManager;
 use sp_runtime::{
 	curve::PiecewiseLinear,
 	traits::{
-		AtLeast32Bit, Bounded, CheckedSub, Convert, EnsureOrigin, One, SaturatedConversion, Saturating, StaticLookup,
-		Zero,
+		AtLeast32Bit, Bounded, CheckedAdd, CheckedSub, Convert, EnsureOrigin, One, SaturatedConversion, Saturating,
+		StaticLookup, Zero,
 	},
 	PerThing, Perbill, RuntimeDebug,
 };

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1359,13 +1359,13 @@ impl<T: Trait> Module<T> {
 		imbalance
 	}
 
-	pub fn set_current_era_transaction_fee_reward( amount: BalanceOf<T> ){
+	pub fn set_current_era_transaction_fee_reward(amount: BalanceOf<T>) {
 		CurrentEraTransactionRewards::<T>::mutate(|reward| {
 			*reward = amount;
 		});
 	}
 
-	pub fn add_to_current_era_transaction_fee_reward( amount: BalanceOf<T> ){
+	pub fn add_to_current_era_transaction_fee_reward(amount: BalanceOf<T>) {
 		CurrentEraTransactionRewards::<T>::mutate(|reward| {
 			*reward = reward.checked_add(&amount).unwrap_or_else(|| *reward)
 		});

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -23,9 +23,10 @@ use cennznet_primitives::{
 };
 use crml_transaction_payment::GAS_FEE_EXCHANGE_KEY;
 use frame_support::{
-	storage, StorageValue,
+	storage,
 	traits::{Currency, ExistenceRequirement, Get, Imbalance, OnUnbalanced, WithdrawReason},
 	weights::Weight,
+	StorageValue,
 };
 use pallet_contracts::{Gas, GasMeter};
 use pallet_generic_asset::StakingAssetCurrency;

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -16,7 +16,7 @@
 
 //! Some configurable implementations as associated type for the substrate runtime.
 
-use crate::{Call, MaximumBlockWeight, NegativeImbalance, PositiveImbalance, Runtime, System};
+use crate::{Call, MaximumBlockWeight, NegativeImbalance, Runtime, System};
 use cennznet_primitives::{
 	traits::{BuyFeeAsset, IsGasMeteredCall},
 	types::{Balance, FeeExchange},

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -49,9 +49,7 @@ impl OnUnbalanced<NegativeImbalance> for SplitToAllValidators {
 		let amount = imbalance.peek();
 
 		if !amount.is_zero() {
-			<crml_staking::CurrentEraTransactionRewards<Runtime>>::mutate(|reward| {
-				*reward = reward.checked_add(amount).unwrap_or_else(|| *reward)
-			})
+			crml_staking::Module::<Runtime>::add_to_current_era_transaction_fee_reward(amount);
 		}
 	}
 }

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -26,7 +26,6 @@ use frame_support::{
 	storage,
 	traits::{Currency, ExistenceRequirement, Get, Imbalance, OnUnbalanced, WithdrawReason},
 	weights::Weight,
-	StorageValue,
 };
 use pallet_contracts::{Gas, GasMeter};
 use pallet_generic_asset::StakingAssetCurrency;

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -216,7 +216,7 @@ impl pallet_timestamp::Trait for Test {
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
 }
-pallet_staking_reward_curve::build! {
+crml_staking_reward_curve::build! {
 	const I_NPOS: PiecewiseLinear<'static> = curve!(
 		min_inflation: 0_025_000,
 		max_inflation: 0_100_000,
@@ -242,9 +242,9 @@ impl crml_staking::Trait for Test {
 	type Slash = ();
 	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;
+	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = SlashDeferDuration;
 	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId, ()>;
-	type BondingDuration = BondingDuration;
 	type SessionInterface = Self;
 	type RewardCurve = RewardCurve;
 }

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -15,16 +15,26 @@
 // along with CENNZnet.  If not, see <http://www.gnu.org/licenses/>.
 
 #![allow(dead_code)]
+use std::{collections::HashSet, cell::RefCell};
 use cennznet_cli::chain_spec::{get_authority_keys_from_seed, session_keys, AuthorityKeys};
-use cennznet_primitives::types::{AccountId, Balance, BlockNumber};
-use cennznet_runtime::{constants::asset::*, Runtime, StakerStatus, VERSION, SessionKeys};
+use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
 use crml_cennzx_spot::{FeeRate, PerMilli, PerMillion};
 use pallet_contracts::{Gas, Schedule};
-use sp_runtime::Perbill;
-use frame_support::parameter_types;
-use sp_runtime::traits::OpaqueKeys;
+use sp_runtime::{traits::{OpaqueKeys, IdentityLookup}, Perbill, KeyTypeId, curve::PiecewiseLinear};
+use sp_runtime::testing::{Header, UintAuthorityId};
+use sp_core::crypto::key_types;
+use sp_staking::SessionIndex;
+use crml_staking::EraIndex;
+
+use pallet_generic_asset::{SpendingAssetCurrency, StakingAssetCurrency};
+use frame_support::{impl_outer_origin, parameter_types, traits::{FindAuthor}};
+use cennznet_runtime::impls::{CurrencyToVoteHandler, FeeMultiplierUpdateHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee};
+use cennznet_runtime::constants::{currency::*, time::*};
+use cennznet_runtime::{
+	constants::asset::*, CennzxSpot, DealWithFees, RandomnessCollectiveFlip, StakerStatus, VERSION,
+};
 
 pub const GENESIS_HASH: [u8; 32] = [69u8; 32];
 pub const SPEC_VERSION: u32 = VERSION.spec_version;
@@ -42,29 +52,228 @@ fn generate_initial_authorities(n: usize) -> Vec<AuthorityKeys> {
 // get all validators (stash account , controller account)
 pub fn validators(n: usize) -> Vec<(AccountId, AccountId)> {
 	assert!(n > 0 && n < 7); // because there are 6 pre-defined accounts
-	generate_initial_authorities(n)
+	let mut accounts = generate_initial_authorities(n)
 		.iter()
 		.map(|x| (x.0.clone(), x.1.clone()))
 		.collect()
 }
 
-// Test config for `pallet_session`
-// parameter_types! {
-// 	pub const Period: BlockNumber = 1;
-// 	pub const Offset: BlockNumber = 0;
-// 	pub const UncleGenerations: u64 = 0;
-// 	pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(25);
-// }
-// impl pallet_session::Trait for Runtime {
-// 	type SessionManager = pallet_session::historical::NoteHistoricalRoot<Runtime, Staking>;
-// 	type Keys = SessionKeys;
-// 	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-// 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
-// 	type Event = ();
-// 	type ValidatorId = <Runtime as frame_system::Trait>::AccountId;
-// 	type ValidatorIdOf = crml_staking::StashOf<Runtime>;
-// 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
-// }
+/// Author of block is always `Alice`
+pub struct AuthorAlice;
+impl FindAuthor<u64> for AuthorAlice {
+	fn find_author<'a, I>(_digests: I) -> Option<u64>
+		where I: 'a + IntoIterator<Item=(frame_support::ConsensusEngineId, &'a [u8])>
+	{
+		Some(validators(1).0)
+	}
+}
+
+thread_local! {
+	pub(crate) static SESSION: RefCell<(Vec<AccountId>, HashSet<AccountId>)> = RefCell::new(Default::default());
+	static SLASH_DEFER_DURATION: RefCell<EraIndex> = RefCell::new(0);
+}
+
+pub struct TestSessionHandler;
+impl pallet_session::SessionHandler<AccountId> for TestSessionHandler {
+	const KEY_TYPE_IDS: &'static [KeyTypeId] = &[key_types::DUMMY];
+
+	fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(AccountId, Ks)]) {}
+
+	fn on_new_session<Ks: OpaqueKeys>(
+		_changed: bool,
+		validators: &[(AccountId, Ks)],
+		_queued_validators: &[(AccountId, Ks)],
+	) {
+		SESSION.with(|x|
+			*x.borrow_mut() = (validators.iter().map(|x| x.0.clone()).collect(), HashSet::new())
+		);
+	}
+
+	fn on_disabled(validator_index: usize) {
+		SESSION.with(|d| {
+			let mut d = d.borrow_mut();
+			let value = d.0[validator_index];
+			d.1.insert(value);
+		})
+	}
+}
+
+pub struct SlashDeferDuration;
+impl Get<EraIndex> for SlashDeferDuration {
+	fn get() -> EraIndex {
+		SLASH_DEFER_DURATION.with(|v| *v.borrow())
+	}
+}
+
+impl_outer_origin! {
+	pub enum Origin for Test where system = frame_system {}
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Test;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: u32 = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+impl frame_system::Trait for Test {
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = BlockNumber;
+	type Call = ();
+	type Hash = Hash;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = ();
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type MaximumBlockLength = MaximumBlockLength;
+	type Version = ();
+	type ModuleToIndex = ();
+	type Doughnut = ();
+	type DelegatedDispatchVerifier = ();
+}
+
+impl pallet_generic_asset::Trait for Test {
+	type Balance = Balance;
+	type AssetId = AssetId;
+	type Event = ();
+}
+
+parameter_types! {
+	pub const TransactionBaseFee: Balance = 1 * CENTS;
+	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
+	// setting this to zero will disable the weight fee.
+	pub const WeightFeeCoefficient: Balance = 1_000;
+}
+
+impl crml_transaction_payment::Trait for Test {
+	type Balance = Balance;
+	type AssetId = AssetId;
+	type Currency = SpendingAssetCurrency<Self>;
+	type OnTransactionPayment = DealWithFees;
+	type TransactionBaseFee = TransactionBaseFee;
+	type TransactionByteFee = TransactionByteFee;
+	type WeightToFee = LinearWeightToFee<WeightFeeCoefficient>;
+	type FeeMultiplierUpdate = FeeMultiplierUpdateHandler;
+	type BuyFeeAsset = CennzxSpot;
+	type GasMeteredCallResolver = GasMeteredCallResolver;
+}
+
+parameter_types! {
+	pub const Period: BlockNumber = 1;
+	pub const Offset: BlockNumber = 0;
+	pub const UncleGenerations: u64 = 0;
+	pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(25);
+}
+impl pallet_session::Trait for Test {
+	type SessionManager = Staking;
+	type Keys = UintAuthorityId;
+	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+	type SessionHandler = TestSessionHandler;
+	type Event = ();
+	type ValidatorId = AccountId;
+	type ValidatorIdOf = crml_staking::StashOf<Self>;
+	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+}
+
+impl pallet_session::historical::Trait for Test {
+	type FullIdentification = crml_staking::Exposure<AccountId, Balance>;
+	type FullIdentificationOf = crml_staking::ExposureOf<Test>;
+}
+impl pallet_authorship::Trait for Test {
+	type FindAuthor = AuthorAlice;
+	type UncleGenerations = UncleGenerations;
+	type FilterUncle = ();
+	type EventHandler = Staking;
+}
+parameter_types! {
+	pub const MinimumPeriod: u64 = 5;
+}
+impl pallet_timestamp::Trait for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+}
+pallet_staking_reward_curve::build! {
+	const I_NPOS: PiecewiseLinear<'static> = curve!(
+		min_inflation: 0_025_000,
+		max_inflation: 0_100_000,
+		ideal_stake: 0_500_000,
+		falloff: 0_050_000,
+		max_piece_count: 40,
+		test_precision: 0_005_000,
+	);
+}
+parameter_types! {
+	pub const SessionsPerEra: SessionIndex = 3;
+	pub const BondingDuration: EraIndex = 3;
+	pub const RewardCurve: &'static PiecewiseLinear<'static> = &I_NPOS;
+}
+impl crml_staking::Trait for Test {
+	type Currency = StakingAssetCurrency<Self>;
+	type RewardCurrency = SpendingAssetCurrency<Self>;
+	type CurrencyToReward = Balance;
+	type Time = pallet_timestamp::Module<Self>;
+	type CurrencyToVote = CurrencyToVoteHandler;
+	type RewardRemainder = ();
+	type Event = ();
+	type Slash = ();
+	type Reward = ();
+	type SessionsPerEra = SessionsPerEra;
+	type SlashDeferDuration = SlashDeferDuration;
+	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId, ()>;
+	type BondingDuration = BondingDuration;
+	type SessionInterface = Self;
+	type RewardCurve = RewardCurve;
+}
+parameter_types! {
+	pub const ContractTransferFee: Balance = 1 * NANOCENTS;
+	pub const ContractCreationFee: Balance = 1 * MICROCENTS;
+	pub const ContractTransactionBaseFee: Balance = 1 * NANOCENTS;
+	pub const ContractTransactionByteFee: Balance = 10 * MICROCENTS;
+	pub const ContractFee: Balance = 1 * CENTS;
+	pub const TombstoneDeposit: Balance = 1 * DOLLARS;
+	pub const RentByteFee: Balance = 1 * DOLLARS;
+	pub const RentDepositOffset: Balance = 1000 * DOLLARS;
+	pub const SurchargeReward: Balance = 150 * DOLLARS;
+	pub const BlockGasLimit: u64 = 100 * DOLLARS as u64;
+}
+impl pallet_contracts::Trait for Test {
+	type Currency = SpendingAssetCurrency<Self>;
+	type Time = Timestamp;
+	type Randomness = RandomnessCollectiveFlip;
+	type Call = Call;
+	type Event = ();
+	type DetermineContractAddress = pallet_contracts::SimpleAddressDeterminator<Test>;
+	type ComputeDispatchFee = pallet_contracts::DefaultDispatchFeeComputor<Test>;
+	type TrieIdGenerator = pallet_contracts::TrieIdFromParentCounter<Test>;
+	type GasPayment = ();
+	type GasHandler = GasHandler;
+	type RentPayment = ();
+	type SignedClaimHandicap = pallet_contracts::DefaultSignedClaimHandicap;
+	type TombstoneDeposit = TombstoneDeposit;
+	type StorageSizeOffset = pallet_contracts::DefaultStorageSizeOffset;
+	type RentByteFee = RentByteFee;
+	type RentDepositOffset = RentDepositOffset;
+	type SurchargeReward = SurchargeReward;
+	type TransferFee = ContractTransferFee;
+	type CreationFee = ContractCreationFee;
+	type TransactionBaseFee = ContractTransactionBaseFee;
+	type TransactionByteFee = ContractTransactionByteFee;
+	type ContractFee = ContractFee;
+	type CallBaseFee = pallet_contracts::DefaultCallBaseFee;
+	type InstantiateBaseFee = pallet_contracts::DefaultInstantiateBaseFee;
+	type MaxDepth = pallet_contracts::DefaultMaxDepth;
+	type MaxValueSize = pallet_contracts::DefaultMaxValueSize;
+	type BlockGasLimit = BlockGasLimit;
+}
 
 pub struct ExtBuilder {
 	initial_balance: Balance,
@@ -117,14 +326,14 @@ impl ExtBuilder {
 	}
 	pub fn build(self) -> sp_io::TestExternalities {
 		let mut endowed_accounts = vec![alice(), bob(), charlie(), dave(), eve(), ferdie()];
-		let initial_authorities = generate_initial_authorities(self.validator_count);
-		let stash_accounts: Vec<_> = initial_authorities.iter().map(|x| x.0.clone()).collect();
+		let initial_validators = validators(self.validator_count);
+		let stash_accounts: Vec<_> = initial_validators.iter().map(|x| x.0.clone()).collect();
 		endowed_accounts.extend(stash_accounts);
 
 		let mut t = frame_system::GenesisConfig::default()
-			.build_storage::<Runtime>()
+			.build_storage::<Test>()
 			.unwrap();
-		crml_cennzx_spot::GenesisConfig::<Runtime> {
+		crml_cennzx_spot::GenesisConfig::<Test> {
 			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}
@@ -136,14 +345,14 @@ impl ExtBuilder {
 		gas_price_schedule.sandbox_data_read_cost = self.gas_sandbox_data_read_cost;
 		gas_price_schedule.regular_op_cost = self.gas_regular_op_cost;
 
-		pallet_contracts::GenesisConfig::<Runtime> {
+		pallet_contracts::GenesisConfig::<Test> {
 			current_schedule: gas_price_schedule,
 			gas_price: self.gas_price,
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		pallet_generic_asset::GenesisConfig::<Runtime> {
+		pallet_generic_asset::GenesisConfig::<Test> {
 			assets: vec![
 				CENNZ_ASSET_ID,
 				CENTRAPAY_ASSET_ID,
@@ -161,11 +370,11 @@ impl ExtBuilder {
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		crml_staking::GenesisConfig::<Runtime> {
+		crml_staking::GenesisConfig::<Test> {
 			current_era: 0,
-			validator_count: initial_authorities.len() as u32 * 2,
-			minimum_validator_count: initial_authorities.len() as u32,
-			stakers: initial_authorities
+			validator_count: initial_validators.len() as u32 * 2,
+			minimum_validator_count: initial_validators.len() as u32,
+			stakers: initial_validators
 				.iter()
 				.map(|x| (x.0.clone(), x.1.clone(), self.stash, StakerStatus::Validator))
 				.collect(),
@@ -175,10 +384,10 @@ impl ExtBuilder {
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		pallet_session::GenesisConfig::<Runtime> {
-			keys: initial_authorities
+		pallet_session::GenesisConfig::<Test> {
+			keys: initial_validators
 				.iter()
-				.map(|x| (x.0.clone(), session_keys(x.clone())))
+				.map(|x| (x.0.clone(), UintAuthorityId(x.0)))
 				.collect::<Vec<_>>(),
 		}
 		.assimilate_storage(&mut t)

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -16,13 +16,13 @@
 
 #![allow(dead_code)]
 use cennznet_cli::chain_spec::{get_authority_keys_from_seed, AuthorityKeys};
-use cennznet_primitives::types::{AssetId, Balance, BlockNumber, Hash, AccountId};
+use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash};
 use cennznet_runtime::constants::{asset::*, currency::*};
 use cennznet_runtime::impls::{
 	CurrencyToVoteHandler, FeeMultiplierUpdateHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee,
 };
 use cennznet_runtime::{
-	CennzxSpot, DealWithFees, ExchangeAddressGenerator, RandomnessCollectiveFlip, StakerStatus, VERSION, Call,
+	Call, CennzxSpot, DealWithFees, ExchangeAddressGenerator, RandomnessCollectiveFlip, StakerStatus, VERSION,
 };
 use cennznet_testing::keyring::*;
 use crml_cennzx_spot::{FeeRate, PerMilli, PerMillion};

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -16,13 +16,15 @@
 
 #![allow(dead_code)]
 use cennznet_cli::chain_spec::{get_authority_keys_from_seed, session_keys, AuthorityKeys};
-use cennznet_primitives::types::{AccountId, Balance};
-use cennznet_runtime::{constants::asset::*, Runtime, StakerStatus, VERSION};
+use cennznet_primitives::types::{AccountId, Balance, BlockNumber};
+use cennznet_runtime::{constants::asset::*, Runtime, StakerStatus, VERSION, SessionKeys};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
 use crml_cennzx_spot::{FeeRate, PerMilli, PerMillion};
 use pallet_contracts::{Gas, Schedule};
 use sp_runtime::Perbill;
+use frame_support::parameter_types;
+use sp_runtime::traits::OpaqueKeys;
 
 pub const GENESIS_HASH: [u8; 32] = [69u8; 32];
 pub const SPEC_VERSION: u32 = VERSION.spec_version;
@@ -45,6 +47,24 @@ pub fn validators(n: usize) -> Vec<(AccountId, AccountId)> {
 		.map(|x| (x.0.clone(), x.1.clone()))
 		.collect()
 }
+
+// Test config for `pallet_session`
+// parameter_types! {
+// 	pub const Period: BlockNumber = 1;
+// 	pub const Offset: BlockNumber = 0;
+// 	pub const UncleGenerations: u64 = 0;
+// 	pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(25);
+// }
+// impl pallet_session::Trait for Runtime {
+// 	type SessionManager = pallet_session::historical::NoteHistoricalRoot<Runtime, Staking>;
+// 	type Keys = SessionKeys;
+// 	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+// 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
+// 	type Event = ();
+// 	type ValidatorId = <Runtime as frame_system::Trait>::AccountId;
+// 	type ValidatorIdOf = crml_staking::StashOf<Runtime>;
+// 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+// }
 
 pub struct ExtBuilder {
 	initial_balance: Balance,

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -15,45 +15,17 @@
 // along with CENNZnet.  If not, see <http://www.gnu.org/licenses/>.
 
 #![allow(dead_code)]
-use cennznet_cli::chain_spec::{get_authority_keys_from_seed, AuthorityKeys};
-use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash};
-use cennznet_runtime::constants::{asset::*, currency::*};
-use cennznet_runtime::impls::{
-	CurrencyToVoteHandler, FeeMultiplierUpdateHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee,
-};
-use cennznet_runtime::{
-	Call, CennzxSpot, DealWithFees, ExchangeAddressGenerator, RandomnessCollectiveFlip, StakerStatus, VERSION,
-};
+use cennznet_cli::chain_spec::{get_authority_keys_from_seed, session_keys, AuthorityKeys};
+use cennznet_primitives::types::{AccountId, Balance};
+use cennznet_runtime::{constants::asset::*, Runtime, StakerStatus, VERSION};
 use cennznet_testing::keyring::*;
-use crml_cennzx_spot::{FeeRate, PerMilli, PerMillion};
-use crml_staking::EraIndex;
-use std::{cell::RefCell, collections::HashSet};
-
 use core::convert::TryFrom;
-use frame_support::{
-	impl_outer_origin, parameter_types,
-	traits::{FindAuthor, Get},
-	weights::Weight,
-};
+use crml_cennzx_spot::{FeeRate, PerMilli, PerMillion};
 use pallet_contracts::{Gas, Schedule};
-use pallet_generic_asset::{SpendingAssetCurrency, StakingAssetCurrency};
-use sp_core::crypto::key_types;
-use sp_runtime::testing::{Header, UintAuthorityId};
-use sp_runtime::{
-	curve::PiecewiseLinear,
-	traits::{IdentityLookup, OpaqueKeys},
-	KeyTypeId, Perbill,
-};
-use sp_staking::SessionIndex;
+use sp_runtime::Perbill;
 
 pub const GENESIS_HASH: [u8; 32] = [69u8; 32];
 pub const SPEC_VERSION: u32 = VERSION.spec_version;
-
-pub type System = frame_system::Module<Test>;
-pub type GenericAsset = pallet_generic_asset::Module<Test>;
-pub type Session = pallet_session::Module<Test>;
-pub type Timestamp = pallet_timestamp::Module<Test>;
-pub type Staking = crml_staking::Module<Test>;
 
 fn generate_initial_authorities(n: usize) -> Vec<AuthorityKeys> {
 	assert!(n > 0 && n < 7); // because there are 6 pre-defined accounts
@@ -72,229 +44,6 @@ pub fn validators(n: usize) -> Vec<(AccountId, AccountId)> {
 		.iter()
 		.map(|x| (x.0.clone(), x.1.clone()))
 		.collect()
-}
-
-/// Author of block is always `Alice`
-pub struct AuthorAlice;
-impl FindAuthor<AccountId> for AuthorAlice {
-	fn find_author<'a, I>(_digests: I) -> Option<AccountId>
-	where
-		I: 'a + IntoIterator<Item = (frame_support::ConsensusEngineId, &'a [u8])>,
-	{
-		Some(validators(1).0)
-	}
-}
-
-thread_local! {
-	pub(crate) static SESSION: RefCell<(Vec<AccountId>, HashSet<AccountId>)> = RefCell::new(Default::default());
-	static SLASH_DEFER_DURATION: RefCell<EraIndex> = RefCell::new(0);
-}
-
-pub struct TestSessionHandler;
-impl pallet_session::SessionHandler<AccountId> for TestSessionHandler {
-	const KEY_TYPE_IDS: &'static [KeyTypeId] = &[key_types::DUMMY];
-
-	fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(AccountId, Ks)]) {}
-
-	fn on_new_session<Ks: OpaqueKeys>(
-		_changed: bool,
-		validators: &[(AccountId, Ks)],
-		_queued_validators: &[(AccountId, Ks)],
-	) {
-		SESSION.with(|x| *x.borrow_mut() = (validators.iter().map(|x| x.0.clone()).collect(), HashSet::new()));
-	}
-
-	fn on_disabled(validator_index: usize) {
-		SESSION.with(|d| {
-			let mut d = d.borrow_mut();
-			let value = d.0[validator_index];
-			d.1.insert(value);
-		})
-	}
-}
-
-pub struct SlashDeferDuration;
-impl Get<EraIndex> for SlashDeferDuration {
-	fn get() -> EraIndex {
-		SLASH_DEFER_DURATION.with(|v| *v.borrow())
-	}
-}
-
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
-
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Test;
-
-parameter_types! {
-	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 1024;
-	pub const MaximumBlockLength: u32 = 2 * 1024;
-	pub const AvailableBlockRatio: Perbill = Perbill::one();
-}
-
-impl frame_system::Trait for Test {
-	type Origin = Origin;
-	type Index = u64;
-	type BlockNumber = BlockNumber;
-	type Call = Call;
-	type Hash = Hash;
-	type Hashing = sp_runtime::traits::BlakeTwo256;
-	type AccountId = AccountId;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = ();
-	type BlockHashCount = BlockHashCount;
-	type MaximumBlockWeight = MaximumBlockWeight;
-	type AvailableBlockRatio = AvailableBlockRatio;
-	type MaximumBlockLength = MaximumBlockLength;
-	type Version = ();
-	type ModuleToIndex = ();
-	type Doughnut = ();
-	type DelegatedDispatchVerifier = ();
-}
-
-impl pallet_generic_asset::Trait for Test {
-	type Balance = Balance;
-	type AssetId = AssetId;
-	type Event = ();
-}
-
-parameter_types! {
-	pub const TransactionBaseFee: Balance = 1 * CENTS;
-	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
-	// setting this to zero will disable the weight fee.
-	pub const WeightFeeCoefficient: Balance = 1_000;
-}
-
-impl crml_transaction_payment::Trait for Test {
-	type Balance = Balance;
-	type AssetId = AssetId;
-	type Currency = SpendingAssetCurrency<Self>;
-	type OnTransactionPayment = DealWithFees;
-	type TransactionBaseFee = TransactionBaseFee;
-	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = LinearWeightToFee<WeightFeeCoefficient>;
-	type FeeMultiplierUpdate = FeeMultiplierUpdateHandler;
-	type BuyFeeAsset = CennzxSpot;
-	type GasMeteredCallResolver = GasMeteredCallResolver;
-}
-
-parameter_types! {
-	pub const Period: BlockNumber = 1;
-	pub const Offset: BlockNumber = 0;
-	pub const UncleGenerations: BlockNumber = 0;
-	pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(25);
-}
-impl pallet_session::Trait for Test {
-	type SessionManager = Staking;
-	type Keys = UintAuthorityId;
-	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-	type SessionHandler = TestSessionHandler;
-	type Event = ();
-	type ValidatorId = AccountId;
-	type ValidatorIdOf = crml_staking::StashOf<Self>;
-	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
-}
-
-impl pallet_session::historical::Trait for Test {
-	type FullIdentification = crml_staking::Exposure<AccountId, Balance>;
-	type FullIdentificationOf = crml_staking::ExposureOf<Test>;
-}
-impl pallet_authorship::Trait for Test {
-	type FindAuthor = AuthorAlice;
-	type UncleGenerations = UncleGenerations;
-	type FilterUncle = ();
-	type EventHandler = Staking;
-}
-parameter_types! {
-	pub const MinimumPeriod: u64 = 5;
-}
-impl pallet_timestamp::Trait for Test {
-	type Moment = u64;
-	type OnTimestampSet = ();
-	type MinimumPeriod = MinimumPeriod;
-}
-crml_staking_reward_curve::build! {
-	const I_NPOS: PiecewiseLinear<'static> = curve!(
-		min_inflation: 0_025_000,
-		max_inflation: 0_100_000,
-		ideal_stake: 0_500_000,
-		falloff: 0_050_000,
-		max_piece_count: 40,
-		test_precision: 0_005_000,
-	);
-}
-parameter_types! {
-	pub const SessionsPerEra: SessionIndex = 3;
-	pub const BondingDuration: EraIndex = 3;
-	pub const RewardCurve: &'static PiecewiseLinear<'static> = &I_NPOS;
-}
-impl crml_staking::Trait for Test {
-	type Currency = StakingAssetCurrency<Self>;
-	type RewardCurrency = SpendingAssetCurrency<Self>;
-	type CurrencyToReward = Balance;
-	type Time = pallet_timestamp::Module<Self>;
-	type CurrencyToVote = CurrencyToVoteHandler;
-	type RewardRemainder = ();
-	type Event = ();
-	type Slash = ();
-	type Reward = ();
-	type SessionsPerEra = SessionsPerEra;
-	type BondingDuration = BondingDuration;
-	type SlashDeferDuration = SlashDeferDuration;
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId, ()>;
-	type SessionInterface = Self;
-	type RewardCurve = RewardCurve;
-}
-impl crml_cennzx_spot::Trait for Test {
-	type Call = Call;
-	type Event = ();
-	type ExchangeAddressGenerator = ExchangeAddressGenerator<Self>;
-	type BalanceToUnsignedInt = Balance;
-	type UnsignedIntToBalance = Balance;
-}
-parameter_types! {
-	pub const ContractTransferFee: Balance = 1 * NANOCENTS;
-	pub const ContractCreationFee: Balance = 1 * MICROCENTS;
-	pub const ContractTransactionBaseFee: Balance = 1 * NANOCENTS;
-	pub const ContractTransactionByteFee: Balance = 10 * MICROCENTS;
-	pub const ContractFee: Balance = 1 * CENTS;
-	pub const TombstoneDeposit: Balance = 1 * DOLLARS;
-	pub const RentByteFee: Balance = 1 * DOLLARS;
-	pub const RentDepositOffset: Balance = 1000 * DOLLARS;
-	pub const SurchargeReward: Balance = 150 * DOLLARS;
-	pub const BlockGasLimit: u64 = 100 * DOLLARS as u64;
-}
-impl pallet_contracts::Trait for Test {
-	type Currency = SpendingAssetCurrency<Self>;
-	type Time = Timestamp;
-	type Randomness = RandomnessCollectiveFlip;
-	type Call = Call;
-	type Event = ();
-	type DetermineContractAddress = pallet_contracts::SimpleAddressDeterminator<Test>;
-	type ComputeDispatchFee = pallet_contracts::DefaultDispatchFeeComputor<Test>;
-	type TrieIdGenerator = pallet_contracts::TrieIdFromParentCounter<Test>;
-	type GasPayment = ();
-	type GasHandler = GasHandler;
-	type RentPayment = ();
-	type SignedClaimHandicap = pallet_contracts::DefaultSignedClaimHandicap;
-	type TombstoneDeposit = TombstoneDeposit;
-	type StorageSizeOffset = pallet_contracts::DefaultStorageSizeOffset;
-	type RentByteFee = RentByteFee;
-	type RentDepositOffset = RentDepositOffset;
-	type SurchargeReward = SurchargeReward;
-	type TransferFee = ContractTransferFee;
-	type CreationFee = ContractCreationFee;
-	type TransactionBaseFee = ContractTransactionBaseFee;
-	type TransactionByteFee = ContractTransactionByteFee;
-	type ContractFee = ContractFee;
-	type CallBaseFee = pallet_contracts::DefaultCallBaseFee;
-	type InstantiateBaseFee = pallet_contracts::DefaultInstantiateBaseFee;
-	type MaxDepth = pallet_contracts::DefaultMaxDepth;
-	type MaxValueSize = pallet_contracts::DefaultMaxValueSize;
-	type BlockGasLimit = BlockGasLimit;
 }
 
 pub struct ExtBuilder {
@@ -348,12 +97,14 @@ impl ExtBuilder {
 	}
 	pub fn build(self) -> sp_io::TestExternalities {
 		let mut endowed_accounts = vec![alice(), bob(), charlie(), dave(), eve(), ferdie()];
-		let initial_validators = validators(self.validator_count);
-		let stash_accounts: Vec<_> = initial_validators.iter().map(|x| x.0.clone()).collect();
+		let initial_authorities = generate_initial_authorities(self.validator_count);
+		let stash_accounts: Vec<_> = initial_authorities.iter().map(|x| x.0.clone()).collect();
 		endowed_accounts.extend(stash_accounts);
 
-		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		crml_cennzx_spot::GenesisConfig::<Test> {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap();
+		crml_cennzx_spot::GenesisConfig::<Runtime> {
 			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}
@@ -365,14 +116,14 @@ impl ExtBuilder {
 		gas_price_schedule.sandbox_data_read_cost = self.gas_sandbox_data_read_cost;
 		gas_price_schedule.regular_op_cost = self.gas_regular_op_cost;
 
-		pallet_contracts::GenesisConfig::<Test> {
+		pallet_contracts::GenesisConfig::<Runtime> {
 			current_schedule: gas_price_schedule,
 			gas_price: self.gas_price,
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		pallet_generic_asset::GenesisConfig::<Test> {
+		pallet_generic_asset::GenesisConfig::<Runtime> {
 			assets: vec![
 				CENNZ_ASSET_ID,
 				CENTRAPAY_ASSET_ID,
@@ -390,11 +141,11 @@ impl ExtBuilder {
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		crml_staking::GenesisConfig::<Test> {
+		crml_staking::GenesisConfig::<Runtime> {
 			current_era: 0,
-			validator_count: initial_validators.len() as u32 * 2,
-			minimum_validator_count: initial_validators.len() as u32,
-			stakers: initial_validators
+			validator_count: initial_authorities.len() as u32 * 2,
+			minimum_validator_count: initial_authorities.len() as u32,
+			stakers: initial_authorities
 				.iter()
 				.map(|x| (x.0.clone(), x.1.clone(), self.stash, StakerStatus::Validator))
 				.collect(),
@@ -404,10 +155,10 @@ impl ExtBuilder {
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		pallet_session::GenesisConfig::<Test> {
-			keys: initial_validators
+		pallet_session::GenesisConfig::<Runtime> {
+			keys: initial_authorities
 				.iter()
-				.map(|x| (x.0.clone(), UintAuthorityId(x.0)))
+				.map(|x| (x.0.clone(), session_keys(x.clone())))
 				.collect::<Vec<_>>(),
 		}
 		.assimilate_storage(&mut t)

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -32,6 +32,8 @@ use frame_support::{
 	weights::{DispatchClass, DispatchInfo, GetDispatchInfo},
 };
 use frame_system::{EventRecord, Phase};
+use crml_staking::EraIndex;
+use sp_staking::SessionIndex;
 use pallet_contracts::{ContractAddressFor, RawEvent};
 use sp_runtime::{
 	testing::Digest,
@@ -242,8 +244,8 @@ fn staking_validators_should_receive_equal_transaction_fee_reward() {
 
 			let fm = TransactionPayment::next_fee_multiplier();
 			let fee = transfer_fee(&xt, fm, &runtime_call);
-			let fee_reward = fee / validators.len() as u128;
-			let remainder = fee % validators.len() as u128;
+			let fee_reward = fee / validators.len() as Balance;
+			let remainder = fee % validators.len() as Balance;
 
 			let previous_total_issuance = GenericAsset::total_issuance(&CENTRAPAY_ASSET_ID);
 

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -18,8 +18,8 @@ use cennznet_primitives::types::{AccountId, Balance, FeeExchange, FeeExchangeV1}
 use cennznet_runtime::{
 	constants::{asset::*, currency::*},
 	Babe, Call, CennzxSpot, CheckedExtrinsic, ContractTransactionBaseFee, EpochDuration, Event, Executive,
-	GenericAsset, Origin, Runtime, Session, SessionsPerEra, Staking, System, Timestamp, TransactionBaseFee,
-	TransactionByteFee, TransactionPayment, UncheckedExtrinsic,
+	ExpectedBlockTime, GenericAsset, Origin, Runtime, Session, SessionsPerEra, Staking, System, Timestamp,
+	TransactionBaseFee, TransactionByteFee, TransactionPayment, UncheckedExtrinsic,
 };
 use cennznet_testing::keyring::*;
 use codec::Encode;
@@ -160,7 +160,7 @@ fn current_total_payout(validator_count: Balance) -> Balance {
 
 	crml_staking::inflation::compute_total_payout(
 		<Runtime as crml_staking::Trait>::RewardCurve::get(),
-		<crml_staking::SlotStake<Runtime>>::get() * validator_count,
+		Staking::slot_stake() * validator_count,
 		GenericAsset::total_issuance(&CENNZ_ASSET_ID),
 		era_duration.saturated_into::<u64>(),
 	)
@@ -171,12 +171,12 @@ fn reward_validators(validators: &[(AccountId, AccountId)]) -> Balance {
 	let validator_len = validators.len() as Balance;
 	let total_payout = current_total_payout(validator_len);
 	assert!(total_payout > 1);
-	Staking::reward_by_ids(
-		validators
-			.iter()
-			.map(|v| (v.0.clone(), 1))
-			.collect::<Vec<(AccountId, u32)>>(),
-	);
+
+	let validators_points = validators
+		.iter()
+		.map(|v| (v.0.clone(), 1))
+		.collect::<Vec<(AccountId, u32)>>();
+	Staking::reward_by_ids(validators_points);
 
 	total_payout
 }

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -151,14 +151,6 @@ fn start_era(era_index: EraIndex) {
 	assert_eq!(Staking::current_era(), era_index);
 }
 
-#[test]
-fn start_session_works() {
-	ExtBuilder::default().build().execute_with(|| {
-		start_session(1);
-		start_session(3);
-		start_session(5);
-	});
-}
 pub fn current_total_payout_for_duration(duration: u64) -> Balance {
 	crml_staking::inflation::compute_total_payout(
 		<Runtime as crml_staking::Trait>::RewardCurve::get(),
@@ -167,6 +159,15 @@ pub fn current_total_payout_for_duration(duration: u64) -> Balance {
 		duration,
 	)
 	.0
+}
+
+#[test]
+fn start_session_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		start_session(1);
+		start_session(3);
+		start_session(5);
+	});
 }
 
 #[test]
@@ -194,6 +195,8 @@ fn staking_reward_should_work() {
 					.map(|v| (v.0.clone(), 1))
 					.collect::<Vec<(AccountId, u32)>>(),
 			);
+		});
+}
 
 #[test]
 fn advance_session_works() {

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -820,11 +820,11 @@ fn contract_call_works_without_fee_exchange() {
 			assert!(r.is_ok());
 
 			assert_eq!(
-				<GenericAsset as MultiCurrencyAccounting>::free_balance(&bob(), Some(CENTRAPAY_ASSET_ID)),
+				<GenericAsset as MultiCurrency>::free_balance(&bob(), Some(CENTRAPAY_ASSET_ID)),
 				balance_amount + transfer_amount,
 			);
 			assert_eq!(
-				<GenericAsset as MultiCurrencyAccounting>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID)),
+				<GenericAsset as MultiCurrency>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID)),
 				9997559989999715,
 			);
 		});
@@ -875,7 +875,7 @@ fn contract_call_works_with_fee_exchange() {
 			check_free_balance_updated(&bob(), balance_amount + transfer_amount);
 			check_free_balance_updated(&alice(), balance_amount - transfer_amount);
 			assert_eq!(
-				<GenericAsset as MultiCurrencyAccounting>::free_balance(&alice(), Some(CENNZ_ASSET_ID)),
+				<GenericAsset as MultiCurrency>::free_balance(&alice(), Some(CENNZ_ASSET_ID)),
 				9999739653196821,
 			);
 		});

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -170,6 +170,7 @@ fn start_session_works() {
 	});
 }
 
+// TODO: move down
 #[test]
 fn staking_reward_should_work() {
 	let balance_amount = 10_000 * TransactionBaseFee::get();
@@ -185,6 +186,7 @@ fn staking_reward_should_work() {
 		.validator_count(validators.len())
 		.build()
 		.execute_with(|| {
+			start_era(1);
 			// Compute total payout now for whole duration as other parameter won't change
 			let total_payout_0 = current_total_payout_for_duration(6000);
 			let per_staking_reward = total_payout_0 / (validators.len() as Balance);
@@ -195,6 +197,15 @@ fn staking_reward_should_work() {
 					.map(|v| (v.0.clone(), 1))
 					.collect::<Vec<(AccountId, u32)>>(),
 			);
+
+			start_era(2);
+			for validator in validators {
+				let (stash, _) = validator;
+				assert_eq!(
+					<GenericAsset as MultiCurrencyAccounting>::free_balance(&stash, Some(CENTRAPAY_ASSET_ID)),
+					balance_amount + per_staking_reward
+				);
+			}
 		});
 }
 


### PR DESCRIPTION
Instead of triggering reward payout / balance transfer at every extrinsic, we want to store the rewards and make a payout once per era (per validator) for performance reasons.

## Implementation

Add:
- `CurrentEraTransactionRewards` storage in staking module
- add, set and get (behind test) methods for the storage above
- `fn split_rewards_evenly_to_all(recipients, total_amount)` to split total_amount (rewards) evenly across the recipients
- call the above method inside `fn new_era` responsible for payout at era change

Change:
- refactor `fn on_nonzero_unbalanced` from runtime/src/impls.rs so that transaction fee rewards are accumulated in the `CurrentEraTransactionRewards` storage

## Test
Config updates:
- Add `start_session` and `start_era` functions to trigger session and era manually.

Test cases:
- new session and new era work
-  transaction rewards storage update works
- validators received staking reward after new era start
- validators should received transaction reward after new era start