### PR TITLE
Basic pre-audit refactors for Cennzx-spot

### DIFF
--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -257,7 +257,7 @@ decl_module! {
 				<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &from_account, &exchange_address, trade_asset_amount)?;
 
 				Self::set_liquidity(&exchange_key, &from_account,
-									Self::get_liquidity(&exchange_key, &from_account) + liquidity_minted);
+					<LiquidityBalance<T>>::get(&exchange_key, &from_account) + liquidity_minted);
 				Self::mint_total_supply(&exchange_key, liquidity_minted);
 				Self::deposit_event(RawEvent::AddLiquidity(from_account, core_amount, asset_id, trade_asset_amount));
 			}
@@ -288,7 +288,7 @@ decl_module! {
 
 			let core_asset_id = Self::core_asset_id();
 			let exchange_key = (core_asset_id, asset_id);
-			let account_liquidity = Self::get_liquidity(&exchange_key, &from_account);
+			let account_liquidity = <LiquidityBalance<T>>::get(&exchange_key, &from_account);
 			ensure!(
 				account_liquidity >= liquidity_withdrawn,
 				Error::<T>::LiquidityTooLow
@@ -383,10 +383,6 @@ impl<T: Trait> Module<T> {
 
 	fn set_liquidity(exchange_key: &ExchangeKey<T>, who: &T::AccountId, balance: T::Balance) {
 		<LiquidityBalance<T>>::insert(exchange_key, who, balance);
-	}
-
-	pub fn get_liquidity(exchange_key: &ExchangeKey<T>, who: &T::AccountId) -> T::Balance {
-		<LiquidityBalance<T>>::get(exchange_key, who)
 	}
 
 	/// Trade core asset for asset (`asset_id`) at the given `fee_rate`.

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -743,9 +743,10 @@ impl<T: Trait> Module<T> {
 		output_reserve: T::Balance,
 		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		if input_reserve.is_zero() || output_reserve.is_zero() {
-			Err(Error::<T>::EmptyExchangePool)?;
-		}
+		ensure!(
+			!input_reserve.is_zero() && !output_reserve.is_zero(),
+			Error::<T>::EmptyExchangePool
+		);
 		ensure!(output_reserve > output_amount, Error::<T>::InsufficientAssetReserve);
 
 		let output_amount_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(output_amount).into());
@@ -758,9 +759,8 @@ impl<T: Trait> Module<T> {
 			.ok_or::<Error<T>>(Error::<T>::DivideByZero)?;
 
 		let price_lp_result: Result<LowPrecisionUnsigned, &'static str> = LowPrecisionUnsigned::try_from(price_hp);
-		if price_lp_result.is_err() {
-			Err(Error::<T>::Overflow)?;
-		}
+		ensure!(price_lp_result.is_ok(), Error::<T>::Overflow);
+
 		let price_lp = price_lp_result.unwrap();
 		let price_plus_one = price_lp
 			.checked_add(One::one())
@@ -780,9 +780,10 @@ impl<T: Trait> Module<T> {
 		output_reserve: T::Balance,
 		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		if input_reserve.is_zero() || output_reserve.is_zero() {
-			Err(Error::<T>::EmptyExchangePool)?;
-		}
+		ensure!(
+			!input_reserve.is_zero() && !output_reserve.is_zero(),
+			Error::<T>::EmptyExchangePool
+		);
 
 		let div_rate: FeeRate<PerMillion> = fee_rate
 			.checked_add(FeeRate::<PerMillion>::one())
@@ -802,10 +803,9 @@ impl<T: Trait> Module<T> {
 			.ok_or::<Error<T>>(Error::<T>::DivideByZero)?;
 
 		let price_lp_result: Result<LowPrecisionUnsigned, &'static str> = LowPrecisionUnsigned::try_from(price_hp);
-		if price_lp_result.is_err() {
-			Err(Error::<T>::Overflow)?;
-		}
+		ensure!(price_lp_result.is_ok(), Error::<T>::Overflow);
 		let price_lp = price_lp_result.unwrap();
+
 		let price = T::UnsignedIntToBalance::from(price_lp).into();
 		ensure!(output_reserve > price, Error::<T>::InsufficientAssetReserve);
 		Ok(price)

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -227,7 +227,7 @@ decl_module! {
 				Error::<T>::TradeAssetBalanceToAddLiquidityTooLow
 			);
 			let exchange_key = (core_asset_id, asset_id);
-			let total_liquidity = Self::get_total_supply(&exchange_key);
+			let total_liquidity = <TotalSupply<T>>::get(&exchange_key);
 			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, asset_id);
 
 			if total_liquidity.is_zero() {
@@ -294,7 +294,7 @@ decl_module! {
 				Error::<T>::LiquidityTooLow
 			);
 
-			let total_liquidity = Self::get_total_supply(&exchange_key);
+			let total_liquidity = <TotalSupply<T>>::get(&exchange_key);
 			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, asset_id);
 			ensure!(
 				total_liquidity > Zero::zero(),
@@ -367,11 +367,6 @@ decl_storage! {
 
 // The main implementation block for the module.
 impl<T: Trait> Module<T> {
-	// Storage R/W
-	fn get_total_supply(exchange_key: &ExchangeKey<T>) -> T::Balance {
-		<TotalSupply<T>>::get(exchange_key)
-	}
-
 	/// mint total supply for an exchange pool
 	fn mint_total_supply(exchange_key: &ExchangeKey<T>, increase: T::Balance) {
 		<TotalSupply<T>>::mutate(exchange_key, |balance| *balance += increase); // will not overflow because it's limited by core assets's total supply

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -254,7 +254,7 @@ fn investor_can_add_liquidity() {
 		));
 
 		assert_exchange_balance_eq!(CoreAssetCurrency => 20, TradeAssetCurrencyA => 31);
-		assert_eq!(CennzXSpot::get_liquidity(&DEFAULT_EXCHANGE_KEY, &investor), 20);
+		assert_eq!(CennzXSpot::liquidity_balance(&DEFAULT_EXCHANGE_KEY, &investor), 20);
 	});
 }
 

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -577,7 +577,7 @@ fn generic_asset_transfer_works_with_fee_exchange() {
 				liquidity_core_amount,
 			);
 			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
-			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &alice()), liquidity_core_amount);
+			assert_eq!(CennzxSpot::liquidity_balance(&ex_key, &alice()), liquidity_core_amount);
 
 			// Exchange CENNZ (sell) for CPAY (buy) to pay for transaction fee
 			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
@@ -838,7 +838,10 @@ fn contract_call_fails_with_insufficient_gas_with_fee_exchange() {
 				liquidity_core_amount,
 			);
 			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
-			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &charlie()), liquidity_core_amount);
+			assert_eq!(
+				CennzxSpot::liquidity_balance(&ex_key, &charlie()),
+				liquidity_core_amount
+			);
 
 			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
 				asset_id: CENNZ_ASSET_ID,
@@ -925,7 +928,10 @@ fn contract_call_works_with_fee_exchange() {
 				liquidity_core_amount,
 			);
 			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
-			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &charlie()), liquidity_core_amount);
+			assert_eq!(
+				CennzxSpot::liquidity_balance(&ex_key, &charlie()),
+				liquidity_core_amount
+			);
 
 			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
 				asset_id: CENNZ_ASSET_ID,
