### PR TITLE
Cennzx-spot exchange_address_for only takes trade assetId

### DIFF
--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -25,7 +25,7 @@ use sp_std::{marker::PhantomData, prelude::*};
 
 /// A function that generates an `AccountId` for a CENNZX-SPOT exchange / (core, asset) pair
 pub trait ExchangeAddressFor<AssetId: Sized, AccountId: Sized> {
-	fn exchange_address_for(core_asset_id: AssetId, asset_id: AssetId) -> AccountId;
+	fn exchange_address_for(asset_id: AssetId) -> AccountId;
 }
 
 // A CENNZX-Spot exchange address generator implementation
@@ -37,8 +37,9 @@ where
 	T::AssetId: Into<u64>,
 {
 	/// Generates an exchange address for the given core / asset pair
-	fn exchange_address_for(core_asset_id: T::AssetId, asset_id: T::AssetId) -> T::AccountId {
+	fn exchange_address_for(asset_id: T::AssetId) -> T::AccountId {
 		let mut buf = Vec::new();
+		let core_asset_id = Module::<T>::core_asset_id();
 		buf.extend_from_slice(b"cennz-x-spot:");
 		buf.extend_from_slice(&core_asset_id.into().to_le_bytes());
 		buf.extend_from_slice(&asset_id.into().to_le_bytes());
@@ -83,7 +84,7 @@ impl<T: Trait> BuyFeeAsset for Module<T> {
 pub(crate) mod impl_tests {
 	use super::*;
 	use crate::{
-		mock::{self, CORE_ASSET_ID, FEE_ASSET_ID, TRADE_ASSET_A_ID},
+		mock::{self, FEE_ASSET_ID, TRADE_ASSET_A_ID},
 		tests::{CennzXSpot, ExtBuilder, Test},
 		Error,
 	};

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -206,7 +206,7 @@ decl_module! {
 			);
 			let exchange_key = (core_asset_id, asset_id);
 			let total_liquidity = <TotalSupply<T>>::get(&exchange_key);
-			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, asset_id);
+			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(asset_id);
 
 			if total_liquidity.is_zero() {
 				// new exchange pool
@@ -273,7 +273,7 @@ decl_module! {
 			);
 
 			let total_liquidity = <TotalSupply<T>>::get(&exchange_key);
-			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, asset_id);
+			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(asset_id);
 			ensure!(
 				total_liquidity > Zero::zero(),
 				Error::<T>::NoLiquidityToRemove
@@ -372,7 +372,7 @@ impl<T: Trait> Module<T> {
 		ensure!(buy_amount > Zero::zero(), Error::<T>::BuyAmountNotPositive);
 
 		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_id);
+		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
 
 		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
@@ -393,7 +393,7 @@ impl<T: Trait> Module<T> {
 		);
 
 		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_id);
+		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
 
 		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
@@ -482,7 +482,7 @@ impl<T: Trait> Module<T> {
 		ensure!(buy_amount > Zero::zero(), Error::<T>::BuyAmountNotPositive);
 
 		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_id);
+		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
 
 		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
@@ -504,7 +504,7 @@ impl<T: Trait> Module<T> {
 		);
 
 		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_id);
+		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
 		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 
@@ -603,9 +603,9 @@ impl<T: Trait> Module<T> {
 		// otherwise, we make two exchanges
 		if *asset_to_sell == core_asset_id || *asset_to_buy == core_asset_id {
 			let exchange_address = if *asset_to_buy == core_asset_id {
-				T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_to_sell)
+				T::ExchangeAddressGenerator::exchange_address_for(*asset_to_sell)
 			} else {
-				T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_to_buy)
+				T::ExchangeAddressGenerator::exchange_address_for(*asset_to_buy)
 			};
 			let _ = <pallet_generic_asset::Module<T>>::make_transfer(
 				&asset_to_sell,
@@ -621,8 +621,8 @@ impl<T: Trait> Module<T> {
 			));
 		} else {
 			let core_amount = Self::get_asset_to_core_sell_price(asset_to_sell, amount_to_sell)?;
-			let exchange_address_a = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_to_sell);
-			let exchange_address_b = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, *asset_to_buy);
+			let exchange_address_a = T::ExchangeAddressGenerator::exchange_address_for(*asset_to_sell);
+			let exchange_address_b = T::ExchangeAddressGenerator::exchange_address_for(*asset_to_buy);
 
 			let _ = <pallet_generic_asset::Module<T>>::make_transfer(
 				asset_to_sell,

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -153,7 +153,6 @@ macro_rules! with_exchange (
 	($a1:ident => $b1:expr, $a2:ident => $b2:expr) => {
 		{
 			let exchange_address = <Test as Trait>::ExchangeAddressGenerator::exchange_address_for(
-				resolve_asset_id!($a1),
 				resolve_asset_id!($a2),
 			);
 			let _ = $a1::deposit_creating(&exchange_address, $b1);
@@ -168,7 +167,6 @@ macro_rules! assert_exchange_balance_eq (
 	($a1:ident => $b1:expr, $a2:ident => $b2:expr) => {
 		{
 			let exchange_address = <Test as Trait>::ExchangeAddressGenerator::exchange_address_for(
-				resolve_asset_id!($a1),
 				resolve_asset_id!($a2),
 			);
 			let bal1 = $a1::free_balance(&exchange_address);


### PR DESCRIPTION
This is the result of an audit on CENNZxSpot

## Addresses:

- exchange key generation should only require the trading `asset_id`

## Changes:

- `exchange_address_for` only requires trading `asset_id`
- the exchange address still uses the `CoreAssetId` from storage to keep the addresses consistent

---

## Concerns:

- none