### PR TITLE
CENNZxSpot liquidity audit refactors

### DIFF
--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -237,7 +237,7 @@ decl_module! {
 		/// Burn exchange assets to withdraw core asset and trade asset at current ratio
 		///
 		/// `asset_id` - The trade asset ID
-		/// `liquidity_to_withdraw` - Amount of user's liquidity to burn
+		/// `liquidity_to_withdraw` - Amount of user's liquidity to withdraw
 		/// `min_asset_withdraw` - The minimum trade asset withdrawn
 		/// `min_core_withdraw` -  The minimum core asset withdrawn
 		pub fn remove_liquidity(
@@ -315,11 +315,11 @@ decl_storage! {
 		pub CoreAssetId get(core_asset_id) config(): T::AssetId;
 		/// Default Trading fee rate
 		pub DefaultFeeRate get(fee_rate) config(): FeeRate<PerMillion>;
-		/// Total liquidity in each individual exchange.
-		/// it will always be less than the core asset's total supply
+		/// Total liquidity holdings of all investers in an exchange.
+		/// ie/ total_liquidity(exchange) == sum(liquidity_balance(exchange, user)) at all times
 		pub TotalLiquidity get(total_liquidity): map hasher(twox_64_concat) ExchangeKey<T> => T::Balance;
 
-		/// Asset balance of an investor in an exchange pool.
+		/// Liquidity holdings of a user in an exchange pool.
 		/// Key: `(core_asset_id, trade_asset_id), account_id`
 		pub LiquidityBalance get(liquidity_balance): double_map hasher(twox_64_concat) ExchangeKey<T>, hasher(blake2_128_concat) T::AccountId => T::Balance;
 	}

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -205,7 +205,7 @@ decl_module! {
 				Error::<T>::TradeAssetBalanceToAddLiquidityTooLow
 			);
 			let exchange_key = (core_asset_id, asset_id);
-			let total_liquidity = <TotalSupply<T>>::get(&exchange_key);
+			let total_liquidity = <TotalLiquidity<T>>::get(&exchange_key);
 			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(asset_id);
 			let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 
@@ -231,7 +231,7 @@ decl_module! {
 			<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &from_account, &exchange_address, trade_asset_amount)?;
 
 			Self::set_liquidity(&exchange_key, &from_account, <LiquidityBalance<T>>::get(&exchange_key, &from_account) + liquidity_minted);
-			Self::mint_total_supply(&exchange_key, liquidity_minted);
+			Self::mint_total_liquidity(&exchange_key, liquidity_minted);
 			Self::deposit_event(RawEvent::AddLiquidity(from_account, core_amount, asset_id, trade_asset_amount));
 		}
 
@@ -258,7 +258,7 @@ decl_module! {
 				Error::<T>::LiquidityTooLow
 			);
 
-			let total_liquidity = <TotalSupply<T>>::get(&exchange_key);
+			let total_liquidity = <TotalLiquidity<T>>::get(&exchange_key);
 			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(asset_id);
 			ensure!(
 				total_liquidity > Zero::zero(),
@@ -280,9 +280,8 @@ decl_module! {
 
 			<pallet_generic_asset::Module<T>>::make_transfer(&core_asset_id, &exchange_address, &from_account, core_asset_amount)?;
 			<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &exchange_address, &from_account, trade_asset_amount)?;
-			Self::set_liquidity(&exchange_key, &from_account,
-									account_liquidity - liquidity_to_withdraw);
-			Self::burn_total_supply(&exchange_key, liquidity_to_withdraw);
+			Self::set_liquidity(&exchange_key, &from_account, account_liquidity - liquidity_to_withdraw);
+			Self::burn_total_liquidity(&exchange_key, liquidity_to_withdraw);
 			Self::deposit_event(RawEvent::RemoveLiquidity(from_account, core_asset_amount, asset_id, trade_asset_amount));
 			Ok(())
 		}
@@ -318,10 +317,9 @@ decl_storage! {
 		pub CoreAssetId get(core_asset_id) config(): T::AssetId;
 		/// Default Trading fee rate
 		pub DefaultFeeRate get(fee_rate) config(): FeeRate<PerMillion>;
-		/// Total supply of exchange token in existence.
+		/// Total liquidity in each individual exchange.
 		/// it will always be less than the core asset's total supply
-		/// Key: `(asset id, core asset id)`
-		pub TotalSupply get(total_supply): map hasher(twox_64_concat) ExchangeKey<T> => T::Balance;
+		pub TotalLiquidity get(total_liquidity): map hasher(twox_64_concat) ExchangeKey<T> => T::Balance;
 
 		/// Asset balance of an investor in an exchange pool.
 		/// Key: `(core_asset_id, trade_asset_id), account_id`
@@ -332,12 +330,12 @@ decl_storage! {
 // The main implementation block for the module.
 impl<T: Trait> Module<T> {
 	/// mint total supply for an exchange pool
-	fn mint_total_supply(exchange_key: &ExchangeKey<T>, increase: T::Balance) {
-		<TotalSupply<T>>::mutate(exchange_key, |balance| *balance += increase); // will not overflow because it's limited by core assets's total supply
+	fn mint_total_liquidity(exchange_key: &ExchangeKey<T>, increase: T::Balance) {
+		<TotalLiquidity<T>>::mutate(exchange_key, |balance| *balance += increase); // will not overflow because it's limited by core assets's total supply
 	}
 
-	fn burn_total_supply(exchange_key: &ExchangeKey<T>, decrease: T::Balance) {
-		<TotalSupply<T>>::mutate(exchange_key, |balance| *balance -= decrease); // will not underflow for the same reason
+	fn burn_total_liquidity(exchange_key: &ExchangeKey<T>, decrease: T::Balance) {
+		<TotalLiquidity<T>>::mutate(exchange_key, |balance| *balance -= decrease); // will not underflow for the same reason
 	}
 
 	fn set_liquidity(exchange_key: &ExchangeKey<T>, who: &T::AccountId, balance: T::Balance) {

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -249,14 +249,6 @@ decl_module! {
 			#[compact] min_core_withdraw: T::Balance
 		) -> DispatchResult {
 			let from_account = ensure_signed(origin)?;
-			ensure!(
-				liquidity_to_withdraw > Zero::zero(),
-				Error::<T>::LiquidityToWithdrawNotAboveZero
-			);
-			ensure!(
-				min_asset_withdraw > Zero::zero() && min_core_withdraw > Zero::zero(),
-				Error::<T>::AssetToWithdrawNotAboveZero
-			);
 
 			let core_asset_id = Self::core_asset_id();
 			let exchange_key = (core_asset_id, asset_id);

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -207,15 +207,13 @@ decl_module! {
 			let exchange_key = (core_asset_id, asset_id);
 			let total_liquidity = <TotalSupply<T>>::get(&exchange_key);
 			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, asset_id);
+			let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 
-			let (trade_asset_amount, liquidity_minted) = if total_liquidity.is_zero() {
+			let (trade_asset_amount, liquidity_minted) = if total_liquidity.is_zero() || core_asset_reserve.is_zero() {
 				// new exchange pool
-				<pallet_generic_asset::Module<T>>::make_transfer(&core_asset_id, &from_account, &exchange_address, core_amount)?;
-				<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &from_account, &exchange_address, max_asset_amount)?;
 				(max_asset_amount, core_amount)
 			} else {
 				let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
-				let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 				let trade_asset_amount = core_amount * trade_asset_reserve / core_asset_reserve + One::one();
 				let liquidity_minted = core_amount * total_liquidity / core_asset_reserve;
 				ensure!(
@@ -226,11 +224,12 @@ decl_module! {
 					max_asset_amount >= trade_asset_amount,
 					Error::<T>::TradeAssetToAddLiquidityAboveMaxAmount
 				);
-
-				<pallet_generic_asset::Module<T>>::make_transfer(&core_asset_id, &from_account, &exchange_address, core_amount)?;
-				<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &from_account, &exchange_address, trade_asset_amount)?;
 				(trade_asset_amount, liquidity_minted)
 			};
+
+			<pallet_generic_asset::Module<T>>::make_transfer(&core_asset_id, &from_account, &exchange_address, core_amount)?;
+			<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &from_account, &exchange_address, trade_asset_amount)?;
+
 			Self::set_liquidity(&exchange_key, &from_account, <LiquidityBalance<T>>::get(&exchange_key, &from_account) + liquidity_minted);
 			Self::mint_total_supply(&exchange_key, liquidity_minted);
 			Self::deposit_event(RawEvent::AddLiquidity(from_account, core_amount, asset_id, trade_asset_amount));

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -208,15 +208,11 @@ decl_module! {
 			let total_liquidity = <TotalSupply<T>>::get(&exchange_key);
 			let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(core_asset_id, asset_id);
 
-			if total_liquidity.is_zero() {
+			let (trade_asset_amount, liquidity_minted) = if total_liquidity.is_zero() {
 				// new exchange pool
 				<pallet_generic_asset::Module<T>>::make_transfer(&core_asset_id, &from_account, &exchange_address, core_amount)?;
 				<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &from_account, &exchange_address, max_asset_amount)?;
-				let trade_asset_amount = max_asset_amount;
-				let initial_liquidity = core_amount;
-				Self::set_liquidity(&exchange_key, &from_account, initial_liquidity);
-				Self::mint_total_supply(&exchange_key, initial_liquidity);
-				Self::deposit_event(RawEvent::AddLiquidity(from_account, initial_liquidity, asset_id, trade_asset_amount));
+				(max_asset_amount, core_amount)
 			} else {
 				let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
 				let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
@@ -233,12 +229,11 @@ decl_module! {
 
 				<pallet_generic_asset::Module<T>>::make_transfer(&core_asset_id, &from_account, &exchange_address, core_amount)?;
 				<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &from_account, &exchange_address, trade_asset_amount)?;
-
-				Self::set_liquidity(&exchange_key, &from_account,
-					<LiquidityBalance<T>>::get(&exchange_key, &from_account) + liquidity_minted);
-				Self::mint_total_supply(&exchange_key, liquidity_minted);
-				Self::deposit_event(RawEvent::AddLiquidity(from_account, core_amount, asset_id, trade_asset_amount));
-			}
+				(trade_asset_amount, liquidity_minted)
+			};
+			Self::set_liquidity(&exchange_key, &from_account, <LiquidityBalance<T>>::get(&exchange_key, &from_account) + liquidity_minted);
+			Self::mint_total_supply(&exchange_key, liquidity_minted);
+			Self::deposit_event(RawEvent::AddLiquidity(from_account, core_amount, asset_id, trade_asset_amount));
 		}
 
 		/// Burn exchange assets to withdraw core asset and trade asset at current ratio


### PR DESCRIPTION
This is the result of an audit on CENNZxSpot

## Addresses:

- Potential divide by zero in `add_liquidity`
- All storage and event actions in `add_liquidity` are duplicated
- `remove_liquidity` docs are out of date with the code
- `remove_liquidity` should allow zero `min_asset_withdraw` and `min_core_withdraw`
- `TotalSupply` is badly documented and should be named `TotalLiquidity`
---

## Concerns:

- none