### PR TITLE
Bring over changes from substrate #5186

### DIFF
--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -846,8 +846,6 @@ decl_error! {
 		AlreadyPaired,
 		/// Targets cannot be empty.
 		EmptyTargets,
-		/// Duplicate index.
-		DuplicateIndex,
 		/// Slash record index out of bounds.
 		InvalidSlashIndex,
 		/// Can not bond with value less than minimum balance.
@@ -856,6 +854,8 @@ decl_error! {
 		NoMoreChunks,
 		/// Can not rebond without unlocking chunks.
 		NoUnlockChunk,
+		/// Items are not sorted and unique.
+		NotSortedAndUnique,
 	}
 }
 
@@ -1239,21 +1239,15 @@ decl_module! {
 				.map(|_| ())
 				.or_else(ensure_root)?;
 
-			let mut slash_indices = slash_indices;
-			slash_indices.sort_unstable();
+			ensure!(!slash_indices.is_empty(), Error::<T>::EmptyTargets);
+			ensure!(Self::is_sorted_and_unique(&slash_indices), Error::<T>::NotSortedAndUnique);
+
 			let mut unapplied = <Self as Store>::UnappliedSlashes::get(&era);
+			let last_item = slash_indices[slash_indices.len() - 1];
+			ensure!((last_item as usize) < unapplied.len(), Error::<T>::InvalidSlashIndex);
 
 			for (removed, index) in slash_indices.into_iter().enumerate() {
-				let index = index as usize;
-
-				// if `index` is not duplicate, `removed` must be <= index.
-				ensure!(removed <= index, Error::<T>::DuplicateIndex);
-
-				// all prior removals were from before this index, since the
-				// list is sorted.
-				let index = index - removed;
-				ensure!(index < unapplied.len(), Error::<T>::InvalidSlashIndex);
-
+				let index = (index as usize) - removed;
 				unapplied.remove(index);
 			}
 
@@ -1629,6 +1623,11 @@ impl<T: Trait> Module<T> {
 			// TODO: #2494
 			(Self::slot_stake(), None)
 		}
+	}
+
+	/// Check that list is sorted and has no duplicates.
+	fn is_sorted_and_unique(list: &Vec<u32>) -> bool {
+		list.windows(2).all(|w| w[0] < w[1])
 	}
 
 	/// Remove all associated data of a stash account from the staking system.

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -2771,7 +2771,13 @@ fn remove_deferred() {
 			1,
 		);
 
-		Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![0]).unwrap();
+		// fails if empty
+		assert_noop!(
+			Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![]),
+			Error::<Test>::EmptyTargets
+		);
+
+		assert_ok!(Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![0]));
 
 		assert_eq!(Balances::free_balance(11), 1000);
 		assert_eq!(Balances::free_balance(101), 2000);
@@ -2838,12 +2844,46 @@ fn remove_multi_deferred() {
 			&[Perbill::from_percent(25)],
 		);
 
-		assert_eq!(<Staking as Store>::UnappliedSlashes::get(&1).len(), 3);
-		Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![0, 2]).unwrap();
+		on_offence_now(
+			&[OffenceDetails {
+				offender: (42, exposure.clone()),
+				reporters: vec![],
+			}],
+			&[Perbill::from_percent(25)],
+		);
+
+		on_offence_now(
+			&[OffenceDetails {
+				offender: (69, exposure.clone()),
+				reporters: vec![],
+			}],
+			&[Perbill::from_percent(25)],
+		);
+
+		assert_eq!(<Staking as Store>::UnappliedSlashes::get(&1).len(), 5);
+
+		// fails if list is not sorted
+		assert_noop!(
+			Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![2, 0, 4]),
+			Error::<Test>::NotSortedAndUnique
+		);
+		// fails if list is not unique
+		assert_noop!(
+			Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![0, 2, 2]),
+			Error::<Test>::NotSortedAndUnique
+		);
+		// fails if bad index
+		assert_noop!(
+			Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![1, 2, 3, 4, 5]),
+			Error::<Test>::InvalidSlashIndex
+		);
+
+		assert_ok!(Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![0, 2, 4]));
 
 		let slashes = <Staking as Store>::UnappliedSlashes::get(&1);
-		assert_eq!(slashes.len(), 1);
+		assert_eq!(slashes.len(), 2);
 		assert_eq!(slashes[0].validator, 21);
+		assert_eq!(slashes[1].validator, 42);
 	})
 }
 


### PR DESCRIPTION
Bring over changes from substrate paritytech/substrate/#5186
The general idea was to make `cancel_deferred_slash` follow the "verify first, write last" pattern.

## Changes from paritytech/substrate/#5186:
- new error `NotSortedAndUnique`
- `cancel_deferred_slash` ensures before changing any storage
- `is_sorted_and_unique` helper function added
- tests added

## Deviations between this PR and paritytech/substrate/#5186:
- removed `DuplicateIndex` error - no longer required
- did not add the refactoring in `rebond` function - an unrelated nit-pick
- made `is_sorted_and_unique` a free function (recommended by rphmeier) 

---

## Maintainability / refactor concerns:
- none