### PR TITLE
Chore/staking test

### DIFF
--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1476,7 +1476,7 @@ impl<T: Trait> Module<T> {
 	}
 
 	/// Compute current `total_payout` and `max_payout` for specific era duration
-	pub fn current_total_payout(total_tokens: RewardBalanceOf<T>) -> (RewardBalanceOf<T>, RewardBalanceOf<T>) {
+	pub fn current_total_payout(total_issuance: RewardBalanceOf<T>) -> (RewardBalanceOf<T>, RewardBalanceOf<T>) {
 		let validators = Self::current_elected();
 		let validator_len = validators.len() as u32;
 		let era_duration = Self::current_era_duration();
@@ -1486,7 +1486,7 @@ impl<T: Trait> Module<T> {
 		let (total_payout, max_payout) = inflation::compute_total_payout::<RewardBalanceOf<T>>(
 			&T::RewardCurve::get(),
 			total_rewarded_stake,
-			total_tokens,
+			total_issuance,
 			// Duration of era; more than u64::MAX is rewarded as u64::MAX.
 			era_duration.saturated_into::<u64>(),
 		);

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1419,7 +1419,7 @@ impl<T: Trait> Module<T> {
 			Self::split_fee_rewards_evenly_to_all(&validators, total_tx_fee_reward);
 
 			let (total_payout, max_payout) = Self::current_total_payout(T::RewardCurrency::total_issuance());
-			let mut total_imbalance = T::RewardCurrency::burn(Zero::zero()); // hack way to get new ImBalance with asset_id
+			let mut total_imbalance = T::RewardCurrency::burn(Zero::zero()); // hack to get new ImBalance with asset_id
 
 			let points = CurrentEraPointsEarned::take();
 			for (v, p) in validators.iter().zip(points.individual.into_iter()) {

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -716,6 +716,8 @@ decl_storage! {
 		/// The start of the current era.
 		pub CurrentEraStart get(fn current_era_start): MomentOf<T>;
 
+		CurrentEraDuration get(fn current_era_duration) : MomentOf<T>;
+
 		/// The session index at which the current era started.
 		pub CurrentEraStartSessionIndex get(fn current_era_start_session_index): SessionIndex;
 
@@ -1407,6 +1409,8 @@ impl<T: Trait> Module<T> {
 		let now = T::Time::now();
 		let previous_era_start = <CurrentEraStart<T>>::mutate(|v| sp_std::mem::replace(v, now));
 		let era_duration = now - previous_era_start;
+		<CurrentEraDuration<T>>::put(era_duration);
+
 		if !era_duration.is_zero() {
 			let validators = Self::current_elected();
 
@@ -1414,18 +1418,8 @@ impl<T: Trait> Module<T> {
 			let total_tx_fee_reward = CurrentEraFeeRewards::<T>::take();
 			Self::split_fee_rewards_evenly_to_all(&validators, total_tx_fee_reward);
 
-			let validator_len = validators.len() as u32;
-			let total_rewarded_stake =
-				RewardBalanceOf::<T>::saturated_from((Self::slot_stake() * validator_len.into()).saturated_into()); // ugly hack to get `T::RewardCurrency` balance from `T::Currency` balance
-			let (total_payout, max_payout) = inflation::compute_total_payout::<RewardBalanceOf<T>>(
-				&T::RewardCurve::get(),
-				total_rewarded_stake,
-				T::RewardCurrency::total_issuance(),
-				// Duration of era; more than u64::MAX is rewarded as u64::MAX.
-				era_duration.saturated_into::<u64>(),
-			);
-
-			let mut total_imbalance = <RewardPositiveImbalanceOf<T>>::zero();
+			let (total_payout, max_payout) = Self::current_total_payout(T::RewardCurrency::total_issuance());
+			let mut total_imbalance = T::RewardCurrency::burn(Zero::zero()); // hack way to get new ImBalance with asset_id
 
 			let points = CurrentEraPointsEarned::take();
 			for (v, p) in validators.iter().zip(points.individual.into_iter()) {
@@ -1479,6 +1473,24 @@ impl<T: Trait> Module<T> {
 		Self::apply_unapplied_slashes(current_era);
 
 		maybe_new_validators
+	}
+
+	/// Compute current `total_payout` and `max_payout` for specific era duration
+	pub fn current_total_payout(total_tokens: RewardBalanceOf<T>) -> (RewardBalanceOf<T>, RewardBalanceOf<T>) {
+		let validators = Self::current_elected();
+		let validator_len = validators.len() as u32;
+		let era_duration = Self::current_era_duration();
+
+		let total_rewarded_stake =
+			RewardBalanceOf::<T>::saturated_from((Self::slot_stake() * validator_len.into()).saturated_into()); // ugly hack to get `T::RewardCurrency` balance from `T::Currency` balance
+		let (total_payout, max_payout) = inflation::compute_total_payout::<RewardBalanceOf<T>>(
+			&T::RewardCurve::get(),
+			total_rewarded_stake,
+			total_tokens,
+			// Duration of era; more than u64::MAX is rewarded as u64::MAX.
+			era_duration.saturated_into::<u64>(),
+		);
+		(total_payout, max_payout)
 	}
 
 	/// Apply previously-unapplied slashes on the beginning of a new era, after a delay.

--- a/crml/staking/src/multi_token_economy_tests.rs
+++ b/crml/staking/src/multi_token_economy_tests.rs
@@ -303,5 +303,12 @@ fn validator_reward_is_not_added_to_staked_amount_in_dual_currency_model() {
 				unlocking: vec![],
 			})
 		);
-	});
+		// Check total issuance
+		let total_issuance = 1_000_000_000 * 2; // one stash and controller accounts
+		assert_eq!(GenericAsset::total_issuance(STAKING_ASSET_ID), total_issuance);
+		assert_eq!(
+			GenericAsset::total_issuance(REWARD_ASSET_ID),
+			total_issuance + total_payout_0
+		);
+	})
 }

--- a/crml/staking/src/multi_token_economy_tests.rs
+++ b/crml/staking/src/multi_token_economy_tests.rs
@@ -280,8 +280,8 @@ fn validator_reward_is_not_added_to_staked_amount_in_dual_currency_model() {
 		);
 
 		// Compute total payout now for whole duration as other parameter won't change
-		let total_payout_0 = current_total_payout_for_duration(3000);
-		assert!(total_payout_0 > 1); // Test is meaningfull if reward something
+		let total_payout = current_total_payout_for_duration(3000);
+		assert!(total_payout > 1); // Test is meaningfull if reward something
 		<Module<Test>>::reward_by_ids(vec![(11, 1)]);
 
 		start_era(1);
@@ -291,7 +291,7 @@ fn validator_reward_is_not_added_to_staked_amount_in_dual_currency_model() {
 		// Check that reward went to the stash account of validator
 		assert_eq!(
 			GenericAsset::free_balance(&REWARD_ASSET_ID, &11),
-			1_000_000_000 + total_payout_0
+			1_000_000_000 + total_payout
 		);
 		// Check that amount at stake has NOT changed
 		assert_eq!(
@@ -308,7 +308,7 @@ fn validator_reward_is_not_added_to_staked_amount_in_dual_currency_model() {
 		assert_eq!(GenericAsset::total_issuance(STAKING_ASSET_ID), total_issuance);
 		assert_eq!(
 			GenericAsset::total_issuance(REWARD_ASSET_ID),
-			total_issuance + total_payout_0
+			total_issuance + total_payout
 		);
 	})
 }

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -321,8 +321,7 @@ fn staking_inflation_and_reward_should_work() {
 			let per_staking_reward = total_payout / validator_len;
 
 			// validators should receive skaking reward after new era
-			for validator in validators.clone() {
-				let (stash, _) = validator;
+			for (stash, _) in &validators {
 				assert_eq!(
 					<GenericAsset as MultiCurrency>::free_balance(&stash, Some(CENTRAPAY_ASSET_ID)),
 					balance_amount + per_staking_reward
@@ -342,8 +341,7 @@ fn staking_inflation_and_reward_should_work() {
 				);
 
 				// The balance of stash accounts remain the same within the same era
-				for validator in validators.clone() {
-					let (stash, _) = validator;
+				for (stash, _) in &validators {
 					assert_eq!(
 						<GenericAsset as MultiCurrency>::free_balance(&stash, Some(CENTRAPAY_ASSET_ID)),
 						balance_amount + per_staking_reward
@@ -361,8 +359,7 @@ fn staking_inflation_and_reward_should_work() {
 
 			// validators should receive skaking reward after new era
 			let per_staking_reward = total_payout / validator_len + per_staking_reward;
-			for validator in validators.clone() {
-				let (stash, _) = validator;
+			for (stash, _) in &validators {
 				assert_eq!(
 					<GenericAsset as MultiCurrency>::free_balance(&stash, Some(CENTRAPAY_ASSET_ID)),
 					balance_amount + per_staking_reward
@@ -382,8 +379,7 @@ fn staking_inflation_and_reward_should_work() {
 				);
 
 				// The balance of stash accounts remain the same within the same era
-				for validator in validators.clone() {
-					let (stash, _) = validator;
+				for (stash, _) in &validators {
 					assert_eq!(
 						<GenericAsset as MultiCurrency>::free_balance(&stash, Some(CENTRAPAY_ASSET_ID)),
 						balance_amount + per_staking_reward
@@ -437,8 +433,7 @@ fn staking_validators_should_receive_equal_transaction_fee_reward() {
 			);
 
 			// Check if stash account balances are not yet changed
-			for validator in validators.clone() {
-				let (stash, _) = validator;
+			for (stash, _) in &validators {
 				assert_eq!(
 					<GenericAsset as MultiCurrency>::free_balance(&stash, Some(CENTRAPAY_ASSET_ID)),
 					balance_amount

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -320,11 +320,19 @@ fn staking_reward_inflation_works() {
 		.build()
 		.execute_with(|| {
 			// TODO: find out where / how the number is computed
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 0);
+			assert_eq!(max_payout, 0);
 
 			start_session(0);
 			assert_eq!(Staking::current_era(), 0);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(GenericAsset::total_issuance(CENTRAPAY_ASSET_ID), total_issuance);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 139_500_000);
+			assert_eq!(max_payout, 372_000_000);
+
+			// --------------------------------------------------------------------------------- //
 
 			// This triggers new_era, hence the cpay issuance is increased
 			start_session(1);
@@ -334,6 +342,9 @@ fn staking_reward_inflation_works() {
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
 				total_issuance + 744_000_000
 			);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 0);
+			assert_eq!(max_payout, 0);
 
 			start_session(2);
 			assert_eq!(Staking::current_era(), 1);
@@ -342,6 +353,9 @@ fn staking_reward_inflation_works() {
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
 				total_issuance + 744_000_000
 			);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 0);
+			assert_eq!(max_payout, 0);
 
 			start_session(3);
 			assert_eq!(Staking::current_era(), 1);
@@ -350,6 +364,9 @@ fn staking_reward_inflation_works() {
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
 				total_issuance + 744_000_000
 			);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 139_500_000);
+			assert_eq!(max_payout, 372_000_000);
 
 			start_session(4);
 			assert_eq!(Staking::current_era(), 1);
@@ -358,6 +375,9 @@ fn staking_reward_inflation_works() {
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
 				total_issuance + 744_000_000
 			);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 279_000_000);
+			assert_eq!(max_payout, 744_000_000);
 
 			start_session(5);
 			assert_eq!(Staking::current_era(), 1);
@@ -366,6 +386,9 @@ fn staking_reward_inflation_works() {
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
 				total_issuance + 744_000_000
 			);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 423_000_000);
+			assert_eq!(max_payout, 1_128_000_000);
 
 			start_session(6);
 			assert_eq!(Staking::current_era(), 1);
@@ -374,6 +397,11 @@ fn staking_reward_inflation_works() {
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
 				total_issuance + 744_000_000
 			);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 567_000_000);
+			assert_eq!(max_payout, 1_512_000_000);
+
+			// --------------------------------------------------------------------------------- //
 
 			// This triggers new_era, hence the cpay issuance is increased
 			start_session(7);
@@ -383,6 +411,9 @@ fn staking_reward_inflation_works() {
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
 				total_issuance + 2_640_000_000
 			);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 0);
+			assert_eq!(max_payout, 0);
 
 			start_session(8);
 			assert_eq!(Staking::current_era(), 2);
@@ -391,6 +422,9 @@ fn staking_reward_inflation_works() {
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
 				total_issuance + 2_640_000_000
 			);
+			let (tot_payout, max_payout) = current_total_payout(6);
+			assert_eq!(tot_payout, 139_500_000);
+			assert_eq!(max_payout, 372_000_000);
 		});
 }
 

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -307,6 +307,94 @@ fn staking_genesis_config_works() {
 }
 
 #[test]
+fn staking_reward_inflation_works() {
+	let balance_amount = 10_000 * TransactionBaseFee::get();
+	let total_issuance = balance_amount * 12; // 6 pre-configured + 6 stash accounts
+	let staked_amount = balance_amount / 6;
+	let validators = validators(6);
+
+	ExtBuilder::default()
+		.initial_balance(balance_amount)
+		.stash(staked_amount)
+		.validator_count(validators.len())
+		.build()
+		.execute_with(|| {
+			// TODO: find out where / how the number is computed
+
+			start_session(0);
+			assert_eq!(Staking::current_era(), 0);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(GenericAsset::total_issuance(CENTRAPAY_ASSET_ID), total_issuance);
+
+			// This triggers new_era, hence the cpay issuance is increased
+			start_session(1);
+			assert_eq!(Staking::current_era(), 1);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + 744_000_000
+			);
+
+			start_session(2);
+			assert_eq!(Staking::current_era(), 1);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + 744_000_000
+			);
+
+			start_session(3);
+			assert_eq!(Staking::current_era(), 1);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + 744_000_000
+			);
+
+			start_session(4);
+			assert_eq!(Staking::current_era(), 1);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + 744_000_000
+			);
+
+			start_session(5);
+			assert_eq!(Staking::current_era(), 1);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + 744_000_000
+			);
+
+			start_session(6);
+			assert_eq!(Staking::current_era(), 1);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + 744_000_000
+			);
+
+			// This triggers new_era, hence the cpay issuance is increased
+			start_session(7);
+			assert_eq!(Staking::current_era(), 2);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + 2_640_000_000
+			);
+
+			start_session(8);
+			assert_eq!(Staking::current_era(), 2);
+			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + 2_640_000_000
+			);
+		});
+}
+
+#[test]
 fn staking_reward_should_work() {
 	let balance_amount = 10_000 * TransactionBaseFee::get();
 	let total_issuance = balance_amount * 12; // 6 pre-configured + 6 stash accounts

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -35,7 +35,7 @@ use frame_system::{EventRecord, Phase};
 use pallet_contracts::{ContractAddressFor, RawEvent};
 use sp_runtime::{
 	testing::Digest,
-	traits::{Convert, Hash, Header as HeaderT, OnInitialize, SaturatedConversion},
+	traits::{Convert, Hash, Header as HeaderT, OnInitialize},
 	transaction_validity::InvalidTransaction,
 };
 use sp_staking::SessionIndex;
@@ -154,33 +154,12 @@ fn start_era(era_index: EraIndex) {
 	assert_eq!(Staking::current_era(), era_index);
 }
 
-fn current_total_payout(validator_count: Balance) -> (Balance, Balance) {
-	let now = Timestamp::now();
-	let previous_era_start = <crml_staking::CurrentEraStart<Runtime>>::get();
-	let era_duration = now - previous_era_start;
-
-	let (total_payout, max_payout) = crml_staking::inflation::compute_total_payout(
-		<Runtime as crml_staking::Trait>::RewardCurve::get(),
-		Staking::slot_stake() * validator_count,
-		GenericAsset::total_issuance(&CENNZ_ASSET_ID),
-		era_duration.saturated_into::<u64>(),
-	);
-
-	(total_payout, max_payout)
-}
-
-fn reward_validators(validators: &[(AccountId, AccountId)]) -> (Balance, Balance) {
-	let validator_len = validators.len() as Balance;
-	let (total_payout, max_payout) = current_total_payout(validator_len);
-	assert!(total_payout > 1);
-
+fn reward_validators(validators: &[(AccountId, AccountId)]) {
 	let validators_points = validators
 		.iter()
 		.map(|v| (v.0.clone(), 1))
 		.collect::<Vec<(AccountId, u32)>>();
 	Staking::reward_by_ids(validators_points);
-
-	(total_payout, max_payout)
 }
 
 #[test]
@@ -320,111 +299,89 @@ fn staking_reward_inflation_works() {
 		.build()
 		.execute_with(|| {
 			// TODO: find out where / how the number is computed
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 0);
-			assert_eq!(max_payout, 0);
-
 			start_session(0);
 			assert_eq!(Staking::current_era(), 0);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(GenericAsset::total_issuance(CENTRAPAY_ASSET_ID), total_issuance);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 139_500_000);
-			assert_eq!(max_payout, 372_000_000);
 
 			// --------------------------------------------------------------------------------- //
 
 			// This triggers new_era, hence the cpay issuance is increased
+			let total_issuance_0 = GenericAsset::total_issuance(CENTRAPAY_ASSET_ID);
 			start_session(1);
+			let (tot_payout, max_payout_era_1) = Staking::current_total_payout(total_issuance_0);
+			assert_eq!(tot_payout, 279_000_000);
+			assert_eq!(max_payout_era_1, 744_000_000);
+
 			assert_eq!(Staking::current_era(), 1);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
-				total_issuance + 744_000_000
+				total_issuance + max_payout_era_1
 			);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 0);
-			assert_eq!(max_payout, 0);
 
 			start_session(2);
 			assert_eq!(Staking::current_era(), 1);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
-				total_issuance + 744_000_000
+				total_issuance + max_payout_era_1
 			);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 0);
-			assert_eq!(max_payout, 0);
 
 			start_session(3);
 			assert_eq!(Staking::current_era(), 1);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
-				total_issuance + 744_000_000
+				total_issuance + max_payout_era_1
 			);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 139_500_000);
