### PR TITLE
CENNZxSpot Get Price Audit Refactors

### DIFF
--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -85,7 +85,7 @@ pub(crate) mod impl_tests {
 	use super::*;
 	use crate::{
 		mock::{self, FEE_ASSET_ID, TRADE_ASSET_A_ID},
-		tests::{CennzXSpot, ExtBuilder, Test},
+		mock::{CennzXSpot, ExtBuilder, Test},
 		Error,
 	};
 	use frame_support::traits::Currency;

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -363,7 +363,7 @@ impl<T: Trait> Module<T> {
 		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 
-		Self::get_output_price(buy_amount, core_reserve, asset_reserve)
+		Self::calculate_buy_price(buy_amount, core_reserve, asset_reserve)
 	}
 
 	/// `asset_id` - Trade asset
@@ -383,10 +383,10 @@ impl<T: Trait> Module<T> {
 
 		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-		Self::get_input_price(sell_amount, asset_reserve, core_reserve)
+		Self::calculate_sell_price(sell_amount, asset_reserve, core_reserve)
 	}
 
-	fn get_output_price(
+	fn calculate_buy_price(
 		output_amount: T::Balance,
 		input_reserve: T::Balance,
 		output_reserve: T::Balance,
@@ -422,7 +422,7 @@ impl<T: Trait> Module<T> {
 		Ok(T::UnsignedIntToBalance::from(output.into()).into())
 	}
 
-	fn get_input_price(
+	fn calculate_sell_price(
 		input_amount: T::Balance,
 		input_reserve: T::Balance,
 		output_reserve: T::Balance,
@@ -473,7 +473,7 @@ impl<T: Trait> Module<T> {
 		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
 
-		Self::get_output_price(buy_amount, trade_asset_reserve, core_asset_reserve)
+		Self::calculate_buy_price(buy_amount, trade_asset_reserve, core_asset_reserve)
 	}
 
 	/// Returns the amount of trade asset to pay for `sell_amount` of core sold.
@@ -494,9 +494,7 @@ impl<T: Trait> Module<T> {
 		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 
-		let output_amount = Self::get_input_price(sell_amount, core_asset_reserve, trade_asset_reserve)?;
-
-		Ok(output_amount)
+		Self::calculate_sell_price(sell_amount, core_asset_reserve, trade_asset_reserve)
 	}
 
 	/// Buy `amount_to_buy` of `asset_to_buy` with `asset_to_sell`.

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -377,7 +377,7 @@ impl<T: Trait> Module<T> {
 		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 
-		Self::get_output_price(buy_amount, core_reserve, asset_reserve)
+		Self::calculate_buy_price(buy_amount, core_reserve, asset_reserve)
 	}
 
 	/// `asset_id` - Trade asset
@@ -397,10 +397,10 @@ impl<T: Trait> Module<T> {
 
 		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-		Self::get_input_price(sell_amount, asset_reserve, core_reserve)
+		Self::calculate_sell_price(sell_amount, asset_reserve, core_reserve)
 	}
 
-	fn get_output_price(
+	fn calculate_buy_price(
 		output_amount: T::Balance,
 		input_reserve: T::Balance,
 		output_reserve: T::Balance,
@@ -436,7 +436,7 @@ impl<T: Trait> Module<T> {
 		Ok(T::UnsignedIntToBalance::from(output.into()).into())
 	}
 
-	fn get_input_price(
+	fn calculate_sell_price(
 		input_amount: T::Balance,
 		input_reserve: T::Balance,
 		output_reserve: T::Balance,
@@ -487,7 +487,7 @@ impl<T: Trait> Module<T> {
 		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
 
-		Self::get_output_price(buy_amount, trade_asset_reserve, core_asset_reserve)
+		Self::calculate_buy_price(buy_amount, trade_asset_reserve, core_asset_reserve)
 	}
 
 	/// Returns the amount of trade asset to pay for `sell_amount` of core sold.
@@ -508,9 +508,7 @@ impl<T: Trait> Module<T> {
 		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
 
-		let output_amount = Self::get_input_price(sell_amount, core_asset_reserve, trade_asset_reserve)?;
-
-		Ok(output_amount)
+		Self::calculate_sell_price(sell_amount, core_asset_reserve, trade_asset_reserve)
 	}
 
 	/// Buy `amount_to_buy` of `asset_to_buy` with `asset_to_sell`.

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -388,13 +388,8 @@ impl<T: Trait> Module<T> {
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(buy_amount > Zero::zero(), Error::<T>::BuyAmountNotPositive);
 
-		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
-
-		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
-
-		Self::calculate_buy_price(buy_amount, trade_asset_reserve, core_asset_reserve)
+		let (core_reserve, asset_reserve) = Self::get_exchange_reserves(asset_id);
+		Self::calculate_buy_price(buy_amount, asset_reserve, core_reserve)
 	}
 
 	/// `asset_id` - Trade asset
@@ -406,12 +401,7 @@ impl<T: Trait> Module<T> {
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(buy_amount > Zero::zero(), Error::<T>::BuyAmountNotPositive);
 
-		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
-
-		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
-		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-
+		let (core_reserve, asset_reserve) = Self::get_exchange_reserves(asset_id);
 		Self::calculate_buy_price(buy_amount, core_reserve, asset_reserve)
 	}
 
@@ -498,11 +488,7 @@ impl<T: Trait> Module<T> {
 			Error::<T>::AssetToCoreSellAmountNotAboveZero
 		);
 
-		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
-
-		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
-		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
+		let (core_reserve, asset_reserve) = Self::get_exchange_reserves(asset_id);
 		Self::calculate_sell_price(sell_amount, asset_reserve, core_reserve)
 	}
 
@@ -519,12 +505,8 @@ impl<T: Trait> Module<T> {
 			Error::<T>::CoreToAssetSellAmountNotAboveZero
 		);
 
-		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
-		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
-
-		Self::calculate_sell_price(sell_amount, core_asset_reserve, trade_asset_reserve)
+		let (core_reserve, asset_reserve) = Self::get_exchange_reserves(asset_id);
+		Self::calculate_sell_price(sell_amount, core_reserve, asset_reserve)
 	}
 
 	/// `sell_amount` - Amount to sell
@@ -565,6 +547,16 @@ impl<T: Trait> Module<T> {
 		let price = T::UnsignedIntToBalance::from(price_lp).into();
 		ensure!(buy_reserve > price, Error::<T>::InsufficientAssetReserve);
 		Ok(price)
+	}
+
+	/// A helper for pricing functions
+	/// Fetches the reserves from an exchange for a particular `asset_id`
+	fn get_exchange_reserves(asset_id: &T::AssetId) -> (T::Balance, T::Balance) {
+		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
+
+		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&Self::core_asset_id(), &exchange_address);
+		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
+		(core_reserve, asset_reserve)
 	}
 
 	//
@@ -712,5 +704,4 @@ impl<T: Trait> Module<T> {
 
 		Ok(())
 	}
-
 }

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -530,7 +530,7 @@ impl<T: Trait> Module<T> {
 		maximum_sell: T::Balance,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		// Check the sell amount meets the maximum requirement
-		let amount_to_sell = Self::calculate_buy_price(*asset_to_buy, amount_to_buy, *asset_to_sell)?;
+		let amount_to_sell = Self::get_buy_price(*asset_to_buy, amount_to_buy, *asset_to_sell)?;
 		ensure!(amount_to_sell <= maximum_sell, Error::<T>::PriceAboveMaxLimit);
 
 		// Check the seller has enough balance
@@ -574,7 +574,7 @@ impl<T: Trait> Module<T> {
 		);
 
 		// Check the buy amount meets the minimum requirement
-		let amount_to_buy = Self::calculate_sell_price(*asset_to_sell, amount_to_sell, *asset_to_buy)?;
+		let amount_to_buy = Self::get_sell_price(*asset_to_sell, amount_to_sell, *asset_to_buy)?;
 		ensure!(amount_to_buy >= minimum_buy, Error::<T>::SaleValueBelowRequiredMinimum);
 
 		Self::execute_trade(
@@ -655,12 +655,12 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
-	/// Calculate the buy price of some asset for another
+	/// Get the buy price of some asset for another
 	/// In simple terms: 'If I want to buy _x_ amount of asset _a_ how much of asset _b_ will it cost?'
 	/// `asset_to_buy` is the asset to buy
 	/// `amount_to_buy` is the amount of `asset_to_buy` required
 	/// `asset_to_pay` is the asset to use for payment (the final price will be given in this asset)
-	pub fn calculate_buy_price(
+	pub fn get_buy_price(
 		asset_to_buy: T::AssetId,
 		amount_to_buy: T::Balance,
 		asset_to_pay: T::AssetId,
@@ -686,12 +686,12 @@ impl<T: Trait> Module<T> {
 		Ok(pay_asset_amount)
 	}
 
-	/// Calculate the sell price of some asset for another
+	/// Get the sell price of some asset for another
 	/// In simple terms: 'If I sell _x_ amount of asset _a_ how much of asset _b_ will I get in return?'
 	/// `asset_to_sell` is the asset to be sold
 	/// `amount_to_sell` is the amount of `asset_to_sell` to be sold
 	/// `asset_to_payout` is the asset to be paid out in exchange for the sale of `asset_to_sell` (the final sale value is given in this asset)
-	pub fn calculate_sell_price(
+	pub fn get_sell_price(
 		asset_to_sell: T::AssetId,
 		amount_to_sell: T::Balance,
 		asset_to_payout: T::AssetId,

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -516,7 +516,7 @@ impl<T: Trait> Module<T> {
 		maximum_sell: T::Balance,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		// Check the sell amount meets the maximum requirement
-		let amount_to_sell = Self::calculate_buy_price(*asset_to_buy, amount_to_buy, *asset_to_sell)?;
+		let amount_to_sell = Self::get_buy_price(*asset_to_buy, amount_to_buy, *asset_to_sell)?;
 		ensure!(amount_to_sell <= maximum_sell, Error::<T>::PriceAboveMaxLimit);
 
 		// Check the seller has enough balance
@@ -560,7 +560,7 @@ impl<T: Trait> Module<T> {
 		);
 
 		// Check the buy amount meets the minimum requirement
-		let amount_to_buy = Self::calculate_sell_price(*asset_to_sell, amount_to_sell, *asset_to_buy)?;
+		let amount_to_buy = Self::get_sell_price(*asset_to_sell, amount_to_sell, *asset_to_buy)?;
 		ensure!(amount_to_buy >= minimum_buy, Error::<T>::SaleValueBelowRequiredMinimum);
 
 		Self::execute_trade(
@@ -641,12 +641,12 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
-	/// Calculate the buy price of some asset for another
+	/// Get the buy price of some asset for another
 	/// In simple terms: 'If I want to buy _x_ amount of asset _a_ how much of asset _b_ will it cost?'
 	/// `asset_to_buy` is the asset to buy
 	/// `amount_to_buy` is the amount of `asset_to_buy` required
 	/// `asset_to_pay` is the asset to use for payment (the final price will be given in this asset)
-	pub fn calculate_buy_price(
+	pub fn get_buy_price(
 		asset_to_buy: T::AssetId,
 		amount_to_buy: T::Balance,
 		asset_to_pay: T::AssetId,
@@ -672,12 +672,12 @@ impl<T: Trait> Module<T> {
 		Ok(pay_asset_amount)
 	}
 
-	/// Calculate the sell price of some asset for another
+	/// Get the sell price of some asset for another
 	/// In simple terms: 'If I sell _x_ amount of asset _a_ how much of asset _b_ will I get in return?'
 	/// `asset_to_sell` is the asset to be sold
 	/// `amount_to_sell` is the amount of `asset_to_sell` to be sold
 	/// `asset_to_payout` is the asset to be paid out in exchange for the sale of `asset_to_sell` (the final sale value is given in this asset)
-	pub fn calculate_sell_price(
+	pub fn get_sell_price(
 		asset_to_sell: T::AssetId,
 		amount_to_sell: T::Balance,
 		asset_to_payout: T::AssetId,

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -362,6 +362,55 @@ impl<T: Trait> Module<T> {
 	// Get Prices
 	//
 
+	/// Get the buy price of some asset for another
+	/// In simple terms: 'If I want to buy _x_ amount of asset _a_ how much of asset _b_ will it cost?'
+	/// `asset_to_buy` is the asset to buy
+	/// `amount_to_buy` is the amount of `asset_to_buy` required
+	/// `asset_to_pay` is the asset to use for payment (the final price will be given in this asset)
+	pub fn get_buy_price(
+		asset_to_buy: T::AssetId,
+		amount_to_buy: T::Balance,
+		asset_to_pay: T::AssetId,
+	) -> Result<T::Balance, DispatchError> {
+		ensure!(asset_to_buy != asset_to_pay, Error::<T>::AssetCannotSwapForItself);
+
+		// Find the cost of `amount_to_buy` of `asset_to_buy` in terms of core asset
+		// (how much core asset does it cost?).
+		let core_asset_amount = if asset_to_buy == Self::core_asset_id() {
+			amount_to_buy
+		} else {
+			Self::get_core_to_asset_buy_price(&asset_to_buy, amount_to_buy)?
+		};
+
+		// Find the price of `core_asset_amount` in terms of `asset_to_pay`
+		// (how much `asset_to_pay` does `core_asset_amount` cost?)
+		let pay_asset_amount = if asset_to_pay == Self::core_asset_id() {
+			core_asset_amount
+		} else {
+			Self::get_asset_to_core_buy_price(&asset_to_pay, core_asset_amount)?
+		};
+
+		Ok(pay_asset_amount)
+	}
+
+	/// `asset_id` - Trade asset
+	/// `buy_amount` - Amount of output core
+	/// Returns the amount of trade assets needed to buy `buy_amount` core assets.
+	pub fn get_asset_to_core_buy_price(
+		asset_id: &T::AssetId,
+		buy_amount: T::Balance,
+	) -> sp_std::result::Result<T::Balance, DispatchError> {
+		ensure!(buy_amount > Zero::zero(), Error::<T>::BuyAmountNotPositive);
+
+		let core_asset_id = Self::core_asset_id();
+		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
+
+		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
+		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
+
+		Self::calculate_buy_price(buy_amount, trade_asset_reserve, core_asset_reserve)
+	}
+
 	/// `asset_id` - Trade asset
 	/// `buy_amount`- Amount of the trade asset to buy
 	/// Returns the amount of core asset needed to purchase `buy_amount` of trade asset.
@@ -378,26 +427,6 @@ impl<T: Trait> Module<T> {
 		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
 
 		Self::calculate_buy_price(buy_amount, core_reserve, asset_reserve)
-	}
-
-	/// `asset_id` - Trade asset
-	/// `amount_sold` - Amount of the trade asset to sell
-	/// Returns amount of core that can be bought with input assets.
-	pub fn get_asset_to_core_sell_price(
-		asset_id: &T::AssetId,
-		sell_amount: T::Balance,
-	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		ensure!(
-			sell_amount > Zero::zero(),
-			Error::<T>::AssetToCoreSellAmountNotAboveZero
-		);
-
-		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
-
-		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
-		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-		Self::calculate_sell_price(sell_amount, asset_reserve, core_reserve)
 	}
 
 	fn calculate_buy_price(
@@ -436,6 +465,78 @@ impl<T: Trait> Module<T> {
 		Ok(T::UnsignedIntToBalance::from(output.into()).into())
 	}
 
+	/// Get the sell price of some asset for another
+	/// In simple terms: 'If I sell _x_ amount of asset _a_ how much of asset _b_ will I get in return?'
+	/// `asset_to_sell` is the asset to be sold
+	/// `amount_to_sell` is the amount of `asset_to_sell` to be sold
+	/// `asset_to_payout` is the asset to be paid out in exchange for the sale of `asset_to_sell` (the final sale value is given in this asset)
+	pub fn get_sell_price(
+		asset_to_sell: T::AssetId,
+		amount_to_sell: T::Balance,
+		asset_to_payout: T::AssetId,
+	) -> Result<T::Balance, DispatchError> {
+		ensure!(asset_to_sell != asset_to_payout, Error::<T>::AssetCannotSwapForItself);
+
+		// Find the value of `amount_to_sell` of `asset_to_sell` in terms of core asset
+		// (how much core asset is the sale worth?)
+		let core_asset_amount = if asset_to_sell == Self::core_asset_id() {
+			amount_to_sell
+		} else {
+			Self::get_asset_to_core_sell_price(&asset_to_sell, amount_to_sell)?
+		};
+
+		// Skip payout asset price if asset to be paid out is core
+		// (how much `asset_to_payout` is the sale worth?)
+		let payout_asset_value = if asset_to_payout == Self::core_asset_id() {
+			core_asset_amount
+		} else {
+			Self::get_core_to_asset_sell_price(&asset_to_payout, core_asset_amount)?
+		};
+
+		Ok(payout_asset_value)
+	}
+
+	/// `asset_id` - Trade asset
+	/// `amount_sold` - Amount of the trade asset to sell
+	/// Returns amount of core that can be bought with input assets.
+	pub fn get_asset_to_core_sell_price(
+		asset_id: &T::AssetId,
+		sell_amount: T::Balance,
+	) -> sp_std::result::Result<T::Balance, DispatchError> {
+		ensure!(
+			sell_amount > Zero::zero(),
+			Error::<T>::AssetToCoreSellAmountNotAboveZero
+		);
+
+		let core_asset_id = Self::core_asset_id();
+		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
+
+		let asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
+		let core_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
+		Self::calculate_sell_price(sell_amount, asset_reserve, core_reserve)
+	}
+
+	/// Returns the amount of trade asset to pay for `sell_amount` of core sold.
+	///
+	/// `asset_id` - Trade asset
+	/// `sell_amount` - Amount of input core to sell
+	pub fn get_core_to_asset_sell_price(
+		asset_id: &T::AssetId,
+		sell_amount: T::Balance,
+	) -> sp_std::result::Result<T::Balance, DispatchError> {
+		ensure!(
+			sell_amount > Zero::zero(),
+			Error::<T>::CoreToAssetSellAmountNotAboveZero
+		);
+
+		let core_asset_id = Self::core_asset_id();
+		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
+		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
+		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
+
+		Self::calculate_sell_price(sell_amount, core_asset_reserve, trade_asset_reserve)
+	}
+
 	fn calculate_sell_price(
 		input_amount: T::Balance,
 		input_reserve: T::Balance,
@@ -472,44 +573,9 @@ impl<T: Trait> Module<T> {
 		Ok(price)
 	}
 
-	/// `asset_id` - Trade asset
-	/// `buy_amount` - Amount of output core
-	/// Returns the amount of trade assets needed to buy `buy_amount` core assets.
-	pub fn get_asset_to_core_buy_price(
-		asset_id: &T::AssetId,
-		buy_amount: T::Balance,
-	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		ensure!(buy_amount > Zero::zero(), Error::<T>::BuyAmountNotPositive);
-
-		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
-
-		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
-
-		Self::calculate_buy_price(buy_amount, trade_asset_reserve, core_asset_reserve)
-	}
-
-	/// Returns the amount of trade asset to pay for `sell_amount` of core sold.
-	///
-	/// `asset_id` - Trade asset
-	/// `sell_amount` - Amount of input core to sell
-	pub fn get_core_to_asset_sell_price(
-		asset_id: &T::AssetId,
-		sell_amount: T::Balance,
-	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		ensure!(
-			sell_amount > Zero::zero(),
-			Error::<T>::CoreToAssetSellAmountNotAboveZero
-		);
-
-		let core_asset_id = Self::core_asset_id();
-		let exchange_address = T::ExchangeAddressGenerator::exchange_address_for(*asset_id);
-		let core_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&core_asset_id, &exchange_address);
-		let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(asset_id, &exchange_address);
-
-		Self::calculate_sell_price(sell_amount, core_asset_reserve, trade_asset_reserve)
-	}
+	//
+	// Trade functions
+	//
 
 	/// Buy `amount_to_buy` of `asset_to_buy` with `asset_to_sell`.
 	///
@@ -653,65 +719,4 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
-	/// Get the buy price of some asset for another
-	/// In simple terms: 'If I want to buy _x_ amount of asset _a_ how much of asset _b_ will it cost?'
-	/// `asset_to_buy` is the asset to buy
-	/// `amount_to_buy` is the amount of `asset_to_buy` required
-	/// `asset_to_pay` is the asset to use for payment (the final price will be given in this asset)
-	pub fn get_buy_price(
-		asset_to_buy: T::AssetId,
-		amount_to_buy: T::Balance,
-		asset_to_pay: T::AssetId,
-	) -> Result<T::Balance, DispatchError> {
-		ensure!(asset_to_buy != asset_to_pay, Error::<T>::AssetCannotSwapForItself);
-
-		// Find the cost of `amount_to_buy` of `asset_to_buy` in terms of core asset
-		// (how much core asset does it cost?).
-		let core_asset_amount = if asset_to_buy == Self::core_asset_id() {
-			amount_to_buy
-		} else {
-			Self::get_core_to_asset_buy_price(&asset_to_buy, amount_to_buy)?
-		};
-
-		// Find the price of `core_asset_amount` in terms of `asset_to_pay`
-		// (how much `asset_to_pay` does `core_asset_amount` cost?)
-		let pay_asset_amount = if asset_to_pay == Self::core_asset_id() {
-			core_asset_amount
-		} else {
-			Self::get_asset_to_core_buy_price(&asset_to_pay, core_asset_amount)?
-		};
-
-		Ok(pay_asset_amount)
-	}
-
-	/// Get the sell price of some asset for another
-	/// In simple terms: 'If I sell _x_ amount of asset _a_ how much of asset _b_ will I get in return?'
-	/// `asset_to_sell` is the asset to be sold
-	/// `amount_to_sell` is the amount of `asset_to_sell` to be sold
-	/// `asset_to_payout` is the asset to be paid out in exchange for the sale of `asset_to_sell` (the final sale value is given in this asset)
-	pub fn get_sell_price(
-		asset_to_sell: T::AssetId,
-		amount_to_sell: T::Balance,
-		asset_to_payout: T::AssetId,
-	) -> Result<T::Balance, DispatchError> {
-		ensure!(asset_to_sell != asset_to_payout, Error::<T>::AssetCannotSwapForItself);
-
-		// Find the value of `amount_to_sell` of `asset_to_sell` in terms of core asset
-		// (how much core asset is the sale worth?)
-		let core_asset_amount = if asset_to_sell == Self::core_asset_id() {
-			amount_to_sell
-		} else {
-			Self::get_asset_to_core_sell_price(&asset_to_sell, amount_to_sell)?
-		};
-
-		// Skip payout asset price if asset to be paid out is core
-		// (how much `asset_to_payout` is the sale worth?)
-		let payout_asset_value = if asset_to_payout == Self::core_asset_id() {
-			core_asset_amount
-		} else {
-			Self::get_core_to_asset_sell_price(&asset_to_payout, core_asset_amount)?
-		};
-
-		Ok(payout_asset_value)
-	}
 }

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -429,23 +429,27 @@ impl<T: Trait> Module<T> {
 		Self::calculate_buy_price(buy_amount, core_reserve, asset_reserve)
 	}
 
+	/// `buy_amount` - Amount to buy
+	/// `sell_reserve`- How much of the asset to sell is in the exchange
+	/// `buy_reserve` - How much of the asset to buy is in the exchange
+	/// Returns the amount of sellable asset is required
 	fn calculate_buy_price(
-		output_amount: T::Balance,
-		input_reserve: T::Balance,
-		output_reserve: T::Balance,
+		buy_amount: T::Balance,
+		sell_reserve: T::Balance,
+		buy_reserve: T::Balance,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(
-			!input_reserve.is_zero() && !output_reserve.is_zero(),
+			!sell_reserve.is_zero() && !buy_reserve.is_zero(),
 			Error::<T>::EmptyExchangePool
 		);
-		ensure!(output_reserve > output_amount, Error::<T>::InsufficientAssetReserve);
+		ensure!(buy_reserve > buy_amount, Error::<T>::InsufficientAssetReserve);
 
-		let output_amount_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(output_amount).into());
-		let output_reserve_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(output_reserve).into());
-		let input_reserve_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(input_reserve).into());
-		let denominator_hp = output_reserve_hp - output_amount_hp;
-		let price_hp = input_reserve_hp
-			.saturating_mul(output_amount_hp)
+		let buy_amount_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(buy_amount).into());
+		let buy_reserve_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(buy_reserve).into());
+		let sell_reserve_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(sell_reserve).into());
+		let denominator_hp = buy_reserve_hp - buy_amount_hp;
+		let price_hp = sell_reserve_hp
+			.saturating_mul(buy_amount_hp)
 			.checked_div(denominator_hp)
 			.ok_or::<Error<T>>(Error::<T>::DivideByZero)?;
 
@@ -537,13 +541,17 @@ impl<T: Trait> Module<T> {
 		Self::calculate_sell_price(sell_amount, core_asset_reserve, trade_asset_reserve)
 	}
 
+	/// `sell_amount` - Amount to sell
+	/// `sell_reserve`- How much of the asset to sell is in the exchange
+	/// `buy_reserve` - How much of the asset to buy is in the exchange
+	/// Returns the amount of buyable asset that would be received
 	fn calculate_sell_price(
-		input_amount: T::Balance,
-		input_reserve: T::Balance,
-		output_reserve: T::Balance,
+		sell_amount: T::Balance,
+		sell_reserve: T::Balance,
+		buy_reserve: T::Balance,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
 		ensure!(
-			!input_reserve.is_zero() && !output_reserve.is_zero(),
+			!sell_reserve.is_zero() && !buy_reserve.is_zero(),
 			Error::<T>::EmptyExchangePool
 		);
 
@@ -551,16 +559,16 @@ impl<T: Trait> Module<T> {
 			.checked_add(FeeRate::<PerMillion>::one())
 			.ok_or::<Error<T>>(Error::<T>::Overflow)?;
 
-		let input_amount_scaled = FeeRate::<PerMillion>::from(T::BalanceToUnsignedInt::from(input_amount).into())
+		let sell_amount_scaled = FeeRate::<PerMillion>::from(T::BalanceToUnsignedInt::from(sell_amount).into())
 			.checked_div(div_rate)
 			.ok_or::<Error<T>>(Error::<T>::DivideByZero)?;
 
-		let input_reserve_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(input_reserve).into());
-		let output_reserve_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(output_reserve).into());
-		let input_amount_scaled_hp = HighPrecisionUnsigned::from(LowPrecisionUnsigned::from(input_amount_scaled));
-		let denominator_hp = input_amount_scaled_hp + input_reserve_hp;
-		let price_hp = output_reserve_hp
-			.saturating_mul(input_amount_scaled_hp)
+		let sell_reserve_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(sell_reserve).into());
+		let buy_reserve_hp = HighPrecisionUnsigned::from(T::BalanceToUnsignedInt::from(buy_reserve).into());
+		let sell_amount_scaled_hp = HighPrecisionUnsigned::from(LowPrecisionUnsigned::from(sell_amount_scaled));
+		let denominator_hp = sell_amount_scaled_hp + sell_reserve_hp;
+		let price_hp = buy_reserve_hp
+			.saturating_mul(sell_amount_scaled_hp)
 			.checked_div(denominator_hp)
 			.ok_or::<Error<T>>(Error::<T>::DivideByZero)?;
 
@@ -569,7 +577,7 @@ impl<T: Trait> Module<T> {
 		let price_lp = price_lp_result.unwrap();
 
 		let price = T::UnsignedIntToBalance::from(price_lp).into();
-		ensure!(output_reserve > price, Error::<T>::InsufficientAssetReserve);
+		ensure!(buy_reserve > price, Error::<T>::InsufficientAssetReserve);
 		Ok(price)
 	}
 

--- a/crml/cennzx-spot/src/mock.rs
+++ b/crml/cennzx-spot/src/mock.rs
@@ -16,9 +16,93 @@
 //! Define mock currencies
 #![cfg(test)]
 
-use crate::Trait;
+#![macro_use]
+
 use frame_support::additional_traits::AssetIdAuthority;
 use pallet_generic_asset::AssetCurrency;
+
+use crate::{
+	impls::ExchangeAddressGenerator,
+	types::{FeeRate, LowPrecisionUnsigned, PerMilli, PerMillion},
+	Call, GenesisConfig, Module, Trait,
+};
+use core::convert::TryFrom;
+use frame_support::{additional_traits::DummyDispatchVerifier, impl_outer_origin};
+use pallet_generic_asset;
+use sp_core::{sr25519, H256};
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
+	Perbill,
+};
+
+pub type AccountId = <<sr25519::Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+impl_outer_origin! {
+	pub enum Origin for Test where system = frame_system {}
+}
+
+// For testing the module, we construct most of a mock runtime. This means
+// first constructing a configuration type (`Test`) which `impl`s each of the
+// configuration traits of modules we want to use.
+#[derive(Clone, Eq, PartialEq)]
+pub struct Test;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: u32 = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+impl frame_system::Trait for Test {
+	type Origin = Origin;
+	type Call = ();
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<AccountId>;
+	type Header = Header;
+	type Event = ();
+	type BlockHashCount = BlockHashCount;
+	type Doughnut = ();
+	type DelegatedDispatchVerifier = DummyDispatchVerifier<Self::Doughnut, Self::AccountId>;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
+	type ModuleToIndex = ();
+}
+
+impl pallet_generic_asset::Trait for Test {
+	type Balance = LowPrecisionUnsigned;
+	type AssetId = u32;
+	type Event = ();
+}
+
+pub struct UnsignedIntToBalance(LowPrecisionUnsigned);
+impl From<LowPrecisionUnsigned> for UnsignedIntToBalance {
+	fn from(u: LowPrecisionUnsigned) -> Self {
+		UnsignedIntToBalance(u)
+	}
+}
+impl From<UnsignedIntToBalance> for LowPrecisionUnsigned {
+	fn from(u: UnsignedIntToBalance) -> Self {
+		u.0
+	}
+}
+
+impl Trait for Test {
+	type Call = Call<Self>;
+	type Event = ();
+	type ExchangeAddressGenerator = ExchangeAddressGenerator<Self>;
+	type BalanceToUnsignedInt = LowPrecisionUnsigned;
+	type UnsignedIntToBalance = UnsignedIntToBalance;
+}
+
+pub type CennzXSpot = Module<Test>;
 
 pub const CORE_ASSET_ID: u32 = 0;
 pub const TRADE_ASSET_A_ID: u32 = 1;
@@ -65,3 +149,121 @@ impl<T: Trait> AssetIdAuthority for FeeAssetIdProvider<T> {
 		FEE_ASSET_ID.into()
 	}
 }
+
+pub struct ExtBuilder {
+	core_asset_id: u32,
+	fee_rate: FeeRate<PerMillion>,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self {
+			core_asset_id: 0,
+			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(),
+		}
+	}
+}
+
+impl ExtBuilder {
+	pub fn build(self) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+		pallet_generic_asset::GenesisConfig::<Test> {
+			assets: Vec::new(),
+			initial_balance: 0,
+			endowed_accounts: Vec::new(),
+			next_asset_id: 100,
+			staking_asset_id: 0,
+			spending_asset_id: 10,
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+		GenesisConfig::<Test> {
+			core_asset_id: self.core_asset_id,
+			fee_rate: self.fee_rate,
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+		sp_io::TestExternalities::new(t)
+	}
+}
+
+// Helper Macros
+
+/// Returns the matching asset ID for a currency given it's type alias
+/// It's a quick work around to avoid complex trait logic using `AssetIdAuthority`
+macro_rules! resolve_asset_id (
+	(CoreAssetCurrency) => { CORE_ASSET_ID };
+	(TradeAssetCurrencyA) => { TRADE_ASSET_A_ID };
+	(TradeAssetCurrencyB) => { TRADE_ASSET_B_ID };
+	(FeeAssetCurrency) => { FEE_ASSET_ID };
+	($unknown:literal) => { panic!("cannot resolve asset ID for unknown currency: {}", $unknown) };
+);
+
+/// Initializes an exchange pair with the given liquidity
+/// `with_exchange!(asset1_id => balance, asset2_id => balance)`
+macro_rules! with_exchange (
+	($a1:ident => $b1:expr, $a2:ident => $b2:expr) => {
+		{
+			let exchange_address = <Test as Trait>::ExchangeAddressGenerator::exchange_address_for(
+				resolve_asset_id!($a2),
+			);
+			let _ = $a1::deposit_creating(&exchange_address, $b1);
+			let _ = $a2::deposit_creating(&exchange_address, $b2);
+		}
+	};
+);
+
+/// Assert an exchange pair has a balance equal to
+/// `assert_exchange_balance_eq!(0 => 10, 1 => 15)`
+macro_rules! assert_exchange_balance_eq (
+	($a1:ident => $b1:expr, $a2:ident => $b2:expr) => {
+		{
+			let exchange_address = <Test as Trait>::ExchangeAddressGenerator::exchange_address_for(
+				resolve_asset_id!($a2),
+			);
+			let bal1 = $a1::free_balance(&exchange_address);
+			let bal2 = $a2::free_balance(&exchange_address);
+			assert_eq!(bal1, $b1);
+			assert_eq!(bal2, $b2);
+		}
+	};
+);
+
+/// Initializes a preset address with the given exchange balance.
+/// Examples
+/// ```
+/// let andrea = with_account!(0 => 10, 1 => 20);
+/// let bob = with_account!("bob", 0 => 10, 1 => 20);
+/// ```
+macro_rules! with_account (
+	($a1:ident => $b1:expr, $a2:ident => $b2:expr) => {
+		{
+			let _ = $a1::deposit_creating(&H256::from_low_u64_be(1).unchecked_into(), $b1);
+			let _ = $a2::deposit_creating(&H256::from_low_u64_be(1).unchecked_into(), $b2);
+			H256::from_low_u64_be(1).unchecked_into()
+		}
+	};
+	($name:expr, $a1:ident => $b1:expr, $a2:ident => $b2:expr) => {
+		{
+			let account = match $name {
+				"andrea" => H256::from_low_u64_be(1).unchecked_into(),
+				"bob" => H256::from_low_u64_be(2).unchecked_into(),
+				"charlie" => H256::from_low_u64_be(3).unchecked_into(),
+				_ => H256::from_low_u64_be(1).unchecked_into(), // default back to "andrea"
+			};
+			let _ = $a1::deposit_creating(&account, $b1);
+			let _ = $a2::deposit_creating(&account, $b2);
+			account
+		}
+	};
+);
+
+/// Assert account has asset balance equal to
+// alias for `assert_eq!(<pallet_generic_asset::Module<Test>>::free_balance(asset_id, address), amount)`
+macro_rules! assert_balance_eq (
+	($address:expr, $asset_id:ident => $balance:expr) => {
+		{
+			assert_eq!($asset_id::free_balance(&$address), $balance);
+		}
+	};
+);

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -1296,14 +1296,14 @@ fn set_fee_rate() {
 }
 
 #[test]
-fn calculate_buy_price_simple() {
+fn get_buy_price_simple() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyB),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1314,14 +1314,14 @@ fn calculate_buy_price_simple() {
 }
 
 #[test]
-fn calculate_buy_price_with_fee_rate() {
+fn get_buy_price_with_fee_rate() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 100_000.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyB),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1332,13 +1332,13 @@ fn calculate_buy_price_with_fee_rate() {
 }
 
 #[test]
-fn calculate_buy_price_when_buying_core() {
+fn get_buy_price_when_buying_core() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(CoreAssetCurrency),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1349,13 +1349,13 @@ fn calculate_buy_price_when_buying_core() {
 }
 
 #[test]
-fn calculate_buy_price_when_selling_core() {
+fn get_buy_price_when_selling_core() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(CoreAssetCurrency),
@@ -1366,12 +1366,12 @@ fn calculate_buy_price_when_selling_core() {
 }
 
 #[test]
-fn calculate_buy_price_same_asset_id_ignored() {
+fn get_buy_price_same_asset_id_ignored() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1382,13 +1382,13 @@ fn calculate_buy_price_same_asset_id_ignored() {
 }
 
 #[test]
-fn calculate_buy_price_low_buy_asset_liquidity_error() {
+fn get_buy_price_low_buy_asset_liquidity_error() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyA => 10);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1399,13 +1399,13 @@ fn calculate_buy_price_low_buy_asset_liquidity_error() {
 }
 
 #[test]
-fn calculate_buy_price_low_buy_core_liquidity_error() {
+fn get_buy_price_low_buy_core_liquidity_error() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyB => 10);
 
 		assert_err!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1416,12 +1416,12 @@ fn calculate_buy_price_low_buy_core_liquidity_error() {
 }
 
 #[test]
-fn calculate_buy_price_no_exchange() {
+fn get_buy_price_no_exchange() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1432,14 +1432,14 @@ fn calculate_buy_price_no_exchange() {
 }
 
 #[test]
-fn calculate_sell_price_simple() {
+fn get_sell_price_simple() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyB),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1450,14 +1450,14 @@ fn calculate_sell_price_simple() {
 }
 
 #[test]
-fn calculate_sell_price_with_fee_rate() {
+fn get_sell_price_with_fee_rate() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 100_000.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyB),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1468,13 +1468,13 @@ fn calculate_sell_price_with_fee_rate() {
 }
 
 #[test]
-fn calculate_sell_price_when_selling_core() {
+fn get_sell_price_when_selling_core() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(CoreAssetCurrency),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1485,13 +1485,13 @@ fn calculate_sell_price_when_selling_core() {
 }
 
 #[test]
-fn calculate_sell_price_when_buying_core() {
+fn get_sell_price_when_buying_core() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(CoreAssetCurrency),
@@ -1502,12 +1502,12 @@ fn calculate_sell_price_when_buying_core() {
 }
 
 #[test]
-fn calculate_sell_price_same_asset_id_ignored() {
+fn get_sell_price_same_asset_id_ignored() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1518,13 +1518,13 @@ fn calculate_sell_price_same_asset_id_ignored() {
 }
 
 #[test]
-fn calculate_sell_price_low_sell_asset_liquidity() {
+fn get_sell_price_low_sell_asset_liquidity() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyB => 10);
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1535,13 +1535,13 @@ fn calculate_sell_price_low_sell_asset_liquidity() {
 }
 
 #[test]
-fn calculate_sell_price_low_sell_core_liquidity() {
+fn get_sell_price_low_sell_core_liquidity() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyB => 10);
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1552,12 +1552,12 @@ fn calculate_sell_price_low_sell_core_liquidity() {
 }
 
 #[test]
-fn calculate_sell_price_no_exchange() {
+fn get_sell_price_no_exchange() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -257,17 +257,17 @@ fn investor_can_add_liquidity() {
 }
 
 #[test]
-fn get_output_price_zero_cases() {
+fn calculate_buy_price_zero_cases() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::get_output_price(100, 0, 10),
+			CennzXSpot::calculate_buy_price(100, 0, 10),
 			Error::<Test>::EmptyExchangePool
 		);
 
 		assert_err!(
-			CennzXSpot::get_output_price(100, 10, 0),
+			CennzXSpot::calculate_buy_price(100, 10, 0),
 			Error::<Test>::EmptyExchangePool
 		);
 	});
@@ -276,12 +276,12 @@ fn get_output_price_zero_cases() {
 /// Formula Price = ((input reserve * output amount) / (output reserve - output amount)) +  1  (round up)
 /// and apply fee rate to the price
 #[test]
-fn get_output_price_for_valid_data() {
+fn calculate_buy_price_for_valid_data() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CennzXSpot::get_output_price(123, 1000, 1000), 141);
+		assert_ok!(CennzXSpot::calculate_buy_price(123, 1000, 1000), 141);
 
 		assert_ok!(
-			CennzXSpot::get_output_price(100_000_000_000_000, 120_627_710_511_649_660, 20_627_710_511_649_660,),
+			CennzXSpot::calculate_buy_price(100_000_000_000_000, 120_627_710_511_649_660, 20_627_710_511_649_660,),
 			589396433540516
 		);
 	});
@@ -290,10 +290,10 @@ fn get_output_price_for_valid_data() {
 /// Formula Price = ((input reserve * output amount) / (output reserve - output amount)) +  1  (round up)
 /// and apply fee rate to the price
 #[test]
-fn get_output_price_for_max_reserve_balance() {
+fn calculate_buy_price_for_max_reserve_balance() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(
-			CennzXSpot::get_output_price(
+			CennzXSpot::calculate_buy_price(
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value(),
@@ -307,10 +307,10 @@ fn get_output_price_for_max_reserve_balance() {
 /// and apply fee rate to the price
 // Overflows as the both input and output reserve is at max capacity and output amount is little less than max of Balance
 #[test]
-fn get_output_price_should_fail_with_max_reserve_and_max_amount() {
+fn calculate_buy_price_should_fail_with_max_reserve_and_max_amount() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_err!(
-			CennzXSpot::get_output_price(
+			CennzXSpot::calculate_buy_price(
 				LowPrecisionUnsigned::max_value() - 100,
 				LowPrecisionUnsigned::max_value(),
 				LowPrecisionUnsigned::max_value(),
@@ -323,17 +323,17 @@ fn get_output_price_should_fail_with_max_reserve_and_max_amount() {
 /// Formula Price = ((input reserve * output amount) / (output reserve - output amount)) +  1  (round up)
 /// and apply fee rate to the price
 #[test]
-fn get_output_price_max_withdrawal() {
+fn calculate_buy_price_max_withdrawal() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::get_output_price(1000, 1000, 1000),
+			CennzXSpot::calculate_buy_price(1000, 1000, 1000),
 			Error::<Test>::InsufficientAssetReserve
 		);
 
 		assert_err!(
-			CennzXSpot::get_output_price(1_000_000, 1000, 1000),
+			CennzXSpot::calculate_buy_price(1_000_000, 1000, 1000),
 			Error::<Test>::InsufficientAssetReserve
 		);
 	});
@@ -754,23 +754,23 @@ fn core_to_asset_transfer_output() {
 /// Calculate input_amount_without_fee using fee rate and input amount and then calculate price
 /// Price = (input_amount_without_fee * output reserve) / (input reserve + input_amount_without_fee)
 #[test]
-fn get_input_price_for_valid_data() {
+fn calculate_sell_price_for_valid_data() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CennzXSpot::get_input_price(123, 1000, 1000), 108);
+		assert_ok!(CennzXSpot::calculate_sell_price(123, 1000, 1000), 108);
 
 		// No f32/f64 types, so we use large values to test precision
 		assert_ok!(
-			CennzXSpot::get_input_price(123_000_000, 1_000_000_000, 1_000_000_000),
+			CennzXSpot::calculate_sell_price(123_000_000, 1_000_000_000, 1_000_000_000),
 			109236233
 		);
 
 		assert_ok!(
-			CennzXSpot::get_input_price(100_000_000_000_000, 120_627_710_511_649_660, 4_999_727_416_279_531_363),
+			CennzXSpot::calculate_sell_price(100_000_000_000_000, 120_627_710_511_649_660, 4_999_727_416_279_531_363),
 			4128948876492407
 		);
 
 		assert_ok!(
-			CennzXSpot::get_input_price(
+			CennzXSpot::calculate_sell_price(
 				100_000_000_000_000,
 				120_627_710_511_649_660,
 				LowPrecisionUnsigned::max_value()
@@ -784,10 +784,10 @@ fn get_input_price_for_valid_data() {
 /// Price = (input_amount_without_fee * output reserve) / (input reserve + input_amount_without_fee)
 // Input amount is half of max(Balance) and output reserve is max(Balance) and input reserve is half of max(Balance)
 #[test]
-fn get_input_price_for_max_reserve_balance() {
+fn calculate_sell_price_for_max_reserve_balance() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(
-			CennzXSpot::get_input_price(
+			CennzXSpot::calculate_sell_price(
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value()

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -1101,14 +1101,14 @@ fn set_fee_rate() {
 }
 
 #[test]
-fn calculate_buy_price_simple() {
+fn get_buy_price_simple() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyB),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1119,14 +1119,14 @@ fn calculate_buy_price_simple() {
 }
 
 #[test]
-fn calculate_buy_price_with_fee_rate() {
+fn get_buy_price_with_fee_rate() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 100_000.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyB),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1137,13 +1137,13 @@ fn calculate_buy_price_with_fee_rate() {
 }
 
 #[test]
-fn calculate_buy_price_when_buying_core() {
+fn get_buy_price_when_buying_core() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(CoreAssetCurrency),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1154,13 +1154,13 @@ fn calculate_buy_price_when_buying_core() {
 }
 
 #[test]
-fn calculate_buy_price_when_selling_core() {
+fn get_buy_price_when_selling_core() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(CoreAssetCurrency),
@@ -1171,12 +1171,12 @@ fn calculate_buy_price_when_selling_core() {
 }
 
 #[test]
-fn calculate_buy_price_same_asset_id_ignored() {
+fn get_buy_price_same_asset_id_ignored() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1187,13 +1187,13 @@ fn calculate_buy_price_same_asset_id_ignored() {
 }
 
 #[test]
-fn calculate_buy_price_low_buy_asset_liquidity_error() {
+fn get_buy_price_low_buy_asset_liquidity_error() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyA => 10);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1204,13 +1204,13 @@ fn calculate_buy_price_low_buy_asset_liquidity_error() {
 }
 
 #[test]
-fn calculate_buy_price_low_buy_core_liquidity_error() {
+fn get_buy_price_low_buy_core_liquidity_error() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyB => 10);
 
 		assert_err!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1221,12 +1221,12 @@ fn calculate_buy_price_low_buy_core_liquidity_error() {
 }
 
 #[test]
-fn calculate_buy_price_no_exchange() {
+fn get_buy_price_no_exchange() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_buy_price(
+			CennzXSpot::get_buy_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1237,14 +1237,14 @@ fn calculate_buy_price_no_exchange() {
 }
 
 #[test]
-fn calculate_sell_price_simple() {
+fn get_sell_price_simple() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyB),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1255,14 +1255,14 @@ fn calculate_sell_price_simple() {
 }
 
 #[test]
-fn calculate_sell_price_with_fee_rate() {
+fn get_sell_price_with_fee_rate() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 100_000.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyB),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1273,13 +1273,13 @@ fn calculate_sell_price_with_fee_rate() {
 }
 
 #[test]
-fn calculate_sell_price_when_selling_core() {
+fn get_sell_price_when_selling_core() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(CoreAssetCurrency),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1290,13 +1290,13 @@ fn calculate_sell_price_when_selling_core() {
 }
 
 #[test]
-fn calculate_sell_price_when_buying_core() {
+fn get_sell_price_when_buying_core() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let _ = CennzXSpot::set_fee_rate(Origin::ROOT, 0.into());
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(CoreAssetCurrency),
@@ -1307,12 +1307,12 @@ fn calculate_sell_price_when_buying_core() {
 }
 
 #[test]
-fn calculate_sell_price_same_asset_id_ignored() {
+fn get_sell_price_same_asset_id_ignored() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -1323,13 +1323,13 @@ fn calculate_sell_price_same_asset_id_ignored() {
 }
 
 #[test]
-fn calculate_sell_price_low_sell_asset_liquidity() {
+fn get_sell_price_low_sell_asset_liquidity() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyB => 10);
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1340,13 +1340,13 @@ fn calculate_sell_price_low_sell_asset_liquidity() {
 }
 
 #[test]
-fn calculate_sell_price_low_sell_core_liquidity() {
+fn get_sell_price_low_sell_core_liquidity() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyB => 10);
 
 		assert_eq!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),
@@ -1357,12 +1357,12 @@ fn calculate_sell_price_low_sell_core_liquidity() {
 }
 
 #[test]
-fn calculate_sell_price_no_exchange() {
+fn get_sell_price_no_exchange() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::calculate_sell_price(
+			CennzXSpot::get_sell_price(
 				resolve_asset_id!(TradeAssetCurrencyA),
 				100,
 				resolve_asset_id!(TradeAssetCurrencyB),

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -68,15 +68,15 @@ fn investor_can_add_liquidity() {
 }
 
 #[test]
-fn get_buy_price_zero_cases() {
+fn calculate_buy_price_zero_cases() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_err!(
-			CennzXSpot::get_output_price(10, 0, 100),
+			CennzXSpot::calculate_buy_price(10, 0, 100),
 			Error::<Test>::EmptyExchangePool
 		);
 
 		assert_err!(
-			CennzXSpot::get_output_price(10, 100, 0),
+			CennzXSpot::calculate_buy_price(10, 100, 0),
 			Error::<Test>::EmptyExchangePool
 		);
 	});
@@ -85,12 +85,12 @@ fn get_buy_price_zero_cases() {
 /// Formula Price = ((input reserve * output amount) / (output reserve - output amount)) +  1  (round up)
 /// and apply fee rate to the price
 #[test]
-fn get_buy_price_for_valid_data() {
+fn calculate_buy_price_for_valid_data() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CennzXSpot::get_output_price(123, 1000, 1000), 141);
+		assert_ok!(CennzXSpot::calculate_buy_price(123, 1000, 1000), 141);
 
 		assert_ok!(
-			CennzXSpot::get_output_price(100_000_000_000_000, 120_627_710_511_649_660, 20_627_710_511_649_660,),
+			CennzXSpot::calculate_buy_price(100_000_000_000_000, 120_627_710_511_649_660, 20_627_710_511_649_660,),
 			589396433540516
 		);
 	});
@@ -99,10 +99,10 @@ fn get_buy_price_for_valid_data() {
 /// Formula Price = ((input reserve * output amount) / (output reserve - output amount)) +  1  (round up)
 /// and apply fee rate to the price
 #[test]
-fn get_buy_price_for_max_reserve_balance() {
+fn calculate_buy_price_for_max_reserve_balance() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(
-			CennzXSpot::get_output_price(
+			CennzXSpot::calculate_buy_price(
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value(),
@@ -116,10 +116,10 @@ fn get_buy_price_for_max_reserve_balance() {
 /// and apply fee rate to the price
 // Overflows as the both input and output reserve is at max capacity and output amount is little less than max of Balance
 #[test]
-fn get_buy_price_should_fail_with_max_reserve_and_max_amount() {
+fn calculate_buy_price_should_fail_with_max_reserve_and_max_amount() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_err!(
-			CennzXSpot::get_output_price(
+			CennzXSpot::calculate_buy_price(
 				LowPrecisionUnsigned::max_value() - 100,
 				LowPrecisionUnsigned::max_value(),
 				LowPrecisionUnsigned::max_value(),
@@ -132,17 +132,17 @@ fn get_buy_price_should_fail_with_max_reserve_and_max_amount() {
 /// Formula Price = ((input reserve * output amount) / (output reserve - output amount)) +  1  (round up)
 /// and apply fee rate to the price
 #[test]
-fn get_buy_price_max_withdrawal() {
+fn calculate_buy_price_max_withdrawal() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
 		assert_err!(
-			CennzXSpot::get_output_price(1000, 1000, 1000),
+			CennzXSpot::calculate_buy_price(1000, 1000, 1000),
 			Error::<Test>::InsufficientAssetReserve
 		);
 
 		assert_err!(
-			CennzXSpot::get_output_price(1_000_000, 1000, 1000),
+			CennzXSpot::calculate_buy_price(1_000_000, 1000, 1000),
 			Error::<Test>::InsufficientAssetReserve
 		);
 	});
@@ -559,23 +559,23 @@ fn core_to_asset_transfer_buy_10_to_1000() {
 /// Calculate input_amount_without_fee using fee rate and input amount and then calculate price
 /// Price = (input_amount_without_fee * output reserve) / (input reserve + input_amount_without_fee)
 #[test]
-fn get_sell_price_works() {
+fn calculate_sell_price_for_valid_data() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(CennzXSpot::get_input_price(123, 1000, 1000), 108);
+		assert_ok!(CennzXSpot::calculate_sell_price(123, 1000, 1000), 108);
 
 		// No f32/f64 types, so we use large values to test precision
 		assert_ok!(
-			CennzXSpot::get_input_price(123_000_000, 1_000_000_000, 1_000_000_000),
+			CennzXSpot::calculate_sell_price(123_000_000, 1_000_000_000, 1_000_000_000),
 			109236233
 		);
 
 		assert_ok!(
-			CennzXSpot::get_input_price(100_000_000_000_000, 120_627_710_511_649_660, 4_999_727_416_279_531_363),
+			CennzXSpot::calculate_sell_price(100_000_000_000_000, 120_627_710_511_649_660, 4_999_727_416_279_531_363),
 			4128948876492407
 		);
 
 		assert_ok!(
-			CennzXSpot::get_input_price(
+			CennzXSpot::calculate_sell_price(
 				100_000_000_000_000,
 				120_627_710_511_649_660,
 				LowPrecisionUnsigned::max_value()
@@ -589,10 +589,10 @@ fn get_sell_price_works() {
 /// Price = (input_amount_without_fee * output reserve) / (input reserve + input_amount_without_fee)
 // Input amount is half of max(Balance) and output reserve is max(Balance) and input reserve is half of max(Balance)
 #[test]
-fn get_sell_price_for_max_reserve_balance() {
+fn calculate_sell_price_for_max_reserve_balance() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(
-			CennzXSpot::get_input_price(
+			CennzXSpot::calculate_sell_price(
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value() / 2,
 				LowPrecisionUnsigned::max_value()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -803,7 +803,7 @@ impl_runtime_apis! {
 			buy_amount: Balance,
 			sell_asset: AssetId,
 		) -> CennzxSpotResult<Balance> {
-			let result = CennzxSpot::calculate_buy_price(buy_asset, buy_amount, sell_asset);
+			let result = CennzxSpot::get_buy_price(buy_asset, buy_amount, sell_asset);
 			match result {
 				Ok(value) => CennzxSpotResult::Success(value),
 				Err(_) => CennzxSpotResult::Error,
@@ -815,7 +815,7 @@ impl_runtime_apis! {
 			sell_amount: Balance,
 			buy_asset: AssetId,
 		) -> CennzxSpotResult<Balance> {
-			let result = CennzxSpot::calculate_sell_price(sell_asset, sell_amount, buy_asset);
+			let result = CennzxSpot::get_sell_price(sell_asset, sell_amount, buy_asset);
 			match result {
 				Ok(value) => CennzxSpotResult::Success(value),
 				Err(_) => CennzxSpotResult::Error,


### PR DESCRIPTION
This is the result of an audit on CENNZxSpot

## Addresses:

- Group get_<>_<>_<buy/sell>_price together logically
- Renaming price functions to clarify intention
- Remove duplication of fetching reserve balances
---

## Concerns:

- none