### PR TITLE
Sylo module audit refactor

### DIFF
--- a/crml/sylo/src/e2ee.rs
+++ b/crml/sylo/src/e2ee.rs
@@ -13,37 +13,32 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-use frame_support::{decl_event, decl_module, decl_storage, dispatch::Vec, ensure};
-use frame_system::{self, ensure_signed};
-
 use crate::{device, groups, inbox, response};
+use frame_support::{decl_error, decl_module, decl_storage, dispatch::Vec, ensure};
+use frame_system::ensure_signed;
 
 const MAX_PKBS: usize = 50;
 
-pub trait Trait: inbox::Trait + response::Trait + device::Trait + groups::Trait {
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
-}
+pub trait Trait: inbox::Trait + response::Trait + device::Trait + groups::Trait {}
 
 type DeviceId = u32;
 
 // Serialized pre key bundle used to establish one to one e2ee
 pub type PreKeyBundle = Vec<u8>;
 
-decl_event!(
-	pub enum Event<T> where <T as frame_system::Trait>::AccountId {
-		DeviceAdded(AccountId, u32),
+decl_error! {
+	pub enum Error for Module<T: Trait> {
+		/// Cannot store more than MAX_PKBS
+		MaxPreKeyBundle,
 	}
-);
+}
 
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
-		fn deposit_event() = default;
-
-		fn register_device(origin, device_id: u32, pkbs: Vec<PreKeyBundle>) {
+		fn register_device(origin, device_id: DeviceId, pkbs: Vec<PreKeyBundle>) {
 			let sender = ensure_signed(origin)?;
 
-			let current_pkbs = <PreKeyBundles<T>>::get((sender.clone(), device_id));
-			ensure!((current_pkbs.len() + pkbs.len()) <= MAX_PKBS, "User can not store more than maximum number of pkbs");
+			ensure!(Self::check_total_pkbs(&sender, device_id, pkbs.len()), Error::<T>::MaxPreKeyBundle);
 
 			<device::Module<T>>::append_device(&sender, device_id)?;
 
@@ -55,11 +50,10 @@ decl_module! {
 			<PreKeyBundles<T>>::mutate((sender, device_id), |current_pkbs| current_pkbs.extend(pkbs));
 		}
 
-		fn replenish_pkbs(origin, device_id: u32, pkbs: Vec<PreKeyBundle>) {
+		fn replenish_pkbs(origin, device_id: DeviceId, pkbs: Vec<PreKeyBundle>) {
 			let sender = ensure_signed(origin)?;
 
-			let current_pkbs = <PreKeyBundles<T>>::get((sender.clone(), device_id));
-			ensure!((current_pkbs.len() + pkbs.len()) <= MAX_PKBS, "User can not store more than maximum number of pkbs");
+			ensure!(Self::check_total_pkbs(&sender, device_id, pkbs.len()), Error::<T>::MaxPreKeyBundle);
 
 			<PreKeyBundles<T>>::mutate((sender, device_id), |current_pkbs| current_pkbs.extend(pkbs));
 		}
@@ -90,7 +84,12 @@ decl_storage! {
 	}
 }
 
-impl<T: Trait> Module<T> {}
+impl<T: Trait> Module<T> {
+	fn check_total_pkbs(sender_id: &T::AccountId, device_id: DeviceId, pkbs_count: usize) -> bool {
+		let current_pkbs = <PreKeyBundles<T>>::get((sender_id, device_id));
+		(current_pkbs.len() + pkbs_count) <= MAX_PKBS
+	}
+}
 
 #[cfg(test)]
 pub(super) mod tests {
@@ -99,9 +98,7 @@ pub(super) mod tests {
 	use frame_support::assert_ok;
 	use sp_core::H256;
 
-	impl Trait for Test {
-		type Event = ();
-	}
+	impl Trait for Test {}
 	impl device::Trait for Test {}
 	impl inbox::Trait for Test {}
 	impl response::Trait for Test {}

--- a/crml/sylo/src/e2ee.rs
+++ b/crml/sylo/src/e2ee.rs
@@ -95,7 +95,7 @@ impl<T: Trait> Module<T> {}
 #[cfg(test)]
 pub(super) mod tests {
 	use super::*;
-	use crate::mock::{new_test_ext, Origin, Test};
+	use crate::mock::{ExtBuilder, Origin, Test};
 	use frame_support::assert_ok;
 	use sp_core::H256;
 
@@ -114,7 +114,7 @@ pub(super) mod tests {
 
 	#[test]
 	fn should_add_device() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			assert_ok!(E2EE::register_device(
 				Origin::signed(H256::from_low_u64_be(1)),
 				0,
@@ -134,7 +134,7 @@ pub(super) mod tests {
 
 	#[test]
 	fn should_replenish_pkbs() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			assert_ok!(E2EE::register_device(
 				Origin::signed(H256::from_low_u64_be(1)),
 				0,
@@ -155,7 +155,7 @@ pub(super) mod tests {
 
 	#[test]
 	fn should_withdraw_pkbs() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			assert_ok!(E2EE::register_device(
 				Origin::signed(H256::from_low_u64_be(1)),
 				0,

--- a/crml/sylo/src/e2ee.rs
+++ b/crml/sylo/src/e2ee.rs
@@ -102,9 +102,7 @@ pub(super) mod tests {
 	impl Trait for Test {
 		type Event = ();
 	}
-	impl device::Trait for Test {
-		type Event = ();
-	}
+	impl device::Trait for Test {}
 	impl inbox::Trait for Test {}
 	impl response::Trait for Test {}
 	impl groups::Trait for Test {}

--- a/crml/sylo/src/groups/mod.rs
+++ b/crml/sylo/src/groups/mod.rs
@@ -98,7 +98,7 @@ decl_module! {
 
 			ensure!(!<Groups<T>>::contains_key(&group_id), "Group already exists");
 			ensure!(invites.len() < INVITES_MAX, "Can not invite more than maximum amount");
-			ensure!(<vault::Vault<T>>::get(&sender).len() < vault::KEYS_MAX, "Can not store more than maximum amount of keys for user's vault");
+			ensure!(<vault::Vault<T>>::get(&sender).len() < vault::MAX_KEYS, "Can not store more than maximum amount of keys for user's vault");
 
 			let admin: Member<T::AccountId> = Member {
 				user_id: sender.clone(),
@@ -248,7 +248,7 @@ decl_module! {
 
 			ensure!(<Groups<T>>::contains_key(&group_id), "Group not found");
 			ensure!(!Self::is_group_member(&group_id, &payload.account_id), "Already a member of group");
-			ensure!(<vault::Vault<T>>::get(&sender).len() < vault::KEYS_MAX, "Can not store more than maximum amount of keys for user's vault");
+			ensure!(<vault::Vault<T>>::get(&sender).len() < vault::MAX_KEYS, "Can not store more than maximum amount of keys for user's vault");
 
 			let mut group = <Groups<T>>::get(&group_id);
 			let invite = group.clone().invites

--- a/crml/sylo/src/groups/mod.rs
+++ b/crml/sylo/src/groups/mod.rs
@@ -27,7 +27,8 @@ mod tests;
 
 pub trait Trait: frame_system::Trait + inbox::Trait + device::Trait + vault::Trait {}
 
-const INVITES_MAX: usize = 15;
+const MAX_INVITES: usize = 15;
+const MAX_MEMBERS: usize = 100;
 
 // Meta type stored on group, members and invites
 pub type Meta = Vec<(Text, Text)>;
@@ -97,7 +98,7 @@ decl_module! {
 			let sender = ensure_signed(origin)?;
 
 			ensure!(!<Groups<T>>::contains_key(&group_id), "Group already exists");
-			ensure!(invites.len() < INVITES_MAX, "Can not invite more than maximum amount");
+			ensure!(invites.len() < MAX_INVITES, "Can not invite more than maximum amount");
 			ensure!(<vault::Vault<T>>::get(&sender).len() < vault::MAX_KEYS, "Can not store more than maximum amount of keys for user's vault");
 
 			let admin: Member<T::AccountId> = Member {
@@ -234,7 +235,7 @@ decl_module! {
 			ensure!(<Groups<T>>::contains_key(&group_id), "Group not found");
 			ensure!(Self::is_group_member(&group_id, &sender), "Not a member of group");
 			ensure!(Self::is_group_admin(&group_id, &sender), "Insufficient permissions for group");
-			ensure!(invites.len() < INVITES_MAX, "Can not invite more than maximum amount");
+			ensure!(invites.len() < MAX_INVITES, "Can not invite more than maximum amount");
 
 			for invite in invites {
 				let _ = Self::create_invite(&group_id, invite);
@@ -251,6 +252,7 @@ decl_module! {
 			ensure!(<vault::Vault<T>>::get(&sender).len() < vault::MAX_KEYS, "Can not store more than maximum amount of keys for user's vault");
 
 			let mut group = <Groups<T>>::get(&group_id);
+			ensure!(group.members.len() < MAX_MEMBERS, "Can not store more than maximum number of members");
 			let invite = group.clone().invites
 				.into_iter()
 				.find(|invite| invite.invite_key == invite_key)

--- a/crml/sylo/src/groups/tests.rs
+++ b/crml/sylo/src/groups/tests.rs
@@ -16,7 +16,7 @@
 #[cfg(test)]
 mod tests {
 	use crate::groups::{AcceptPayload, Encode, Group, Invite, Member, MemberRoles, Module};
-	use crate::mock::{new_test_ext, Origin, Test};
+	use crate::mock::{ExtBuilder, Origin, Test};
 	use crate::vault;
 	use frame_support::{assert_ok, dispatch::DispatchError};
 	use sp_core::{ed25519, Pair, H256};
@@ -26,7 +26,7 @@ mod tests {
 
 	#[test]
 	fn it_works_creating_a_group() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let meta_1 = vec![(b"key".to_vec(), b"value".to_vec())];
 			let group_id = H256::from([1; 32]);
 			//Create a group
@@ -72,7 +72,7 @@ mod tests {
 
 	#[test]
 	fn it_works_modifying_meta() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let group_id = H256::from([1; 32]);
 			let mut meta_1 = vec![(b"key".to_vec(), b"value".to_vec())];
 			let mut meta_2 = vec![(b"key2".to_vec(), b"value2".to_vec())];
@@ -117,7 +117,7 @@ mod tests {
 
 	#[test]
 	fn should_leave_group() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let group_id = H256::from([1; 32]);
 
 			//Create a group
@@ -157,7 +157,7 @@ mod tests {
 
 	#[test]
 	fn should_accept_invite() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let group_id = H256::from([2; 32]);
 
 			//Create a group
@@ -252,7 +252,7 @@ mod tests {
 
 	#[test]
 	fn should_revoke_invites() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let group_id = H256::from([1; 32]);
 
 			//Create a group
@@ -303,7 +303,7 @@ mod tests {
 
 	#[test]
 	fn should_update_member() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let group_id = H256::from([1; 32]);
 			let meta_1 = vec![(b"key".to_vec(), b"value".to_vec())];
 

--- a/crml/sylo/src/inbox.rs
+++ b/crml/sylo/src/inbox.rs
@@ -101,7 +101,7 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{new_test_ext, Origin, Test};
+	use crate::mock::{ExtBuilder, Origin, Test};
 	use frame_support::assert_ok;
 	use sp_core::H256;
 
@@ -109,7 +109,7 @@ mod tests {
 
 	#[test]
 	fn it_works_adding_values_to_an_inbox() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			// Add a value to an empty inbox
 			assert_ok!(Inbox::add_value(
 				Origin::signed(H256::from_low_u64_be(1)),
@@ -133,7 +133,7 @@ mod tests {
 
 	#[test]
 	fn it_works_removing_values_from_an_inbox() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			// Add values to an empty inbox
 			assert_ok!(Inbox::add_value(
 				Origin::signed(H256::from_low_u64_be(1)),
@@ -173,7 +173,7 @@ mod tests {
 
 	#[test]
 	fn it_works_removing_values_from_an_empty_inbox() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			// Remove a value that doesn't exist
 			assert_ok!(Inbox::delete_values(Origin::signed(H256::from_low_u64_be(2)), vec![0]));
 		});

--- a/crml/sylo/src/mock.rs
+++ b/crml/sylo/src/mock.rs
@@ -66,9 +66,12 @@ impl_outer_origin! {
 
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	frame_system::GenesisConfig::default()
-		.build_storage::<Test>()
-		.unwrap()
-		.into()
+pub struct ExtBuilder;
+impl ExtBuilder {
+	pub fn build(self) -> sp_io::TestExternalities {
+		frame_system::GenesisConfig::default()
+			.build_storage::<Test>()
+			.unwrap()
+			.into()
+	}
 }

--- a/crml/sylo/src/response.rs
+++ b/crml/sylo/src/response.rs
@@ -61,7 +61,7 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 pub(super) mod tests {
 	use super::*;
-	use crate::mock::{new_test_ext, Origin, Test};
+	use crate::mock::{ExtBuilder, Origin, Test};
 	use frame_support::assert_ok;
 	use sp_core::H256;
 
@@ -69,7 +69,7 @@ pub(super) mod tests {
 
 	#[test]
 	fn should_set_response() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let request_id = H256::from([1; 32]);
 			let resp_number = Response::DeviceId(111);
 

--- a/crml/sylo/src/vault.rs
+++ b/crml/sylo/src/vault.rs
@@ -13,29 +13,43 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-use frame_support::{decl_module, decl_storage, dispatch::Vec, ensure};
-use frame_system::{self, ensure_signed};
+use frame_support::{decl_error, decl_module, decl_storage, dispatch::Vec, ensure};
+use frame_system::ensure_signed;
 
-pub const KEYS_MAX: usize = 100;
+pub const MAX_KEYS: usize = 100;
+const MAX_VALUE_LENGTH: usize = 100_000;
+const MAX_DELETE_KEYS: usize = 100;
 
 pub trait Trait: frame_system::Trait {}
 
 pub type VaultKey = Vec<u8>;
 pub type VaultValue = Vec<u8>;
 
+decl_error! {
+	pub enum Error for Module<T: Trait> {
+		/// Cannot store more than MAX_KEYS
+		MaxKeys,
+		/// Cannot store value larger than MAX_VALUE_LENGTH
+		MaxValueLength,
+		/// Cannot delete more than MAX_DELETE_KEYS at a time
+		MaxDeleteKeys,
+	}
+}
+
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
+		type Error = Error<T>;
+
 		fn upsert_value(origin, key: VaultKey, value: VaultValue) {
 			let user_id = ensure_signed(origin)?;
-
-			ensure!(<Vault<T>>::get(&user_id).len() < KEYS_MAX, "Can not store more than maximum amount of keys");
-
+			ensure!(value.len() <= MAX_VALUE_LENGTH, Error::<T>::MaxValueLength);
+			ensure!(<Vault<T>>::get(&user_id).len() < MAX_KEYS, Error::<T>::MaxKeys);
 			Self::upsert(user_id, key, value);
 		}
 
 		fn delete_values(origin, keys: Vec<VaultKey>) {
 			let user_id = ensure_signed(origin)?;
-
+			ensure!(keys.len() <= MAX_DELETE_KEYS, Error::<T>::MaxDeleteKeys);
 			Self::delete(user_id, keys);
 		}
 	}
@@ -73,7 +87,7 @@ impl<T: Trait> Module<T> {
 mod tests {
 	use super::*;
 	use crate::mock::{ExtBuilder, Origin, Test};
-	use frame_support::assert_ok;
+	use frame_support::{assert_noop, assert_ok};
 	use sp_core::H256;
 
 	impl Trait for Test {}
@@ -167,6 +181,25 @@ mod tests {
 			));
 
 			assert_eq!(Vault::values(H256::from_low_u64_be(1)), vec![]);
+		});
+	}
+
+	#[test]
+	fn should_not_add_more_than_max_keys() {
+		ExtBuilder.build().execute_with(|| {
+			let user_id = H256::from_low_u64_be(1);
+			for i in 0..MAX_KEYS {
+				let key = format!("key_{}", i).into_bytes();
+				let value = format!("value_{}", i).into_bytes();
+				assert_ok!(Vault::upsert_value(Origin::signed(user_id), key, value));
+			}
+			assert_eq!(Vault::values(user_id).len(), 100);
+
+			// an attempt to add another item to Vault should fail
+			assert_noop!(
+				Vault::upsert_value(Origin::signed(user_id), b"new_key".to_vec(), b"new_value".to_vec()),
+				Error::<Test>::MaxKeys,
+			);
 		});
 	}
 }

--- a/crml/sylo/src/vault.rs
+++ b/crml/sylo/src/vault.rs
@@ -72,7 +72,7 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{new_test_ext, Origin, Test};
+	use crate::mock::{ExtBuilder, Origin, Test};
 	use frame_support::assert_ok;
 	use sp_core::H256;
 
@@ -81,7 +81,7 @@ mod tests {
 
 	#[test]
 	fn should_upsert_values() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let key_0 = b"0".to_vec();
 			let value_0 = b"1".to_vec();
 
@@ -114,7 +114,7 @@ mod tests {
 
 	#[test]
 	fn should_replace_existing_keys() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let key_0 = b"0".to_vec();
 			let value_0 = b"1".to_vec();
 			let value_1 = b"01".to_vec();
@@ -139,7 +139,7 @@ mod tests {
 
 	#[test]
 	fn should_delete_keys() {
-		new_test_ext().execute_with(|| {
+		ExtBuilder.build().execute_with(|| {
 			let key_0 = b"0".to_vec();
 			let key_1 = b"1".to_vec();
 			let value_0 = b"01".to_vec();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -179,9 +179,7 @@ impl crml_sylo::groups::Trait for Runtime {}
 impl crml_sylo::e2ee::Trait for Runtime {
 	type Event = Event;
 }
-impl crml_sylo::device::Trait for Runtime {
-	type Event = Event;
-}
+impl crml_sylo::device::Trait for Runtime {}
 impl crml_sylo::response::Trait for Runtime {}
 impl crml_sylo::inbox::Trait for Runtime {}
 impl crml_sylo::vault::Trait for Runtime {}
@@ -606,7 +604,7 @@ construct_runtime!(
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
 		SyloGroups: sylo_groups::{Module, Call, Storage},
 		SyloE2EE: sylo_e2ee::{Module, Call, Event<T>, Storage},
-		SyloDevice: sylo_device::{Module, Call, Event<T>, Storage},
+		SyloDevice: sylo_device::{Module, Call, Storage},
 		SyloInbox: sylo_inbox::{Module, Call, Storage},
 		SyloResponse: sylo_response::{Module, Call, Storage},
 		SyloVault: sylo_vault::{Module, Call, Storage},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -176,9 +176,7 @@ impl prml_attestation::Trait for Runtime {
 }
 
 impl crml_sylo::groups::Trait for Runtime {}
-impl crml_sylo::e2ee::Trait for Runtime {
-	type Event = Event;
-}
+impl crml_sylo::e2ee::Trait for Runtime {}
 impl crml_sylo::device::Trait for Runtime {}
 impl crml_sylo::response::Trait for Runtime {}
 impl crml_sylo::inbox::Trait for Runtime {}
@@ -603,7 +601,7 @@ construct_runtime!(
 		Offences: pallet_offences::{Module, Call, Storage, Event},
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
 		SyloGroups: sylo_groups::{Module, Call, Storage},
-		SyloE2EE: sylo_e2ee::{Module, Call, Event<T>, Storage},
+		SyloE2EE: sylo_e2ee::{Module, Call, Storage},
 		SyloDevice: sylo_device::{Module, Call, Storage},
 		SyloInbox: sylo_inbox::{Module, Call, Storage},
 		SyloResponse: sylo_response::{Module, Call, Storage},


### PR DESCRIPTION
This PR is to refactor Sylo module based on the corresponding module audit.

## Changes:

*For reviewing the PR, it will be easier to look at individual commit and its comments rather than viewing all the file changes.*

The below should follow the commit order:
- Add the familiar ExtBuilder pattern in mock and associated changes to all tests
- `devices.rs`
    - Remove unused Event and related code (reason is the purpose of Hash type in the defined event wasn’t clear)
    - Add Error to replace string-based errors
    - Add DeviceId as type alias for u32
    - Add correct length check inside `fn append_device`
    - Add delete_device method to de-register devices
    - Add two unit tests, one for each method
- `inbox.rs`
    - Add arbitrary usize consts to limit messages, associated ensures and Error
    - Add `MessageId` and `Message` type aliases for better readability
    - Remove redundant Values mutation on next_index match
- `vault.rs`
    - Rename KEYS_MAX -> MAX_KEYS for consistency
    - Add MAX_DELETE_KEYS const to limit number of deletes per call
    - Add Error and associated ensures
    - Add a test for adding more than allowed
- `groups`
    - Add MAX_MEMBERS const to limit the number of members in a group and associated ensure
    - Rename INVITES_MAX -> MAX_INVITES for consistency
- `e2ee.rs`
    - Removed unused Event and related code
    - Use already existing DeviceId type alias for u32
    - Add Error to replace string
    - Add `fn check_total_pkbs` method and use it to check whether more pkbs can be added to the storage

## Concerns:

- The const limits are arbitrary at the moment and we need to discuss what they should be