### PR TITLE
Update docker to the latest circleci config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM  rustlang/rust:nightly AS builder
 WORKDIR /cennznet
 COPY . /cennznet
 
-ENV RUST_VERSION nightly-2019-12-19
+ENV RUST_VERSION 1.42.0
 RUN apt-get update && \
     apt-get -y install apt-utils cmake pkg-config libssl-dev git clang libclang-dev && \
     rustup install $RUST_VERSION && \
     rustup default $RUST_VERSION && \
-    rustup target add --toolchain $RUST_VERSION wasm32-unknown-unknown && \
+    rustup target add --toolchain nightly wasm32-unknown-unknown && \
     rustup target add --toolchain $RUST_VERSION x86_64-unknown-linux-musl && \
     mkdir -p /cennznet/.cargo
 ENV CARGO_HOME=/cennznet/.cargo


### PR DESCRIPTION
Instead of using pegged nightly version, the following changes are made to align with the latest circleci settings:
- use stable 1.42 as default
- install nightly wasm toolchain

Update: builds locally and runs well with `docker run cennznet:latest --dev`