@@ -979,7 +985,10 @@ fn contract_call_fails_when_fee_exchange_is_not_enough_for_gas() {
 				liquidity_core_amount,
 			);
 			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
-			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &charlie()), liquidity_core_amount);
+			assert_eq!(
+				CennzxSpot::liquidity_balance(&ex_key, &charlie()),
+				liquidity_core_amount
+			);
 
 			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
 				asset_id: CENNZ_ASSET_ID,
@@ -1023,7 +1032,10 @@ fn contract_call_fails_when_exchange_liquidity_is_low() {
 				liquidity_core_amount,
 			);
 			let ex_key = (CENTRAPAY_ASSET_ID, CENNZ_ASSET_ID);
-			assert_eq!(CennzxSpot::get_liquidity(&ex_key, &charlie()), liquidity_core_amount);
+			assert_eq!(
+				CennzxSpot::liquidity_balance(&ex_key, &charlie()),
+				liquidity_core_amount
+			);
 
 			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
 				asset_id: CENNZ_ASSET_ID,


### PR DESCRIPTION
Based on refactor opportunities identified in BT-148

## Addressed:
- use `ensure()` for all error returns to keep error cases clean and consistent
- remove unnecessary `get_liquidity` getter
- remove unnecessary `get_total_supply` getter

## Made unnecessary:
- Refactor `.is_err` to `.map_err` - made redundant by using `ensure` and `.is_ok`.

---

## Maintainability / refactor concerns:
- Put "`get_input/output_price` should not include the fee rate" into a seperate PR - it is a bigger change.