-			assert_eq!(max_payout, 372_000_000);
 
 			start_session(4);
 			assert_eq!(Staking::current_era(), 1);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
-				total_issuance + 744_000_000
+				total_issuance + max_payout_era_1
 			);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 279_000_000);
-			assert_eq!(max_payout, 744_000_000);
 
 			start_session(5);
 			assert_eq!(Staking::current_era(), 1);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
-				total_issuance + 744_000_000
+				total_issuance + max_payout_era_1
 			);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 423_000_000);
-			assert_eq!(max_payout, 1_128_000_000);
 
 			start_session(6);
 			assert_eq!(Staking::current_era(), 1);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
-				total_issuance + 744_000_000
+				total_issuance + max_payout_era_1
 			);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 567_000_000);
-			assert_eq!(max_payout, 1_512_000_000);
 
 			// --------------------------------------------------------------------------------- //
 
 			// This triggers new_era, hence the cpay issuance is increased
 			start_session(7);
+			let (tot_payout, max_payout_era_2) = Staking::current_total_payout(total_issuance + max_payout_era_1);
+			assert_eq!(tot_payout, 711_000_003);
+			assert_eq!(max_payout_era_2, 1_896_000_012);
+
 			assert_eq!(Staking::current_era(), 2);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
-				total_issuance + 2_640_000_000
+				total_issuance + max_payout_era_1 + max_payout_era_2
 			);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 0);
