### PR TITLE
Remove unnecessary passing around the fee rate in cennzx-spot

### DIFF
--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -79,7 +79,6 @@ impl<T: Trait> BuyFeeAsset for Module<T> {
 			&fee_asset_id,
 			amount,
 			exchange_op.max_payment(),
-			Self::fee_rate(),
 		)
 	}
 }

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -155,7 +155,6 @@ decl_module! {
 				&asset_bought,
 				buy_amount,
 				max_paying_amount,
-				Self::fee_rate()
 			)?;
 			Ok(())
 		}
@@ -183,8 +182,7 @@ decl_module! {
 				&asset_sold,
 				&asset_bought,
 				sell_amount,
-				min_receive,
-				Self::fee_rate()
+				min_receive
 			)?;
 			Ok(())
 		}
@@ -395,16 +393,14 @@ impl<T: Trait> Module<T> {
 	/// `asset_id` - The asset ID to trade
 	/// `sell_amount` - Amount of core asset to sell (input)
 	/// `min_receive` -  The minimum trade asset value to receive from sale (output)
-	/// `fee_rate` - The % of exchange fees for the trade
 	fn make_core_to_asset_input(
 		seller: &T::AccountId,
 		recipient: &T::AccountId,
 		asset_id: &T::AssetId,
 		sell_amount: T::Balance,
 		min_receive: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		let sale_value = Self::get_core_to_asset_input_price(asset_id, sell_amount, fee_rate)?;
+		let sale_value = Self::get_core_to_asset_input_price(asset_id, sell_amount)?;
 
 		ensure!(sale_value > Zero::zero(), Error::<T>::AssetSaleValueNotAboveZero);
 		ensure!(sale_value >= min_receive, Error::<T>::SaleValueBelowRequiredMinimum);
@@ -436,20 +432,18 @@ impl<T: Trait> Module<T> {
 		Ok(sale_value)
 	}
 
-	/// Trade asset (`asset_id`) to core asset at the given `fee_rate`
+	/// Trade asset (`asset_id`) to core asset
 	/// `asset_id` - The asset ID to trade
 	/// `buy_amount` - Amount of core asset to purchase (output)
 	/// `max_paying_amount` -  Maximum asset to pay
-	/// `fee_rate` - The % of exchange fees for the trade
 	fn make_asset_to_core_output(
 		buyer: &T::AccountId,
 		recipient: &T::AccountId,
 		asset_id: &T::AssetId,
 		buy_amount: T::Balance,
 		max_paying_amount: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		let sold_amount = Self::get_asset_to_core_output_price(asset_id, buy_amount, fee_rate)?;
+		let sold_amount = Self::get_asset_to_core_output_price(asset_id, buy_amount)?;
 		ensure!(sold_amount > Zero::zero(), Error::<T>::AssetToCorePriceNotAboveZero);
 		ensure!(
 			max_paying_amount >= sold_amount,
@@ -478,22 +472,20 @@ impl<T: Trait> Module<T> {
 		Ok(sold_amount)
 	}
 
-	/// Trade core asset to asset (`asset_id`) at the given `fee_rate`
+	/// Trade core asset to asset (`asset_id`)
 	/// `buyer` - Account buying core asset for trade asset
 	/// `recipient` - Account receiving trade asset
 	/// `asset_id` - The asset ID to trade
 	/// `buy_amount` - Amount of core asset to purchase (output)
 	/// `max_paying_amount` -  Maximum asset to pay
-	/// `fee_rate` - The % of exchange fees for the trade
 	fn make_core_to_asset_output(
 		buyer: &T::AccountId,
 		recipient: &T::AccountId,
 		asset_id: &T::AssetId,
 		buy_amount: T::Balance,
 		max_paying_amount: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		let sold_amount = Self::get_core_to_asset_output_price(asset_id, buy_amount, fee_rate)?;
+		let sold_amount = Self::get_core_to_asset_output_price(asset_id, buy_amount)?;
 		ensure!(sold_amount > Zero::zero(), Error::<T>::CoreToAssetPriceNotAboveZero);
 		ensure!(
 			max_paying_amount >= sold_amount,
@@ -534,7 +526,6 @@ impl<T: Trait> Module<T> {
 	/// `asset_b` - asset ID to buy
 	/// `buy_amount_b` - The amount of asset 'b' to purchase (output)
 	/// `max_a_for_sale` - Maximum trade asset 'a' to sell
-	/// `fee_rate` - The % of exchange fees for the trade
 	fn make_asset_to_asset_output(
 		buyer: &T::AccountId,
 		recipient: &T::AccountId,
@@ -542,13 +533,12 @@ impl<T: Trait> Module<T> {
 		asset_b: &T::AssetId,
 		buy_amount_for_b: T::Balance,
 		max_a_for_sale: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		// Calculate amount of core token needed to buy trade asset 2 of #buy_amount amount
-		let core_for_b = Self::get_core_to_asset_output_price(asset_b, buy_amount_for_b, fee_rate)?;
+		let core_for_b = Self::get_core_to_asset_output_price(asset_b, buy_amount_for_b)?;
 		let core_asset_id = Self::core_asset_id();
 		let exchange_address_a = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_a);
-		let asset_sold_a = Self::get_asset_to_core_output_price(asset_a, core_for_b, fee_rate)?;
+		let asset_sold_a = Self::get_asset_to_core_output_price(asset_a, core_for_b)?;
 		// sold asset is always > 0
 		ensure!(
 			max_a_for_sale >= asset_sold_a,
@@ -559,7 +549,7 @@ impl<T: Trait> Module<T> {
 			Error::<T>::InsufficientBuyerTradeAssetBalance
 		);
 
-		let core_asset_a = Self::get_core_to_asset_output_price(asset_b, buy_amount_for_b, fee_rate)?;
+		let core_asset_a = Self::get_core_to_asset_output_price(asset_b, buy_amount_for_b)?;
 		ensure!(core_asset_a > Zero::zero(), Error::<T>::CoreToAssetPriceNotAboveZero);
 		ensure!(
 			<pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address_a) >= core_asset_a,
@@ -604,14 +594,13 @@ impl<T: Trait> Module<T> {
 		asset_id: &T::AssetId,
 		sell_amount: T::Balance,
 		min_receive: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(
 			<pallet_generic_asset::Module<T>>::free_balance(asset_id, buyer) >= sell_amount,
 			Error::<T>::InsufficientSellerTradeAssetBalance
 		);
 
-		let sale_value = Self::get_asset_to_core_input_price(asset_id, sell_amount, fee_rate)?;
+		let sale_value = Self::get_asset_to_core_input_price(asset_id, sell_amount)?;
 
 		ensure!(sale_value >= min_receive, Error::<T>::SaleValueBelowRequiredMinimum);
 
@@ -652,7 +641,6 @@ impl<T: Trait> Module<T> {
 		asset_b: &T::AssetId,
 		sell_amount_for_a: T::Balance,
 		min_b_from_sale: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(
 			<pallet_generic_asset::Module<T>>::free_balance(&asset_a, seller) >= sell_amount_for_a,
@@ -661,8 +649,8 @@ impl<T: Trait> Module<T> {
 
 		let core_asset_id = Self::core_asset_id();
 		let exchange_address_a = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_a);
-		let sale_value_a = Self::get_asset_to_core_input_price(asset_a, sell_amount_for_a, fee_rate)?;
-		let asset_b_received = Self::get_core_to_asset_input_price(asset_b, sale_value_a, fee_rate)?;
+		let sale_value_a = Self::get_asset_to_core_input_price(asset_a, sell_amount_for_a)?;
+		let asset_b_received = Self::get_core_to_asset_input_price(asset_b, sale_value_a)?;
 
 		ensure!(asset_b_received > Zero::zero(), Error::<T>::AssetSaleValueNotAboveZero);
 		ensure!(
@@ -712,7 +700,6 @@ impl<T: Trait> Module<T> {
 	pub fn get_core_to_asset_output_price(
 		asset_id: &T::AssetId,
 		buy_amount: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(buy_amount > Zero::zero(), Error::<T>::BuyAmountNotPositive);
 
@@ -722,7 +709,7 @@ impl<T: Trait> Module<T> {
 		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 
-		Self::get_output_price(buy_amount, core_reserve, asset_reserve, fee_rate)
+		Self::get_output_price(buy_amount, core_reserve, asset_reserve)
 	}
 
 	/// `asset_id` - Trade asset
@@ -731,7 +718,6 @@ impl<T: Trait> Module<T> {
 	pub fn get_asset_to_core_input_price(
 		asset_id: &T::AssetId,
 		sell_amount: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(
 			sell_amount > Zero::zero(),
@@ -743,14 +729,13 @@ impl<T: Trait> Module<T> {
 
 		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-		Self::get_input_price(sell_amount, asset_reserve, core_reserve, fee_rate)
+		Self::get_input_price(sell_amount, asset_reserve, core_reserve)
 	}
 
 	fn get_output_price(
 		output_amount: T::Balance,
 		input_reserve: T::Balance,
 		output_reserve: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		if input_reserve.is_zero() || output_reserve.is_zero() {
 			Err(Error::<T>::EmptyExchangePool)?;
@@ -774,7 +759,7 @@ impl<T: Trait> Module<T> {
 		let price_plus_one = price_lp
 			.checked_add(One::one())
 			.ok_or::<Error<T>>(Error::<T>::Overflow)?;
-		let fee_rate_plus_one = fee_rate
+		let fee_rate_plus_one = Self::fee_rate()
 			.checked_add(FeeRate::<PerMillion>::one())
 			.ok_or::<Error<T>>(Error::<T>::Overflow)?;
 		let output = fee_rate_plus_one
@@ -787,13 +772,12 @@ impl<T: Trait> Module<T> {
 		input_amount: T::Balance,
 		input_reserve: T::Balance,
 		output_reserve: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		if input_reserve.is_zero() || output_reserve.is_zero() {
 			Err(Error::<T>::EmptyExchangePool)?;
 		}
 
-		let div_rate: FeeRate<PerMillion> = fee_rate
+		let div_rate: FeeRate<PerMillion> = Self::fee_rate()
 			.checked_add(FeeRate::<PerMillion>::one())
 			.ok_or::<Error<T>>(Error::<T>::Overflow)?;
 
@@ -822,12 +806,10 @@ impl<T: Trait> Module<T> {
 
 	/// `asset_id` - Trade asset
 	/// `buy_amount` - Amount of output core
-	/// `fee_rate` - The % of exchange fees for the trade
 	/// Returns the amount of trade assets needed to buy `buy_amount` core assets.
 	pub fn get_asset_to_core_output_price(
 		asset_id: &T::AssetId,
 		buy_amount: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(buy_amount > Zero::zero(), Error::<T>::BuyAmountNotPositive);
 
@@ -837,18 +819,16 @@ impl<T: Trait> Module<T> {
 		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
 
-		Self::get_output_price(buy_amount, trade_asset_reserve, core_asset_reserve, fee_rate)
+		Self::get_output_price(buy_amount, trade_asset_reserve, core_asset_reserve)
 	}
 
 	/// Returns the amount of trade asset to pay for `sell_amount` of core sold.
 	///
 	/// `asset_id` - Trade asset
 	/// `sell_amount` - Amount of input core to sell
-	/// `fee_rate` - The % of exchange fees for the trade
 	pub fn get_core_to_asset_input_price(
 		asset_id: &T::AssetId,
 		sell_amount: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(
 			sell_amount > Zero::zero(),
@@ -860,7 +840,7 @@ impl<T: Trait> Module<T> {
 		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 
-		let output_amount = Self::get_input_price(sell_amount, core_asset_reserve, trade_asset_reserve, fee_rate)?;
+		let output_amount = Self::get_input_price(sell_amount, core_asset_reserve, trade_asset_reserve)?;
 
 		Ok(output_amount)
 	}
@@ -873,7 +853,6 @@ impl<T: Trait> Module<T> {
 	/// `asset_bought` - asset ID 2 to buy
 	/// `buy_amount` - The amount of asset '2' to purchase
 	/// `max_paying_amount` - Maximum trade asset '1' to pay
-	/// `fee_rate` - The % of exchange fees for the trade
 	pub fn make_asset_swap_output(
 		buyer: &T::AccountId,
 		recipient: &T::AccountId,
@@ -881,14 +860,13 @@ impl<T: Trait> Module<T> {
 		asset_bought: &T::AssetId,
 		buy_amount: T::Balance,
 		max_paying_amount: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		let core_asset = Self::core_asset_id();
 		ensure!(asset_sold != asset_bought, Error::<T>::AssetCannotSwapForItself);
 		let sold_amount = if *asset_sold == core_asset {
-			Self::make_core_to_asset_output(buyer, recipient, asset_bought, buy_amount, max_paying_amount, fee_rate)?
+			Self::make_core_to_asset_output(buyer, recipient, asset_bought, buy_amount, max_paying_amount)?
 		} else if *asset_bought == core_asset {
-			Self::make_asset_to_core_output(buyer, recipient, asset_sold, buy_amount, max_paying_amount, fee_rate)?
+			Self::make_asset_to_core_output(buyer, recipient, asset_sold, buy_amount, max_paying_amount)?
 		} else {
 			Self::make_asset_to_asset_output(
 				buyer,
@@ -897,7 +875,6 @@ impl<T: Trait> Module<T> {
 				asset_bought,
 				buy_amount,
 				max_paying_amount,
-				fee_rate,
 			)?
 		};
 
@@ -912,7 +889,6 @@ impl<T: Trait> Module<T> {
 	/// `asset_bought` - asset ID 2 to buy
 	/// `sell_amount` - The amount of asset '1' to sell
 	/// `min_receive` - Minimum trade asset '2' to receive from sale
-	/// `fee_rate` - The % of exchange fees for the trade
 	pub fn make_asset_swap_input(
 		seller: &T::AccountId,
 		recipient: &T::AccountId,
@@ -920,25 +896,16 @@ impl<T: Trait> Module<T> {
 		asset_bought: &T::AssetId,
 		sell_amount: T::Balance,
 		min_receive: T::Balance,
-		fee_rate: FeeRate<PerMillion>,
 	) -> DispatchResult {
 		let core_asset = Self::core_asset_id();
 		ensure!(asset_sold != asset_bought, "Asset to swap should not be equal");
 		if *asset_sold == core_asset {
-			let _ =
-				Self::make_core_to_asset_input(seller, recipient, asset_bought, sell_amount, min_receive, fee_rate)?;
+			let _ = Self::make_core_to_asset_input(seller, recipient, asset_bought, sell_amount, min_receive)?;
 		} else if *asset_bought == core_asset {
-			let _ = Self::make_asset_to_core_input(seller, recipient, asset_sold, sell_amount, min_receive, fee_rate)?;
+			let _ = Self::make_asset_to_core_input(seller, recipient, asset_sold, sell_amount, min_receive)?;
 		} else {
-			let _ = Self::make_asset_to_asset_input(
-				seller,
-				recipient,
-				asset_sold,
-				asset_bought,
-				sell_amount,
-				min_receive,
-				fee_rate,
-			)?;
+			let _ =
+				Self::make_asset_to_asset_input(seller, recipient, asset_sold, asset_bought, sell_amount, min_receive)?;
 		}
 
 		Ok(())
@@ -961,7 +928,7 @@ impl<T: Trait> Module<T> {
 		let core_asset_amount = if asset_to_buy == Self::core_asset_id() {
 			amount_to_buy
 		} else {
-			Self::get_core_to_asset_output_price(&asset_to_buy, amount_to_buy, Self::fee_rate())?
+			Self::get_core_to_asset_output_price(&asset_to_buy, amount_to_buy)?
 		};
 
 		// Find the price of `core_asset_amount` in terms of `asset_to_pay`
@@ -969,7 +936,7 @@ impl<T: Trait> Module<T> {
 		let pay_asset_amount = if asset_to_pay == Self::core_asset_id() {
 			core_asset_amount
 		} else {
-			Self::get_asset_to_core_output_price(&asset_to_pay, core_asset_amount, Self::fee_rate())?
+			Self::get_asset_to_core_output_price(&asset_to_pay, core_asset_amount)?
 		};
 
 		Ok(pay_asset_amount)
@@ -992,7 +959,7 @@ impl<T: Trait> Module<T> {
 		let core_asset_amount = if asset_to_sell == Self::core_asset_id() {
 			amount_to_sell
 		} else {
-			Self::get_asset_to_core_input_price(&asset_to_sell, amount_to_sell, Self::fee_rate())?
+			Self::get_asset_to_core_input_price(&asset_to_sell, amount_to_sell)?
 		};
 
 		// Skip payout asset price if asset to be paid out is core
@@ -1000,7 +967,7 @@ impl<T: Trait> Module<T> {
 		let payout_asset_value = if asset_to_payout == Self::core_asset_id() {
 			core_asset_amount
 		} else {
-			Self::get_core_to_asset_input_price(&asset_to_payout, core_asset_amount, Self::fee_rate())?
+			Self::get_core_to_asset_input_price(&asset_to_payout, core_asset_amount)?
 		};
 
 		Ok(payout_asset_value)

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -20,7 +20,7 @@ use crate::{
 	impls::{ExchangeAddressFor, ExchangeAddressGenerator},
 	mock::{self, CORE_ASSET_ID, TRADE_ASSET_A_ID, TRADE_ASSET_B_ID},
 	types::{FeeRate, LowPrecisionUnsigned, PerMilli, PerMillion},
-	Call, CoreAssetId, DefaultFeeRate, Error, GenesisConfig, Module, Trait,
+	Call, CoreAssetId, Error, GenesisConfig, Module, Trait,
 };
 use core::convert::TryFrom;
 use frame_support::{additional_traits::DummyDispatchVerifier, impl_outer_origin, traits::Currency, StorageValue};
@@ -264,12 +264,12 @@ fn get_output_price_zero_cases() {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::get_output_price(100, 0, 10, DefaultFeeRate::get()),
+			CennzXSpot::get_output_price(100, 0, 10),
 			Error::<Test>::EmptyExchangePool
 		);
 
 		assert_err!(
-			CennzXSpot::get_output_price(100, 10, 0, DefaultFeeRate::get()),
+			CennzXSpot::get_output_price(100, 10, 0),
 			Error::<Test>::EmptyExchangePool
 		);
 	});
@@ -280,18 +280,10 @@ fn get_output_price_zero_cases() {
 #[test]
 fn get_output_price_for_valid_data() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(
-			CennzXSpot::get_output_price(123, 1000, 1000, DefaultFeeRate::get()),
-			141
-		);
+		assert_ok!(CennzXSpot::get_output_price(123, 1000, 1000), 141);
 
 		assert_ok!(
-			CennzXSpot::get_output_price(
-				100_000_000_000_000,
-				120_627_710_511_649_660,
-				20_627_710_511_649_660,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_output_price(100_000_000_000_000, 120_627_710_511_649_660, 20_627_710_511_649_660,),
 			589396433540516
 		);
 	});
@@ -307,7 +299,6 @@ fn get_output_price_for_max_reserve_balance() {
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value(),
-				DefaultFeeRate::get()
 			),
 			170651607010850639426882365627031758044
 		);
@@ -325,7 +316,6 @@ fn get_output_price_should_fail_with_max_reserve_and_max_amount() {
 				LowPrecisionUnsigned::max_value() - 100,
 				LowPrecisionUnsigned::max_value(),
 				LowPrecisionUnsigned::max_value(),
-				DefaultFeeRate::get()
 			),
 			Error::<Test>::Overflow
 		);
@@ -340,12 +330,12 @@ fn get_output_price_max_withdrawal() {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::get_output_price(1000, 1000, 1000, DefaultFeeRate::get()),
+			CennzXSpot::get_output_price(1000, 1000, 1000),
 			Error::<Test>::InsufficientAssetReserve
 		);
 
 		assert_err!(
-			CennzXSpot::get_output_price(1_000_000, 1000, 1000, DefaultFeeRate::get()),
+			CennzXSpot::get_output_price(1_000_000, 1000, 1000),
 			Error::<Test>::InsufficientAssetReserve
 		);
 	});
@@ -357,20 +347,12 @@ fn asset_swap_output_price() {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_ok!(
-			CennzXSpot::get_asset_to_core_output_price(
-				&resolve_asset_id!(TradeAssetCurrencyA),
-				123,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_asset_to_core_output_price(&resolve_asset_id!(TradeAssetCurrencyA), 123),
 			141
 		);
 
 		assert_ok!(
-			CennzXSpot::get_core_to_asset_output_price(
-				&resolve_asset_id!(TradeAssetCurrencyA),
-				123,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_core_to_asset_output_price(&resolve_asset_id!(TradeAssetCurrencyA), 123),
 			141
 		);
 	});
@@ -380,19 +362,11 @@ fn asset_swap_output_price() {
 fn asset_swap_output_zero_buy_amount() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_err!(
-			CennzXSpot::get_core_to_asset_output_price(
-				&resolve_asset_id!(TradeAssetCurrencyA),
-				0,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_core_to_asset_output_price(&resolve_asset_id!(TradeAssetCurrencyA), 0),
 			Error::<Test>::BuyAmountNotPositive
 		);
 		assert_err!(
-			CennzXSpot::get_asset_to_core_output_price(
-				&resolve_asset_id!(TradeAssetCurrencyA),
-				0,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_asset_to_core_output_price(&resolve_asset_id!(TradeAssetCurrencyA), 0),
 			Error::<Test>::BuyAmountNotPositive
 		);
 	});
@@ -407,7 +381,6 @@ fn asset_swap_output_insufficient_reserve() {
 			CennzXSpot::get_asset_to_core_output_price(
 				&resolve_asset_id!(TradeAssetCurrencyA),
 				1001, // amount_bought
-				DefaultFeeRate::get()
 			),
 			Error::<Test>::InsufficientAssetReserve
 		);
@@ -416,7 +389,6 @@ fn asset_swap_output_insufficient_reserve() {
 			CennzXSpot::get_core_to_asset_output_price(
 				&resolve_asset_id!(TradeAssetCurrencyA),
 				1001, // amount_bought
-				DefaultFeeRate::get()
 			),
 			Error::<Test>::InsufficientAssetReserve
 		);
@@ -449,15 +421,16 @@ fn make_asset_to_core_swap_output() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyA => 1000);
 		let trader = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
+		let new_fee_rate = FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap();
+		assert_ok!(CennzXSpot::set_fee_rate(Origin::ROOT, new_fee_rate), ());
 
 		assert_ok!(
 			CennzXSpot::make_asset_to_core_output(
 				&trader, // buyer
 				&trader, // recipient
 				&resolve_asset_id!(TradeAssetCurrencyA),
-				5,                                                                          // buy_amount: T::Balance,
-				1400,                                                                       // max_sale: T::Balance,
-				FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(), // fee_rate
+				5,    // buy_amount: T::Balance,
+				1400, // max_sale: T::Balance,
 			),
 			1004
 		);
@@ -595,15 +568,16 @@ fn make_core_to_asset_output() {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 10);
 		let buyer = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 		let recipient = with_account!("bob", CoreAssetCurrency => 0, TradeAssetCurrencyA => 0);
+		let new_fee_rate = FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap();
+		assert_ok!(CennzXSpot::set_fee_rate(Origin::ROOT, new_fee_rate), ());
 
 		assert_ok!(
 			CennzXSpot::make_core_to_asset_output(
 				&buyer,
 				&recipient,
 				&resolve_asset_id!(TradeAssetCurrencyA),
-				5,                                                                          // buy_amount: T::Balance,
-				1400,                                                                       // max_sale: T::Balance,
-				FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(), // fee_rate
+				5,    // buy_amount: T::Balance,
+				1400, // max_sale: T::Balance,
 			),
 			1004
 		);
@@ -782,21 +756,16 @@ fn core_to_asset_transfer_output() {
 #[test]
 fn get_input_price_for_valid_data() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CennzXSpot::get_input_price(123, 1000, 1000, DefaultFeeRate::get()), 108);
+		assert_ok!(CennzXSpot::get_input_price(123, 1000, 1000), 108);
 
 		// No f32/f64 types, so we use large values to test precision
 		assert_ok!(
-			CennzXSpot::get_input_price(123_000_000, 1_000_000_000, 1_000_000_000, DefaultFeeRate::get()),
+			CennzXSpot::get_input_price(123_000_000, 1_000_000_000, 1_000_000_000),
 			109236233
 		);
 
 		assert_ok!(
-			CennzXSpot::get_input_price(
-				100_000_000_000_000,
-				120_627_710_511_649_660,
-				4_999_727_416_279_531_363,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_input_price(100_000_000_000_000, 120_627_710_511_649_660, 4_999_727_416_279_531_363),
 			4128948876492407
 		);
 
@@ -804,8 +773,7 @@ fn get_input_price_for_valid_data() {
 			CennzXSpot::get_input_price(
 				100_000_000_000_000,
 				120_627_710_511_649_660,
-				LowPrecisionUnsigned::max_value(),
-				DefaultFeeRate::get()
+				LowPrecisionUnsigned::max_value()
 			),
 			281017019450612581324176880746747822
 		);
@@ -822,8 +790,7 @@ fn get_input_price_for_max_reserve_balance() {
 			CennzXSpot::get_input_price(
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value() / 2,
-				LowPrecisionUnsigned::max_value(),
-				DefaultFeeRate::get()
+				LowPrecisionUnsigned::max_value()
 			),
 			169886353929574869427545984738775941814
 		);
@@ -836,20 +803,12 @@ fn asset_swap_input_price() {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_ok!(
-			CennzXSpot::get_asset_to_core_input_price(
-				&resolve_asset_id!(TradeAssetCurrencyA),
-				123,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_asset_to_core_input_price(&resolve_asset_id!(TradeAssetCurrencyA), 123),
 			108
 		);
 
 		assert_ok!(
-			CennzXSpot::get_core_to_asset_input_price(
-				&resolve_asset_id!(TradeAssetCurrencyA),
-				123,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_core_to_asset_input_price(&resolve_asset_id!(TradeAssetCurrencyA), 123),
 			108
 		);
 	});
@@ -859,19 +818,11 @@ fn asset_swap_input_price() {
 fn asset_swap_input_zero_sell_amount() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_err!(
-			CennzXSpot::get_asset_to_core_input_price(
-				&resolve_asset_id!(TradeAssetCurrencyA),
-				0,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_asset_to_core_input_price(&resolve_asset_id!(TradeAssetCurrencyA), 0),
 			Error::<Test>::AssetToCoreSellAmountNotAboveZero
 		);
 		assert_err!(
-			CennzXSpot::get_core_to_asset_input_price(
-				&resolve_asset_id!(TradeAssetCurrencyA),
-				0,
-				DefaultFeeRate::get()
-			),
+			CennzXSpot::get_core_to_asset_input_price(&resolve_asset_id!(TradeAssetCurrencyA), 0),
 			Error::<Test>::CoreToAssetSellAmountNotAboveZero
 		);
 	});
@@ -889,8 +840,7 @@ fn asset_swap_input_insufficient_balance() {
 				&trader, // recipient
 				&resolve_asset_id!(TradeAssetCurrencyA),
 				10001, // sell_amount
-				100,   // min buy limit
-				DefaultFeeRate::get()
+				100    // min buy limit
 			),
 			Error::<Test>::InsufficientSellerTradeAssetBalance
 		);
@@ -901,8 +851,7 @@ fn asset_swap_input_insufficient_balance() {
 				&trader, // recipient
 				&resolve_asset_id!(TradeAssetCurrencyA),
 				10001, // sell_amount
-				100,   // min buy limit
-				DefaultFeeRate::get()
+				100    // min buy limit
 			),
 			Error::<Test>::InsufficientSellerCoreAssetBalance
 		);
@@ -963,9 +912,8 @@ fn make_asset_to_core_input() {
 				&trader, // buyer
 				&trader, // recipient
 				&resolve_asset_id!(TradeAssetCurrencyA),
-				90,                    // sell_amount: T::Balance,
-				50,                    // min buy: T::Balance,
-				DefaultFeeRate::get()  // fee_rate
+				90, // sell_amount: T::Balance,
+				50, // min buy: T::Balance,
 			),
 			81
 		);
@@ -987,9 +935,8 @@ fn make_core_to_asset_input() {
 				&trader, // buyer
 				&trader, // recipient
 				&resolve_asset_id!(TradeAssetCurrencyA),
-				90,                    // sell_amount: T::Balance,
-				50,                    // min buy: T::Balance,
-				DefaultFeeRate::get()  // fee_rate
+				90, // sell_amount: T::Balance,
+				50, // min buy: T::Balance,
 			),
 			81
 		);

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -196,7 +196,6 @@ where
 		let converted_fill_meter_cost = CennzxSpot::<T>::get_asset_to_core_output_price(
 			&payment_asset,
 			T::Balance::unique_saturated_from(fill_meter_cost.saturated_into()),
-			CennzxSpot::<T>::fee_rate(),
 		)?;
 
 		// Respect the user's max. fee preference

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -595,8 +595,7 @@ fn generic_asset_transfer_works_with_fee_exchange() {
 			let fee = transfer_fee(&xt, &runtime_call);
 
 			// Calculate how much CENNZ should be sold to make the above extrinsic
-			let cennz_sold_amount =
-				CennzxSpot::get_asset_to_core_output_price(&CENNZ_ASSET_ID, fee, CennzxSpot::fee_rate()).unwrap();
+			let cennz_sold_amount = CennzxSpot::get_asset_to_core_output_price(&CENNZ_ASSET_ID, fee).unwrap();
 			assert_eq!(cennz_sold_amount, 6);
 
 			// Initialise block and apply the extrinsic


### PR DESCRIPTION
Based on refactor opportunities identified in BT-148

## Addressed:
- `get_input/output_price` should not include the fee rate

---

## Maintainability / refactor concerns:
- None