### PR TITLE
Add minimum_bond and make it configurable

### DIFF
--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -160,6 +160,7 @@ pub fn config_genesis(network_keys: NetworkKeys, enable_println: bool) -> Genesi
 				.map(|x| (x.0.clone(), x.1.clone(), STASH, StakerStatus::Validator))
 				.collect(),
 			invulnerables: initial_authorities.iter().map(|x| x.0.clone()).collect(),
+			minimum_bond: 1,
 			slash_reward_fraction: Perbill::from_percent(10),
 			..Default::default()
 		}),

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -785,6 +785,7 @@ decl_storage! {
 		config(stakers):
 			Vec<(T::AccountId, T::AccountId, BalanceOf<T>, StakerStatus<T::AccountId>)>;
 		build(|config: &GenesisConfig<T>| {
+			assert!(config.minimum_bond > Zero::zero(), "Minimum bond must be greater than zero.");
 			for &(ref stash, ref controller, balance, ref status) in &config.stakers {
 				assert!(
 					T::Currency::free_balance(&stash) >= balance,

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -667,6 +667,8 @@ impl Default for Forcing {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Staking {
+		/// Minimum amount to bond.
+		MinimumBond get(fn minimum_bond) config(): BalanceOf<T>;
 
 		/// The ideal number of staking participants.
 		pub ValidatorCount get(fn validator_count) config(): u32;
@@ -829,7 +831,8 @@ decl_event!(
 		OldSlashingReportDiscarded(SessionIndex),
 		/// A new set of validators are marked to be invulnerable
 		SetInvulnerables(Vec<AccountId>),
-
+		/// Minimum bond amount is changed.
+		SetMinimumBond(Balance),
 	}
 );
 
@@ -881,7 +884,7 @@ decl_module! {
 		/// Take the origin account as a stash and lock up `value` of its balance. `controller` will
 		/// be the account that controls it.
 		///
-		/// `value` must be more than the `minimum_balance` specified by `T::Currency`.
+		/// `value` must be more than the `minimum_bond` specified in genesis config.
 		///
 		/// The dispatch origin for this call must be _Signed_ by the stash account.
 		///
@@ -912,7 +915,7 @@ decl_module! {
 			}
 
 			// reject a bond which is considered to be _dust_.
-			if value < T::Currency::minimum_balance() {
+			if value < Self::minimum_bond() {
 				Err(Error::<T>::InsufficientValue)?
 			}
 
@@ -1197,6 +1200,14 @@ decl_module! {
 		fn force_new_era(origin) {
 			ensure_root(origin)?;
 			ForceEra::put(Forcing::ForceNew);
+		}
+
+		/// Set the minimum bond amount.
+		#[weight = SimpleDispatchInfo::FixedNormal(5_000)]
+		fn set_minimum_bond(origin, value: BalanceOf<T>) {
+			ensure_root(origin)?;
+			<MinimumBond<T>>::put(value);
+			Self::deposit_event(RawEvent::SetMinimumBond(value));
 		}
 
 		/// Set the validators who cannot be slashed (if any).

--- a/crml/staking/src/mock.rs
+++ b/crml/staking/src/mock.rs
@@ -237,6 +237,7 @@ pub struct ExtBuilder {
 	fair: bool,
 	num_validators: Option<u32>,
 	invulnerables: Vec<u64>,
+	minimum_bond: u64,
 }
 
 impl Default for ExtBuilder {
@@ -251,6 +252,7 @@ impl Default for ExtBuilder {
 			fair: true,
 			num_validators: None,
 			invulnerables: vec![],
+			minimum_bond: 1,
 		}
 	}
 }
@@ -290,6 +292,10 @@ impl ExtBuilder {
 	}
 	pub fn invulnerables(mut self, invulnerables: Vec<u64>) -> Self {
 		self.invulnerables = invulnerables;
+		self
+	}
+	pub fn minimum_bond(mut self, minimum_bond: u64) -> Self {
+		self.minimum_bond = minimum_bond;
 		self
 	}
 	pub fn set_associated_consts(&self) {
@@ -355,6 +361,7 @@ impl ExtBuilder {
 			validator_count: self.validator_count,
 			minimum_validator_count: self.minimum_validator_count,
 			invulnerables: self.invulnerables,
+			minimum_bond: self.minimum_bond,
 			slash_reward_fraction: Perbill::from_percent(10),
 			..Default::default()
 		}

--- a/crml/staking/src/mock.rs
+++ b/crml/staking/src/mock.rs
@@ -20,7 +20,7 @@ use crate::{
 	inflation, EraIndex, GenesisConfig, Module, Nominators, RewardDestination, StakerStatus, Trait, ValidatorPrefs,
 };
 use frame_support::{
-	assert_ok, impl_outer_origin, parameter_types,
+	assert_ok, impl_outer_event, impl_outer_origin, parameter_types,
 	traits::{Currency, FindAuthor, Get},
 	weights::Weight,
 	StorageLinkedMap, StorageValue,
@@ -104,7 +104,19 @@ impl Get<EraIndex> for SlashDeferDuration {
 }
 
 impl_outer_origin! {
-	pub enum Origin for Test  where system = frame_system {}
+	pub enum Origin for Test where system = frame_system {}
+}
+
+mod staking {
+	pub use crate::Event;
+}
+
+impl_outer_event! {
+	pub enum Event for Test where system = frame_system {
+		staking<T>,
+		pallet_balances<T>,
+		pallet_session,
+	}
 }
 
 /// Author of block is always 11
@@ -137,7 +149,7 @@ impl frame_system::Trait for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type AvailableBlockRatio = AvailableBlockRatio;
@@ -154,7 +166,7 @@ impl pallet_balances::Trait for Test {
 	type Balance = Balance;
 	type OnReapAccount = (System, Staking);
 	type OnNewAccount = ();
-	type Event = ();
+	type Event = Event;
 	type TransferPayment = ();
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
@@ -171,7 +183,7 @@ impl pallet_session::Trait for Test {
 	type Keys = UintAuthorityId;
 	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
 	type SessionHandler = TestSessionHandler;
-	type Event = ();
+	type Event = Event;
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = crate::StashOf<Test>;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
@@ -216,7 +228,7 @@ impl Trait for Test {
 	type Time = pallet_timestamp::Module<Self>;
 	type CurrencyToVote = CurrencyToVoteHandler;
 	type RewardRemainder = ();
-	type Event = ();
+	type Event = Event;
 	type Slash = ();
 	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;

--- a/crml/staking/src/multi_token_economy_tests.rs
+++ b/crml/staking/src/multi_token_economy_tests.rs
@@ -199,6 +199,7 @@ impl ExtBuilder {
 		.assimilate_storage(&mut storage);
 
 		let _ = GenesisConfig::<Test> {
+			minimum_bond: 1,
 			current_era: 0,
 			stakers: vec![
 				// (stash, controller, staked_amount, status)

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -3003,3 +3003,9 @@ fn set_minimum_bond_works() {
 		);
 	});
 }
+
+#[test]
+#[should_panic(expected = "Minimum bond must be greater than zero.")]
+fn minimum_bond_in_genesis_config_must_be_greater_than_zero() {
+	ExtBuilder::default().minimum_bond(0).build().execute_with(|| {});
+}

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -1754,6 +1754,7 @@ fn bond_with_no_staked_value() {
 		.existential_deposit(5)
 		.nominate(false)
 		.minimum_validator_count(1)
+		.minimum_bond(3)
 		.build()
 		.execute_with(|| {
 			// Can't bond with 1

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -2324,6 +2324,14 @@ fn invulnerables_can_be_set() {
 
 		//Changing the invulnerables set from [21] to [11].
 		let _ = Staking::set_invulnerables(Origin::ROOT, vec![11]);
+		assert_eq!(
+			System::events(),
+			vec![EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: mock::Event::staking(RawEvent::SetInvulnerables(vec![11])),
+				topics: vec![],
+			}]
+		);
 
 		let exposure = Staking::stakers(&21);
 		let initial_balance = Staking::slashable_balance_of(&21);
@@ -2981,8 +2989,10 @@ fn show_that_max_commission_is_100_percent() {
 		let expected_rewards: u32 = 1_000;
 
 		assert_eq!(stored_prefs.commission * total_rewards, expected_rewards);
-	})
+	});
+}
 
+#[test]
 fn set_minimum_bond_works() {
 	ExtBuilder::default().minimum_bond(7357).build().execute_with(|| {
 		// Non-root accounts cannot set minimum bond

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -142,6 +142,7 @@ impl ExtBuilder {
 		.unwrap();
 
 		crml_staking::GenesisConfig::<Runtime> {
+			minimum_bond: 1,
 			current_era: 0,
 			validator_count: initial_authorities.len() as u32 * 2,
 			minimum_validator_count: initial_authorities.len() as u32,

--- a/testing/src/genesis.rs
+++ b/testing/src/genesis.rs
@@ -103,6 +103,7 @@ pub fn config_endowed(support_changes_trie: bool, code: Option<&[u8]>, extra_end
 			minimum_validator_count: 0,
 			slash_reward_fraction: Perbill::from_percent(10),
 			invulnerables: vec![alice(), bob(), charlie()],
+			minimum_bond: 1,
 			..Default::default()
 		}),
 		pallet_contracts: Some(ContractsConfig {


### PR DESCRIPTION
The purpose of this PR is to decouple the use of GA::minimum_balance(), which is currently zero. The solution is to add a configurable storage, which is (1) initialised from genesis config and (2) could be overridden by root.

## Changes:
- add private `MinimumBond` storage with a get method
- add `SetMinimumBond` event to notify when minimum_bond is set by root (via set_minimum_bond dispatch method)
- add `fn set_minimum_bond` dispatch method that requires root permission
- set default minimum_bond to be 1 in GenesisConfig (so the bond amount is at least 1)
- update condition in `fn bond` to use Self::minimum_bond
- add minimum_bond field in ExtBuilder mock and a setter for it
- update existing test to show the above works

---

## Some maintainability / refactor concerns:
The following refactors (from staking audit) could also be addressed in this PR:
- rename `BalanceOf<T>` to `StakingBalanceOf<T>` as the name is confusing (compared to `RewardBalanceOf<T>` which is really clear)
- remove migration stuff
- change all root dispatch calls with `#[weight = SimpleDispatchInfo::FixedOperational(0)]`

## Other concerns:
- The dispatch method, `fn unbond`, has a logic to not introduce any dust (if staked amount < minimum_balance then unbond the whole staked amount): https://github.com/cennznet/cennznet/blob/8bb5fa31c379418c71cdcbd0db82f300ab032f72/crml/staking/src/lib.rs#L999-L1002 this part is left alone because it makes sense to configure what qualifies as a dust inside generic asset
- Unit test(s) are not added because `bond_with_no_staked_value` test already covers it