-			assert_eq!(max_payout, 0);
 
 			start_session(8);
 			assert_eq!(Staking::current_era(), 2);
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
 				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
-				total_issuance + 2_640_000_000
+				total_issuance + max_payout_era_1 + max_payout_era_2
 			);
-			let (tot_payout, max_payout) = current_total_payout(6);
-			assert_eq!(tot_payout, 139_500_000);
-			assert_eq!(max_payout, 372_000_000);
 		});
 }
 
@@ -449,8 +406,7 @@ fn staking_reward_should_work() {
 
 			start_era(1);
 			let validator_len = validators.len() as Balance;
-			let (total_reward, inflation) = reward_validators(&validators);
-			let per_staking_reward = total_reward / validator_len;
+			reward_validators(&validators);
 			// The balance of stash accounts remain the same within the same era
 			for validator in validators.clone() {
 				let (stash, _) = validator;
@@ -461,11 +417,16 @@ fn staking_reward_should_work() {
 			}
 
 			// Advance a session to begin era 2
+			let total_issuance_1 = GenericAsset::total_issuance(CENTRAPAY_ASSET_ID);
 			advance_session();
+			assert_eq!(Staking::current_era(), 2);
+			let (total_payout, max_payout) = Staking::current_total_payout(total_issuance_1);
+			let per_staking_reward = total_payout / validator_len;
+
 			assert_eq!(GenericAsset::total_issuance(CENNZ_ASSET_ID), total_issuance);
 			assert_eq!(
-				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID), // FIXME: 33_000_000 is coming from a weird timing issue between sessions
-				total_issuance + inflation + 33_000_012, // FIXME: Changing era_duration in fn current_total_payout outputs different inflation amount (but not sure what it should be)
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance_1 + max_payout,
 			);
 
 			// Staking rewards are paid at the next era
@@ -507,8 +468,7 @@ fn staking_validators_should_receive_equal_transaction_fee_reward() {
 
 			start_era(1);
 			let validator_len = validators.len() as Balance;
-			let (total_staking_reward, _) = reward_validators(&validators);
-			let per_staking_reward = total_staking_reward / validator_len;
+			reward_validators(&validators);
 
 			let r = Executive::apply_extrinsic(xt);
 			assert!(r.is_ok());
@@ -532,13 +492,24 @@ fn staking_validators_should_receive_equal_transaction_fee_reward() {
 				);
 			}
 
+			let total_issuance = GenericAsset::total_issuance(CENTRAPAY_ASSET_ID);
 			start_era(2);
+			let (staking_payout, max_payout) = Staking::current_total_payout(total_issuance);
+			let per_staking_reward = staking_payout / validator_len;
+
+			// Check total issuance of Spending Asset updatd after new era
+			assert_eq!(
+				GenericAsset::total_issuance(CENTRAPAY_ASSET_ID),
+				total_issuance + max_payout,
+			);
+
+			// Check if validator balance changed correctly
 			for validator in validators {
 				let (stash, _) = validator;
 				// Check tx fee reward went to the stash account of validator
 				assert_eq!(
 					<GenericAsset as MultiCurrency>::free_balance(&stash, Some(CENTRAPAY_ASSET_ID)),
-					balance_amount + per_fee_reward + per_staking_reward - 1600
+					balance_amount + per_fee_reward + per_staking_reward
 				);
 			}
 		});


### PR DESCRIPTION
This PR try to fix test cases for staking reward and transaction payment reward

## Changes:
- Use `let mut total_imbalance = T::RewardCurrency::burn(Zero::zero());` to initialise `total_imbalance` which has `asset_id`.  (It is not an elegant way, we could optimise this after we fix the problem in GA)
- Add `CurrentEraDuration` in `Staking` module storage.
- Extract `current_total_payout` function from `new_era`, make it public so that in the test cases could also reuse it and make sure the `total_payout` and `max_payout` are same.

## Tests
-  Add `staking_inflation_reward_works`
- Check `total_issuance` in `multi_token_economy_tests`

---

tldr summry:
1. Extracted logic out from `fn new_era` into `pub fn current_total_payout` so it can be used in the tests
    - NOTE: a potential concern here is exposing `current_total_payout` but (1) it's only a getter and (2) doesn't expose any sensitive information
2. Added CurrentEraDuration storage with a getter to serve as one source of truth for computing payout
3. Refactored tests to meet those changes