### PR TITLE
Implement CENNZnut Contract Validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,8 +812,8 @@ dependencies = [
 
 [[package]]
 name = "cennznut"
-version = "0.3.0"
-source = "git+https://github.com/cennznet/cennznut-rs?branch=0.3.0#f0452fff499a57096da315953926dfcca8cf7b8f"
+version = "0.1.1"
+source = "git+https://github.com/cennznet/cennznut-rs?branch=feature/cennznet-integration#400429ad4579ac9b5b04a338cd092bdac6c8c866"
 dependencies = [
  "bit_reverse",
  "pact",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "cennznut"
 version = "0.1.1"
-source = "git+https://github.com/cennznet/cennznut-rs?branch=feature/cennznet-integration#400429ad4579ac9b5b04a338cd092bdac6c8c866"
+source = "git+https://github.com/cennznet/cennznut-rs?branch=0.4.0#f64805d409c4c08730df5bd2175cbbf9715833d3"
 dependencies = [
  "bit_reverse",
  "pact",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/cennznet/cennznet"
 [dependencies]
 # third-party dependencies
 codec = { version = "1.3.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-cennznut = { git = "https://github.com/cennznet/cennznut-rs", default-features = false, branch = "0.3.0" }
+cennznut = { git = "https://github.com/cennznet/cennznut-rs", default-features = false, branch = "feature/cennznet-integration" }
 integer-sqrt = { version = "0.1.2" }
 rustc-hex = { version = "2.0", optional = true }
 serde = { version = "1.0.102", optional = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/cennznet/cennznet"
 [dependencies]
 # third-party dependencies
 codec = { version = "1.3.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-cennznut = { git = "https://github.com/cennznet/cennznut-rs", default-features = false, branch = "feature/cennznet-integration" }
+cennznut = { git = "https://github.com/cennznet/cennznut-rs", default-features = false, branch = "0.4.0" }
 integer-sqrt = { version = "0.1.2" }
 rustc-hex = { version = "2.0", optional = true }
 serde = { version = "1.0.102", optional = true }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -572,9 +572,6 @@ impl Runtime {
 		let address: [u8; 32] = contract_address.clone().into();
 		match cennznut.validate_contract_call(&address) {
 			Ok(r) => Ok(r),
-			Err(ValidationErr::NoPermission(ContractDomain::Contract)) => {
-				Err("CENNZnut does not grant permission for contract")
-			}
 			_ => Err("CENNZnut does not grant permission for contract"),
 		}
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -22,7 +22,7 @@
 #![allow(array_into_iter)]
 
 use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash, Index, Moment, Signature};
-use cennznut::{CENNZnut, Domain, Validate, ValidationErr};
+use cennznut::{CENNZnut, RuntimeDomain, ValidationErr};
 use codec::Decode;
 pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMillion, PerThousand};
 use crml_cennzx_spot_rpc_runtime_api::CennzxSpotResult;
@@ -559,12 +559,12 @@ impl additional_traits::DelegatedDispatchVerifier for Runtime {
 		if module_offset <= 1 || module_offset >= module.len() {
 			return Err("error during module name segmentation");
 		}
-		match cennznut.validate(&module[module_offset..], method, &[]) {
+		match cennznut.validate_runtime_call(&module[module_offset..], method, &[]) {
 			Ok(r) => Ok(r),
 			Err(ValidationErr::ConstraintsInterpretation) => Err("error while interpreting constraints"),
-			Err(ValidationErr::NoPermission(Domain::Method)) => Err("CENNZnut does not grant permission for method"),
-			Err(ValidationErr::NoPermission(Domain::Module)) => Err("CENNZnut does not grant permission for module"),
-			Err(ValidationErr::NoPermission(Domain::MethodArguments)) => {
+			Err(ValidationErr::NoPermission(RuntimeDomain::Method)) => Err("CENNZnut does not grant permission for method"),
+			Err(ValidationErr::NoPermission(RuntimeDomain::Module)) => Err("CENNZnut does not grant permission for module"),
+			Err(ValidationErr::NoPermission(RuntimeDomain::MethodArguments)) => {
 				Err("CENNZnut does not grant permission for method arguments")
 			}
 		}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -555,19 +555,44 @@ impl additional_traits::DelegatedDispatchVerifier for Runtime {
 		let cennznut: CENNZnut = Decode::decode(&mut domain).map_err(|_| "Bad CENNZnut encoding")?;
 
 		// Extract Module name from <prefix>-<Module_name>
-		let module_offset = module.find('-').ok_or("error during module name segmentation")? + 1;
+		let module_offset = module
+			.find('-')
+			.ok_or("CENNZnut does not grant permission for module")?
+			+ 1;
 		if module_offset <= 1 || module_offset >= module.len() {
 			return Err("error during module name segmentation");
 		}
 		match cennznut.validate_runtime_call(&module[module_offset..], method, &[]) {
 			Ok(r) => Ok(r),
 			Err(ValidationErr::ConstraintsInterpretation) => Err("error while interpreting constraints"),
-			Err(ValidationErr::NoPermission(RuntimeDomain::Method)) => Err("CENNZnut does not grant permission for method"),
-			Err(ValidationErr::NoPermission(RuntimeDomain::Module)) => Err("CENNZnut does not grant permission for module"),
+			Err(ValidationErr::NoPermission(RuntimeDomain::Method)) => {
+				Err("CENNZnut does not grant permission for method")
+			}
+			Err(ValidationErr::NoPermission(RuntimeDomain::Module)) => {
+				Err("CENNZnut does not grant permission for module")
+			}
 			Err(ValidationErr::NoPermission(RuntimeDomain::MethodArguments)) => {
 				Err("CENNZnut does not grant permission for method arguments")
 			}
 		}
+	}
+
+	/// Check the doughnut authorizes a dispatched call from runtime to the specified contract address for this domain.
+	fn verify_runtime_to_contract_call(
+		_caller: &Self::AccountId,
+		_doughnut: &Self::Doughnut,
+		_contract_addr: &Self::AccountId,
+	) -> Result<(), &'static str> {
+		Err("Doughnut runtime to contract call verification is not implemented for this domain")
+	}
+
+	/// Check the doughnut authorizes a dispatched call from a contract to another contract with the specified addresses for this domain.
+	fn verify_contract_to_contract_call(
+		_caller: &Self::AccountId,
+		_doughnut: &Self::Doughnut,
+		_contract_addr: &Self::AccountId,
+	) -> Result<(), &'static str> {
+		Err("Doughnut contract to contract call verification is not implemented for this domain")
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -22,12 +22,10 @@
 #![allow(array_into_iter)]
 
 use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash, Index, Moment, Signature};
-use cennznut::{CENNZnut, RuntimeDomain, ValidationErr};
-use codec::Decode;
 pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMillion, PerThousand};
 use crml_cennzx_spot_rpc_runtime_api::CennzxSpotResult;
 use frame_support::{
-	additional_traits::{self, MultiCurrencyAccounting},
+	additional_traits::MultiCurrencyAccounting,
 	construct_runtime, debug, parameter_types,
 	traits::{Randomness, SplitTwoWays},
 	weights::Weight,
@@ -47,9 +45,7 @@ use sp_core::u32_trait::{_0, _1, _2, _4};
 use sp_core::OpaqueMetadata;
 use sp_inherents::{CheckInherentsResult, InherentData};
 use sp_runtime::curve::PiecewiseLinear;
-use sp_runtime::traits::{
-	self, BlakeTwo256, Block as BlockT, IdentityLookup, OpaqueKeys, PlugDoughnutApi, SaturatedConversion,
-};
+use sp_runtime::traits::{self, BlakeTwo256, Block as BlockT, IdentityLookup, OpaqueKeys, SaturatedConversion};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{create_runtime_str, generic, impl_opaque_keys, ApplyExtrinsicResult, Perbill, Percent, Permill};
 use sp_std::prelude::*;
@@ -73,8 +69,8 @@ pub use crml_sylo::vault as sylo_vault;
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
 use impls::{
-	CurrencyToVoteHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee, SplitToAllValidators,
-	TargetedFeeAdjustment,
+	CENNZnetDispatchVerifier, CurrencyToVoteHandler, GasHandler, GasMeteredCallResolver, LinearWeightToFee,
+	SplitToAllValidators, TargetedFeeAdjustment,
 };
 
 /// Constant values used within the runtime.
@@ -131,7 +127,7 @@ impl frame_system::Trait for Runtime {
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Doughnut = prml_doughnut::PlugDoughnut<Runtime>;
-	type DelegatedDispatchVerifier = Runtime;
+	type DelegatedDispatchVerifier = CENNZnetDispatchVerifier;
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
@@ -538,94 +534,6 @@ impl frame_system::offchain::CreateTransaction<Runtime, UncheckedExtrinsic> for 
 		let signature = TSigner::sign(public, &raw_payload)?;
 		let (call, extra, _) = raw_payload.deconstruct();
 		Some((call, (account, signature, extra)))
-	}
-}
-
-/// `DelegatedDispatchVerifier` helpers
-impl Runtime {
-	/// Checks if the doughnut holds a `cennznut` and if so, it returns the decoded `cennznut`
-	fn get_cennznut(doughnut: &<Runtime as frame_system::Trait>::Doughnut) -> Result<CENNZnut, &'static str> {
-		let mut domain = doughnut
-			.get_domain(<Runtime as additional_traits::DelegatedDispatchVerifier>::DOMAIN)
-			.ok_or("CENNZnut does not grant permission for cennznet domain")?;
-		let cennznut: CENNZnut = Decode::decode(&mut domain).map_err(|_| "Bad CENNZnut encoding")?;
-		Ok(cennznut)
-	}
-
-	/// Verify that the smart contract being called is permissioned in the cennznut
-	fn check_contract(
-		contract_address: &<Runtime as frame_system::Trait>::AccountId,
-		cennznut: CENNZnut,
-	) -> Result<(), &'static str> {
-		let address: [u8; 32] = contract_address.clone().into();
-		match cennznut.validate_contract_call(&address) {
-			Ok(r) => Ok(r),
-			_ => Err("CENNZnut does not grant permission for contract"),
-		}
-	}
-}
-
-/// Verify a Doughnut proof authorizes method dispatch given some input parameters
-impl additional_traits::DelegatedDispatchVerifier for Runtime {
-	type Doughnut = <Self as frame_system::Trait>::Doughnut;
-	type AccountId = <Self as frame_system::Trait>::AccountId;
-
-	const DOMAIN: &'static str = "cennznet";
-
-	fn verify_dispatch(doughnut: &Self::Doughnut, module: &str, method: &str) -> Result<(), &'static str> {
-		let cennznut: CENNZnut = Self::get_cennznut(doughnut)?;
-
-		// Extract Module name from <prefix>-<Module_name>
-		let module_offset = module
-			.find('-')
-			.ok_or("CENNZnut does not grant permission for module")?
-			+ 1;
-		if module_offset <= 1 || module_offset >= module.len() {
-			return Err("error during module name segmentation");
-		}
-		match cennznut.validate_runtime_call(&module[module_offset..], method, &[]) {
-			Ok(r) => Ok(r),
-			Err(ValidationErr::ConstraintsInterpretation) => Err("error while interpreting constraints"),
-			Err(ValidationErr::NoPermission(RuntimeDomain::Method)) => {
-				Err("CENNZnut does not grant permission for method")
-			}
-			Err(ValidationErr::NoPermission(RuntimeDomain::Module)) => {
-				Err("CENNZnut does not grant permission for module")
-			}
-			Err(ValidationErr::NoPermission(RuntimeDomain::MethodArguments)) => {
-				Err("CENNZnut does not grant permission for method arguments")
-			}
-		}
-	}
-
-	/// Verify that the contract being called is permissioned on the doughnut
-	/// This is used in two cases:
-	/// * Case 1 - The `holder` of a doughnut wants to invoke a smart contract as the `issuer`
-	/// * Case 2 - The `issuer` wants to execute a contract but only with the permissions avaliable
-	///            in the doughnut being sent. (not implemented yet)
-	fn verify_runtime_to_contract_call(
-		caller: &Self::AccountId,
-		doughnut: &Self::Doughnut,
-		contract_addr: &Self::AccountId,
-	) -> Result<(), &'static str> {
-		if caller.clone() == doughnut.issuer() {
-			// Case 1 - account delegation call of a smart contract
-			let cennznut: CENNZnut = Self::get_cennznut(doughnut)?;
-			return Self::check_contract(contract_addr, cennznut);
-		}
-		Err("Invalid doughnut caller")
-	}
-
-	/// This is used when an issuer delegates permissions to a smart contract
-	/// It should verify that a contract being called by the smart contract is
-	/// permissioned. Not implemented yet.
-	fn verify_contract_to_contract_call(
-		_caller: &Self::AccountId,
-		doughnut: &Self::Doughnut,
-		_contract_addr: &Self::AccountId,
-	) -> Result<(), &'static str> {
-		let _: CENNZnut = Self::get_cennznut(doughnut)?;
-		Ok(()) // Just return OK for now
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -541,6 +541,18 @@ impl frame_system::offchain::CreateTransaction<Runtime, UncheckedExtrinsic> for 
 	}
 }
 
