### PR TITLE
Refactor/runtime tests

### DIFF
--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -202,12 +202,12 @@ fn start_session_works() {
 #[test]
 fn advance_session_works() {
 	ExtBuilder::default().build().execute_with(|| {
-		let session_index = 123;
+		let session_index = 12;
 		start_session(session_index);
 		advance_session();
 		advance_session();
 		advance_session();
-		assert_eq!(Session::current_index(), 126);
+		assert_eq!(Session::current_index(), 15);
 	});
 }
 


### PR DESCRIPTION
Refactor `runtime/tests/tests.rs` to address some technical debts and prepare for upcoming tasks.

---
Changes:
- remove fee_multiplier param from  `fn transfer_fee`
    - because we don't dynamically set fee multiplier for the tests (see https://github.com/cennznet/cennznet/pull/160/commits/b1400abced24214925dbdf9745b83450092a8f0c)
- refactor `fn initialize_block` to return Header instead of wrapping Executive::initialize_block
    - because it doesn't make sense to only wrap Executive::initialize_block in a function while Executive::apply_extrinsic is not (see https://github.com/cennznet/cennznet/pull/160/commits/f2873fa0e9b7abbb19579260d6ab06ef4ba1ead4)
- bump down session_index used in `fn advance_session_works` test to reduce the number of loops
- remove `fn check_free_balance_updated` so that we know which lines of assert_eq! actually panic and check for balances in a more consistent way (see https://github.com/cennznet/cennznet/pull/160/commits/b5eaafdbf9aeef0857e1850c38b0455ef12f5ca6)
---
Something that was considered but not applied in this PR:
- some tests have boilerplate variable set up (eg, balance_amount), which could be set up as `const`
    - some of these can't be turned into a const due to `error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants`
    - and it's not as bad as the above points