### PR TITLE
Add string conversion for serde

### DIFF
--- a/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
+++ b/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
@@ -19,22 +19,42 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, Decode, Encode};
-use sp_runtime::{traits::SimpleArithmetic, RuntimeDebug};
+#[cfg(feature = "std")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sp_runtime::RuntimeDebug;
 
 /// A result of querying the exchange
 #[derive(Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum CennzxSpotResult<Balance> {
 	/// The exchange returned successfully.
+	#[cfg_attr(feature = "std", serde(bound(serialize = "Balance: std::fmt::Display")))]
+	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+	#[cfg_attr(feature = "std", serde(bound(deserialize = "Balance: std::str::FromStr")))]
+	#[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
 	Success(Balance),
 	/// There was an issue querying the exchange
 	Error,
+}
+
+#[cfg(feature = "std")]
+fn serialize_as_string<S: Serializer, T: std::fmt::Display>(t: &T, serializer: S) -> Result<S::Ok, S::Error> {
+	serializer.serialize_str(&t.to_string())
+}
+
+#[cfg(feature = "std")]
+fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(deserializer: D) -> Result<T, D::Error> {
+	let s = String::deserialize(deserializer)?;
+	s.parse::<T>()
+		.map_err(|_| serde::de::Error::custom("Parse from string failed"))
 }
 
 sp_api::decl_runtime_apis! {
 	/// The RPC API to interact with CENNZX Spot Exchange
 	pub trait CennzxSpotApi<AssetId, Balance> where
 		AssetId: Codec,
-		Balance: Codec + SimpleArithmetic,
+		Balance: Codec,
 	{
 		/// Query how much `asset_to_buy` will be given in exchange for `amount` of `asset_to_sell`
 		fn buy_price(
@@ -48,5 +68,34 @@ sp_api::decl_runtime_apis! {
 			amount: Balance,
 			asset_to_buy: AssetId,
 		) -> CennzxSpotResult<Balance>;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn serde_works_with_string() {
+		let result = CennzxSpotResult::Success(123_456_u128);
+		let json_str = r#"{"success":"123456"}"#;
+		assert_eq!(serde_json::to_string(&result).unwrap(), json_str);
+		assert_eq!(
+			serde_json::from_str::<CennzxSpotResult<u128>>(json_str).unwrap(),
+			result
+		);
+		serde_json::to_value(&result).unwrap(); // should not panic
+	}
+
+	#[test]
+	fn serde_works_with_large_integer() {
+		let result = CennzxSpotResult::Success(u128::max_value());
+		let json_str = r#"{"success":"340282366920938463463374607431768211455"}"#;
+		assert_eq!(serde_json::to_string(&result).unwrap(), json_str);
+		assert_eq!(
+			serde_json::from_str::<CennzxSpotResult<u128>>(json_str).unwrap(),
+			result
+		);
+		serde_json::to_value(&result).unwrap(); // should not panic
 	}
 }

--- a/crml/cennzx-spot/rpc/src/lib.rs
+++ b/crml/cennzx-spot/rpc/src/lib.rs
@@ -16,15 +16,14 @@
 
 //! Node-specific RPC methods for interaction with CENNZX.
 
-use std::{convert::TryInto, sync::Arc};
+use std::sync::Arc;
 
 use codec::Codec;
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use sp_api::ProvideRuntimeApi;
-use sp_arithmetic::traits::SaturatedConversion;
 use sp_blockchain::HeaderBackend;
-use sp_runtime::{generic::BlockId, traits::Block as BlockT, traits::SimpleArithmetic};
+use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
 pub use self::gen_client::Client as CennzxSpotClient;
 pub use crml_cennzx_spot_rpc_runtime_api::{
@@ -33,15 +32,17 @@ pub use crml_cennzx_spot_rpc_runtime_api::{
 
 /// Contracts RPC methods.
 #[rpc]
-pub trait CennzxSpotApi<AssetId, Balance> {
+pub trait CennzxSpotApi<AssetId, Balance, ResponseType> {
 	#[rpc(name = "cennzx_buyPrice")]
-	// TODO: prefer to return Result<Balance>, however Serde JSON library only allows u64.
-	//  - change to Result<Balance> once https://github.com/serde-rs/serde/pull/1679 is merged
-	fn buy_price(&self, asset_to_buy: AssetId, amount_to_buy: Balance, asset_to_pay: AssetId) -> Result<u64>;
+	fn buy_price(&self, asset_to_buy: AssetId, amount_to_buy: Balance, asset_to_pay: AssetId) -> Result<ResponseType>;
 
 	#[rpc(name = "cennzx_sellPrice")]
-	// TODO: change to Result<Balance> once https://github.com/serde-rs/serde/pull/1679 is merged
-	fn sell_price(&self, asset_to_sell: AssetId, amount_to_buy: Balance, asset_to_payout: AssetId) -> Result<u64>;
+	fn sell_price(
+		&self,
+		asset_to_sell: AssetId,
+		amount_to_buy: Balance,
+		asset_to_payout: AssetId,
+	) -> Result<ResponseType>;
 }
 
 /// An implementation of CENNZX Spot Exchange specific RPC methods.
@@ -65,28 +66,32 @@ pub enum Error {
 	/// The call to runtime failed.
 	Runtime,
 	CannotExchange,
-	PriceOverflow,
 }
 
+// Required to preserve return code 0 for success
 impl From<Error> for i64 {
 	fn from(e: Error) -> i64 {
 		match e {
 			Error::Runtime => 1,
 			Error::CannotExchange => 2,
-			Error::PriceOverflow => 3,
 		}
 	}
 }
 
-impl<C, Block, AssetId, Balance> CennzxSpotApi<AssetId, Balance> for CennzxSpot<C, Block>
+impl<C, Block, AssetId, Balance> CennzxSpotApi<AssetId, Balance, CennzxSpotResult<Balance>> for CennzxSpot<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	C::Api: CennzxSpotRuntimeApi<Block, AssetId, Balance>,
 	AssetId: Codec,
-	Balance: Codec + SimpleArithmetic,
+	Balance: Codec,
 {
-	fn buy_price(&self, asset_to_buy: AssetId, amount_to_buy: Balance, asset_to_pay: AssetId) -> Result<u64> {
+	fn buy_price(
+		&self,
+		asset_to_buy: AssetId,
+		amount_to_buy: Balance,
+		asset_to_pay: AssetId,
+	) -> Result<CennzxSpotResult<Balance>> {
 		let api = self.client.runtime_api();
 		let best = self.client.info().best_hash;
 		let at = BlockId::hash(best);
@@ -99,13 +104,7 @@ where
 				data: Some(format!("{:?}", e).into()),
 			})?;
 		match result {
-			CennzxSpotResult::Success(price) => {
-				TryInto::<u64>::try_into(price.saturated_into::<u128>()).map_err(|e| RpcError {
-					code: ErrorCode::ServerError(Error::PriceOverflow.into()),
-					message: "Price too large.".into(),
-					data: Some(format!("{:?}", e).into()),
-				})
-			}
+			CennzxSpotResult::Success(_) => Ok(result),
 			CennzxSpotResult::Error => Err(RpcError {
 				code: ErrorCode::ServerError(Error::CannotExchange.into()),
 				message: "Cannot exchange for requested amount.".into(),
@@ -114,7 +113,12 @@ where
 		}
 	}
 
-	fn sell_price(&self, asset_to_sell: AssetId, amount_to_sell: Balance, asset_to_payout: AssetId) -> Result<u64> {
+	fn sell_price(
+		&self,
+		asset_to_sell: AssetId,
+		amount_to_sell: Balance,
+		asset_to_payout: AssetId,
+	) -> Result<CennzxSpotResult<Balance>> {
 		let api = self.client.runtime_api();
 		let best = self.client.info().best_hash;
 		let at = BlockId::hash(best);
@@ -127,13 +131,7 @@ where
 				data: Some(format!("{:?}", e).into()),
 			})?;
 		match result {
-			CennzxSpotResult::Success(price) => {
-				TryInto::<u64>::try_into(price.saturated_into::<u128>()).map_err(|e| RpcError {
-					code: ErrorCode::ServerError(Error::PriceOverflow.into()),
-					message: "Price too large.".into(),
-					data: Some(format!("{:?}", e).into()),
-				})
-			}
+			CennzxSpotResult::Success(_) => Ok(result),
 			CennzxSpotResult::Error => Err(RpcError {
 				code: ErrorCode::ServerError(Error::CannotExchange.into()),
 				message: "Cannot exchange by requested amount.".into(),


### PR DESCRIPTION
Removed weird balance type conversion (as JS doesn't support u128), following this workaround: https://github.com/plugblockchain/plug-blockchain/blob/d2319b9c98c209be11544e5b05b4797e670c5be6/frame/transaction-payment/rpc/runtime-api/src/lib.rs#L37-L42
Numbers are serialised as string.

Changes:
- mostly followed the approach from the above link
- add one more type `ResponseType` to CennzxSpotApi which wraps the result
- remove the TryInto conversion

RPC response is now (see string value of success):
```
{"jsonrpc":"2.0","result":{"success":"1004"},"id":1}
```