+/// `DelegatedDispatchVerifier` helpers
+impl Runtime {
+	/// Checks if the doughnut holds a `cennznut` and if so, it returns the decoded `cennznut`
+	fn get_cennznut(doughnut: &<Runtime as frame_system::Trait>::Doughnut) -> Result<CENNZnut, &'static str> {
+		let mut domain = doughnut
+			.get_domain(<Runtime as additional_traits::DelegatedDispatchVerifier>::DOMAIN)
+			.ok_or("CENNZnut does not grant permission for cennznet domain")?;
+		let cennznut: CENNZnut = Decode::decode(&mut domain).map_err(|_| "Bad CENNZnut encoding")?;
+		Ok(cennznut)
+	}
+}
+
 /// Verify a Doughnut proof authorizes method dispatch given some input parameters
 impl additional_traits::DelegatedDispatchVerifier for Runtime {
 	type Doughnut = <Self as frame_system::Trait>::Doughnut;
@@ -549,10 +561,7 @@ impl additional_traits::DelegatedDispatchVerifier for Runtime {
 	const DOMAIN: &'static str = "cennznet";
 
 	fn verify_dispatch(doughnut: &Self::Doughnut, module: &str, method: &str) -> Result<(), &'static str> {
-		let mut domain = doughnut
-			.get_domain(Self::DOMAIN)
-			.ok_or("CENNZnut does not grant permission for cennznet domain")?;
-		let cennznut: CENNZnut = Decode::decode(&mut domain).map_err(|_| "Bad CENNZnut encoding")?;
+		let cennznut: CENNZnut = Self::get_cennznut(doughnut)?;
 
 		// Extract Module name from <prefix>-<Module_name>
 		let module_offset = module
@@ -580,19 +589,21 @@ impl additional_traits::DelegatedDispatchVerifier for Runtime {
 	/// Check the doughnut authorizes a dispatched call from runtime to the specified contract address for this domain.
 	fn verify_runtime_to_contract_call(
 		_caller: &Self::AccountId,
-		_doughnut: &Self::Doughnut,
+		doughnut: &Self::Doughnut,
 		_contract_addr: &Self::AccountId,
 	) -> Result<(), &'static str> {
-		Err("Doughnut runtime to contract call verification is not implemented for this domain")
+		let _cennznut: CENNZnut = Self::get_cennznut(doughnut)?;
+		Ok(())
 	}
 
 	/// Check the doughnut authorizes a dispatched call from a contract to another contract with the specified addresses for this domain.
 	fn verify_contract_to_contract_call(
 		_caller: &Self::AccountId,
-		_doughnut: &Self::Doughnut,
+		doughnut: &Self::Doughnut,
 		_contract_addr: &Self::AccountId,
 	) -> Result<(), &'static str> {
-		Err("Doughnut contract to contract call verification is not implemented for this domain")
+		let _cennznut: CENNZnut = Self::get_cennznut(doughnut)?;
+		Ok(())
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -608,12 +608,12 @@ impl additional_traits::DelegatedDispatchVerifier for Runtime {
 		doughnut: &Self::Doughnut,
 		contract_addr: &Self::AccountId,
 	) -> Result<(), &'static str> {
-		if caller.clone() == doughnut.holder() {
+		if caller.clone() == doughnut.issuer() {
 			// Case 1 - account delegation call of a smart contract
 			let cennznut: CENNZnut = Self::get_cennznut(doughnut)?;
 			return Self::check_contract(contract_addr, cennznut);
 		}
-		Err("Invalid doughnut holder")
+		Err("Invalid doughnut caller")
 	}
 
 	/// This is used when an issuer delegates permissions to a smart contract

--- a/runtime/tests/doughnut.rs
+++ b/runtime/tests/doughnut.rs
@@ -46,18 +46,19 @@ fn verify_dispatch(doughnut: &CennznetDoughnut, module: &str, method: &str) -> R
 
 // A helper to make test CENNZnuts
 fn make_cennznut(module: &str, method: &str) -> CENNZnut {
-	let method_obj = cennznut::Method {
+	let method_obj = cennznut::v0::method::Method {
 		name: method.to_string(),
 		block_cooldown: None,
 		constraints: None,
 	};
-	let module_obj = cennznut::Module {
+	let module_obj = cennznut::v0::module::Module {
 		name: module.to_string(),
 		block_cooldown: None,
 		methods: vec![(method.to_string(), method_obj)],
 	};
 	CENNZnut::V0(CENNZnutV0 {
 		modules: vec![(module.to_string(), module_obj)],
+		contracts: Default::default()
 	})
 }
 

--- a/runtime/tests/doughnut.rs
+++ b/runtime/tests/doughnut.rs
@@ -66,7 +66,7 @@ fn verify_contract_to_contract(
 }
 
 // A helper to make test CENNZnuts
-fn make_runtime_cennznut(module: &str, method: &str) -> CENNZnut {
+pub fn make_runtime_cennznut(module: &str, method: &str) -> CENNZnut {
 	let method_obj = cennznut::v0::method::Method {
 		name: method.to_string(),
 		block_cooldown: None,
@@ -84,7 +84,7 @@ fn make_runtime_cennznut(module: &str, method: &str) -> CENNZnut {
 }
 
 // A helper to make test CENNZnuts
-fn make_contract_cennznut(contract_addr: &AccountId) -> CENNZnut {
+pub fn make_contract_cennznut(contract_addr: &AccountId) -> CENNZnut {
 	let address = contract_addr.clone();
 	let contract_obj = cennznut::v0::contract::Contract::new(&address.into());
 	CENNZnut::V0(CENNZnutV0 {
@@ -240,7 +240,7 @@ fn it_succeeds_runtime_to_contract_with_valid_contract() {
 	assert_ok!(verify_runtime_to_contract(
 		&TEST_HOLDER.into(),
 		&doughnut,
-		&[0x11; 32].into()
+		&CONTRACT_ADDRESS.into()
 	));
 }
 
@@ -251,39 +251,6 @@ fn it_fails_runtime_to_contract_with_invalid_holder() {
 	let invalid_holder: [u8; 32] = [0x55; 32];
 	assert_err!(
 		verify_runtime_to_contract(&invalid_holder.into(), &doughnut, &CONTRACT_ADDRESS.into()),
-		"Invalid doughnut holder"
-	);
-}
-
-#[test]
-fn it_fails_contract_to_contract_with_invalid_contract() {
-	let cennznut = make_contract_cennznut(&CONTRACT_ADDRESS.into());
-	let doughnut = make_doughnut("cennznet", cennznut.encode());
-	let unregistered_contract: [u8; 32] = [0x22; 32];
-	assert_err!(
-		verify_contract_to_contract(&TEST_HOLDER.into(), &doughnut, &unregistered_contract.into()),
-		"CENNZnut does not grant permission for contract"
-	);
-}
-
-#[test]
-fn it_succeeds_contract_to_contract_with_valid_contract() {
-	let cennznut = make_contract_cennznut(&CONTRACT_ADDRESS.into());
-	let doughnut = make_doughnut("cennznet", cennznut.encode());
-	assert_ok!(verify_contract_to_contract(
-		&TEST_HOLDER.into(),
-		&doughnut,
-		&CONTRACT_ADDRESS.into()
-	));
-}
-
-#[test]
-fn it_fails_contract_to_contract_with_invalid_holder() {
-	let cennznut = make_contract_cennznut(&CONTRACT_ADDRESS.into());
-	let doughnut = make_doughnut("cennznet", cennznut.encode());
-	let invalid_holder: [u8; 32] = [0x55; 32];
-	assert_err!(
-		verify_contract_to_contract(&invalid_holder.into(), &doughnut, &CONTRACT_ADDRESS.into()),
 		"Invalid doughnut holder"
 	);
 }

--- a/runtime/tests/doughnut.rs
+++ b/runtime/tests/doughnut.rs
@@ -196,3 +196,23 @@ fn it_fails_when_using_contract_cennznut_for_runtime() {
 		"CENNZnut does not grant permission for module"
 	);
 }
+
+#[test]
+fn it_fails_runtime_to_contract_with_incorrect_domain() {
+	let cennznut = make_contract_cennznut([0x11; 32].into());
+	let doughnut = make_doughnut("sendsnet", cennznut.encode());
+	assert_err!(
+		verify_runtime_to_contract(&Default::default(), &doughnut, &[0x11; 32].into()),
+		"CENNZnut does not grant permission for cennznet domain"
+	);
+}
+
+#[test]
+fn it_fails_contract_to_contract_with_incorrect_domain() {
+	let cennznut = make_contract_cennznut([0x11; 32].into());
+	let doughnut = make_doughnut("sendsnet", cennznut.encode());
+	assert_err!(
+		verify_contract_to_contract(&Default::default(), &doughnut, &[0x11; 32].into()),
+		"CENNZnut does not grant permission for cennznet domain"
+	);
+}

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -32,20 +32,16 @@ use frame_support::{
 };
 use frame_system::{EventRecord, Phase};
 use pallet_contracts::{ContractAddressFor, RawEvent};
-use sp_keyring::AccountKeyring;
 use sp_runtime::{
 	testing::Digest,
-	traits::{Convert, DoughnutApi, Hash, Header as HeaderT},
-	transaction_validity::InvalidTransaction,
-	Doughnut, DoughnutV0,
+	traits::{Convert, Hash, Header as HeaderT},
+	transaction_validity::{InvalidTransaction, TransactionValidityError},
+	DispatchError,
 };
 use sp_staking::SessionIndex;
 mod doughnut;
 mod mock;
-use cennznet_runtime::CennznetDoughnut;
-use cennznut::{self, CENNZnut, CENNZnutV0};
 use mock::{validators, ExtBuilder};
-use sp_core::crypto::Pair;
 
 const GENESIS_HASH: [u8; 32] = [69u8; 32];
 const VERSION: u32 = cennznet_runtime::VERSION.spec_version;
@@ -623,76 +619,6 @@ fn generic_asset_transfer_works_with_fee_exchange() {
 }
 
 #[test]
-fn generic_asset_transfer_works_with_doughnut() {
-	let method_obj = cennznut::Method {
-		name: "transfer".to_string(),
-		block_cooldown: None,
-		constraints: None,
-	};
-	let module_obj = cennznut::Module {
-		name: "generic-asset".to_string(),
-		block_cooldown: None,
-		methods: vec![("transfer".to_string(), method_obj)],
-	};
-	let cennznut = CENNZnut::V0(CENNZnutV0 {
-		modules: vec![("generic-asset".to_string(), module_obj)],
-	});
-	let (issuer, holder) = (AccountKeyring::Alice, AccountKeyring::Bob);
-	let mut doughnut = DoughnutV0 {
-		issuer: issuer.to_raw_public(),
-		holder: holder.to_raw_public(),
-		expiry: 3000,
-		not_before: 0,
-		payload_version: 0,
-		signature: [1u8; 64].into(),
-		signature_version: 0,
-		domains: vec![("cennznet".to_string(), cennznut.encode())],
-	};
-	let signature_temp: [u8; 64] = issuer.pair().sign(&doughnut.payload()).into();
-	doughnut.signature = signature_temp.into();
-	let doughnut = Doughnut::V0(doughnut);
-	let cennznet_doughnut = CennznetDoughnut::new(doughnut);
-
-	let balance_amount = 1_000_000 * TransactionBaseFee::get();
-	let transfer_amount = 50;
-	let runtime_call = Call::GenericAsset(pallet_generic_asset::Call::transfer(
-		CENNZ_ASSET_ID,
-		charlie(),
-		transfer_amount,
-	));
-
-	ExtBuilder::default()
-		.initial_balance(balance_amount)
-		.build()
-		.execute_with(|| {
-			// Create an extrinsic where the doughnut is passed
-			let xt = sign(CheckedExtrinsic {
-				signed: Some((bob(), signed_extra(0, 0, Some(cennznet_doughnut), None))),
-				function: runtime_call.clone(),
-			});
-
-			// Initialise block and apply the extrinsic
-			Executive::initialize_block(&header());
-			let r = Executive::apply_extrinsic(xt);
-			assert!(r.is_ok());
-
-			// Check remaining balances
-			assert_eq!(
-				<GenericAsset as MultiCurrency>::free_balance(&bob(), Some(CENNZ_ASSET_ID)),
-				balance_amount, // Bob not be charged
-			);
-			assert_eq!(
-				<GenericAsset as MultiCurrency>::free_balance(&alice(), Some(CENNZ_ASSET_ID)),
-				balance_amount - transfer_amount // transfer is paid by Alice
-			);
-			assert_eq!(
-				<GenericAsset as MultiCurrency>::free_balance(&charlie(), Some(CENNZ_ASSET_ID)),
-				balance_amount + transfer_amount
-			);
-		});
-}
-
-#[test]
 fn contract_fails() {
 	ExtBuilder::default()
 		.initial_balance(1_000_000 * TransactionBaseFee::get())
@@ -1216,12 +1142,84 @@ fn generic_asset_transfer_works_with_doughnut() {
 }
 
 #[test]
+fn generic_asset_transfer_works_with_doughnut_and_fee_exchange_combo() {
+	let cennznut = doughnut::make_runtime_cennznut("generic-asset", "transfer");
+	let doughnut = doughnut::make_doughnut("cennznet", cennznut.encode());
+
+	let balance_amount = 1_000_000 * TransactionBaseFee::get();
+	let transfer_amount = 50;
+	let runtime_call = Call::GenericAsset(pallet_generic_asset::Call::transfer(
+		CENTRAPAY_ASSET_ID,
+		charlie(),
+		transfer_amount,
+	));
+
+	ExtBuilder::default()
+		.initial_balance(balance_amount)
+		.build()
+		.execute_with(|| {
+			let liquidity_core_amount = 100 * TransactionBaseFee::get();
+			let liquidity_asset_amount = 100 * TransactionBaseFee::get();
+			let _ = CennzxSpot::add_liquidity(
+				Origin::signed(ferdie()),
+				CENNZ_ASSET_ID,
+				10, // min_liquidity
+				liquidity_asset_amount,
+				liquidity_core_amount,
+			);
+
+			let fee_exchange = FeeExchange::V1(FeeExchangeV1 {
+				asset_id: CENNZ_ASSET_ID,
+				max_payment: 100_000_000 * TransactionBaseFee::get(),
+			});
+
+			// Create an extrinsic where the doughnut is passed
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((bob(), signed_extra(0, 0, Some(doughnut), Some(fee_exchange)))),
+				function: runtime_call.clone(),
+			});
+
+			// Initialise block and apply the extrinsic
+			Executive::initialize_block(&header());
+			let r = Executive::apply_extrinsic(xt);
+			assert!(r.is_ok());
+
+			// Check remaining balances
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&bob(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount, // Bob does not transfer CPAY
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount - transfer_amount // transfer is paid by Alice
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&charlie(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount + transfer_amount
+			);
+			// Check remaining balances
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&bob(), Some(CENNZ_ASSET_ID)),
+				999994942846075929, // Bob pays fees (in CENNZ)
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&alice(), Some(CENNZ_ASSET_ID)),
+				balance_amount, // Alice does not pay transaction fees
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&charlie(), Some(CENNZ_ASSET_ID)),
+				balance_amount
+			);
+		});
+}
+
+#[test]
 fn contract_call_works_with_doughnut() {
 	let cennznut = doughnut::make_contract_cennznut(&charlie());
 	let doughnut = doughnut::make_doughnut("cennznet", cennznut.encode());
 
 	let balance_amount = 10_000 * TransactionBaseFee::get();
-	let transfer_amount = 100000000000000;
+	let transfer_amount = 100_000_000_000_000;
 	let gas_limit_amount = 10 * ContractTransactionBaseFee::get();
 	let contract_call = Call::Contracts(pallet_contracts::Call::call::<Runtime>(
 		charlie(),
@@ -1245,7 +1243,7 @@ fn contract_call_works_with_doughnut() {
 
 			assert_eq!(
 				<GenericAsset as MultiCurrency>::free_balance(&bob(), Some(CENTRAPAY_ASSET_ID)),
-				9994929990000000, // Bob pays transaction fees
+				9_994_929_990_000_000, // Bob pays transaction fees
 			);
 			assert_eq!(
 				<GenericAsset as MultiCurrency>::free_balance(&charlie(), Some(CENTRAPAY_ASSET_ID)),
@@ -1254,6 +1252,114 @@ fn contract_call_works_with_doughnut() {
 			assert_eq!(
 				<GenericAsset as MultiCurrency>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID)),
 				balance_amount - transfer_amount - 235, // alice pays transfer amount + gas
+			);
+		});
+}
+
+#[test]
+fn contract_call_fails_with_invalid_doughnut_holder() {
+	let cennznut = doughnut::make_contract_cennznut(&charlie());
+	let doughnut = doughnut::make_doughnut("cennznet", cennznut.encode());
+
+	// defined in: prml_doughnut::constants::error_code::VALIDATION_HOLDER_SIGNER_IDENTITY_MISMATCH
+	let validation_holder_signer_identity_mismatch = 180;
+
+	let balance_amount = 10_000 * TransactionBaseFee::get();
+	let transfer_amount = 100_000_000_000_000;
+	let gas_limit_amount = 10 * ContractTransactionBaseFee::get();
+	let contract_call = Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+		charlie(),
+		transfer_amount,
+		gas_limit_amount as u64,
+		vec![],
+	));
+
+	ExtBuilder::default()
+		.initial_balance(balance_amount)
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((dave(), signed_extra(0, 0, Some(doughnut), None))),
+				function: contract_call,
+			});
+			Executive::initialize_block(&header());
+			assert_eq!(
+				Executive::apply_extrinsic(xt),
+				Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(
+					validation_holder_signer_identity_mismatch
+				)))
+			);
+
+			// All accounts stay the same
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount,
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&bob(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount,
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&charlie(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount,
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&dave(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount,
+			);
+		});
+}
+
+#[test]
+fn contract_call_with_doughnut_fails_with_invalid_contract_address() {
+	let cennznut = doughnut::make_contract_cennznut(&charlie());
+	let doughnut = doughnut::make_doughnut("cennznet", cennznut.encode());
+
+	let balance_amount = 10_000 * TransactionBaseFee::get();
+	let transfer_amount = 100_000_000_000_000;
+	let gas_limit_amount = 10 * ContractTransactionBaseFee::get();
+	let contract_call = Call::Contracts(pallet_contracts::Call::call::<Runtime>(
+		dave(), // cennznut permissions charlie, but we will try calling dave
+		transfer_amount,
+		gas_limit_amount as u64,
+		vec![],
+	));
+
+	ExtBuilder::default()
+		.initial_balance(balance_amount)
+		.gas_price(1)
+		.build()
+		.execute_with(|| {
+			let xt = sign(CheckedExtrinsic {
+				signed: Some((bob(), signed_extra(0, 0, Some(doughnut), None))),
+				function: contract_call,
+			});
+			Executive::initialize_block(&header());
+			assert_eq!(
+				Executive::apply_extrinsic(xt),
+				Ok(Err(DispatchError::Other(
+					"CENNZnut does not grant permission for contract"
+				)))
+			);
+
+			// Bob pays transaction fees
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&bob(), Some(CENTRAPAY_ASSET_ID)),
+				9_994_929_990_000_000,
+			);
+			// All other accounts stay the same
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&alice(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount,
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&charlie(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount,
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrency>::free_balance(&dave(), Some(CENTRAPAY_ASSET_ID)),
+				balance_amount,
 			);
 		});
 }


### PR DESCRIPTION
This PR implements the `verify_runtime_to_contract_call` and `verify_contract_to_contract_call` checks for CENNZnuts on CENNZnet.

The goal is an MVP which allows a holder to delegate a contract call to the issuer.

Before this PR is merged, cennznut-rs PR: https://github.com/cennznet/cennznut-rs/pull/47 must be merged and the reference to CENNZnut in the runtime `cargo.toml` must be updated to point to the correct location.

## Changes:

- Update cennznet to use the latest `cennznut-rs` interface (some changes were also required on `cennznut-rs` to expose the required types
- Implement `verify_runtime_to_contract_call`
- Implement `verify_contract_to_contract_call`
- Add some Runtime doughnut/cennznut helpers to reduce duplication
- Have added integration tests

## Concerns:

- None

