### PR TITLE
Feature/bt 183 commission cap

### DIFF
--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1328,7 +1328,7 @@ impl<T: Trait> Module<T> {
 	/// nominators' balance, pro-rata based on their exposure, after having removed the validator's
 	/// pre-payout cut.
 	fn reward_validator(stash: &T::AccountId, reward: RewardBalanceOf<T>) -> RewardPositiveImbalanceOf<T> {
-		let off_the_table = Self::validators(stash).commission * reward;
+		let off_the_table = (Self::validators(stash).commission * reward).min(reward);
 		let reward = reward.saturating_sub(off_the_table);
 		let mut imbalance = <RewardPositiveImbalanceOf<T>>::zero();
 		let validator_cut = if reward.is_zero() {

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1061,6 +1061,11 @@ decl_module! {
 			let controller = ensure_signed(origin)?;
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 			let stash = &ledger.stash;
+
+			let prefs = ValidatorPrefs {
+				commission: prefs.commission.min(Perbill::one())
+			};
+
 			<Nominators<T>>::remove(stash);
 			<Validators<T>>::insert(stash, prefs);
 		}

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -2925,18 +2925,18 @@ fn zero_slash_keeps_nominators() {
 }
 
 #[test]
-fn show_that_max_commission_must_is_100_percent() {
+fn show_that_max_commission_is_100_percent() {
 	ExtBuilder::default().build().execute_with(|| {
-		let prefs = ValidatorPrefs{
-			commission: Perbill::from_fraction(1.5)
+		let prefs = ValidatorPrefs {
+			commission: Perbill::from_fraction(1.5),
 		};
 
 		assert_ok!(Staking::validate(Origin::signed(10), prefs.clone()));
 
 		let stored_prefs = <Staking as Store>::Validators::get(&11);
 
-		let total_rewards : u32 = 1_000;
-		let expected_rewards : u32 = 1_000;
+		let total_rewards: u32 = 1_000;
+		let expected_rewards: u32 = 1_000;
 
 		assert_eq!(stored_prefs.commission * total_rewards, expected_rewards);
 	})

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -2925,7 +2925,7 @@ fn zero_slash_keeps_nominators() {
 }
 
 #[test]
-fn show_that_commission_can_be_above_100_percent() {
+fn show_that_max_commission_must_is_100_percent() {
 	ExtBuilder::default().build().execute_with(|| {
 		let prefs = ValidatorPrefs{
 			commission: Perbill::from_fraction(1.5)
@@ -2935,6 +2935,9 @@ fn show_that_commission_can_be_above_100_percent() {
 
 		let stored_prefs = <Staking as Store>::Validators::get(&11);
 
-		assert_eq!(stored_prefs.commission * 1_000_000_000_u32, 1_500_000_000_u32);
+		let total_rewards : u32 = 1_000;
+		let expected_rewards : u32 = 1_000;
+
+		assert_eq!(stored_prefs.commission * total_rewards, expected_rewards);
 	})
 }

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -2923,3 +2923,18 @@ fn zero_slash_keeps_nominators() {
 		assert!(nominations.submitted_in >= last_slash);
 	});
 }
+
+#[test]
+fn show_that_commission_can_be_above_100_percent() {
+	ExtBuilder::default().build().execute_with(|| {
+		let prefs = ValidatorPrefs{
+			commission: Perbill::from_fraction(1.5)
+		};
+
+		assert_ok!(Staking::validate(Origin::signed(10), prefs.clone()));
+
+		let stored_prefs = <Staking as Store>::Validators::get(&11);
+
+		assert_eq!(stored_prefs.commission * 1_000_000_000_u32, 1_500_000_000_u32);
+	})
+}


### PR DESCRIPTION
This PR prevents validators from setting commissions higher than 100%.
Validator preferences are only set on the `validate` extrinsic, so this bound is added there.

## Changes:
- limit validator `commission` in `validate` extrinsic
- add test case to show larger commissions are capped at 100%.
- add protection to `reward_validator` to protect against paying out more than `reward` as commission

---

## Maintainability / refactor concerns:
- If validator prefs are updated to include other fields, the implementation in `validate` also needs to be updated
- If we add other ways to update `commission` (eg, a `commission` extrinsic), then we would have to add the limit there too - might want to refactor that case at that time.