### PR TITLE
CENNZxSpot trading interface refactors

### DIFF
--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -111,9 +111,9 @@ decl_module! {
 
 		fn deposit_event() = default;
 
-		/// Buy `asset_to_buy` with `asset_to_sell`. User specifies an exact `buy_amount` and
-		/// a `maximum_sell` amount.
-		/// `origin`
+		/// Buy `asset_to_buy` with `asset_to_sell`.
+		/// User specifies an exact `buy_amount` and a `maximum_sell` amount.
+		///
 		/// `recipient` - Account to receive `buy_amount`, defaults to `origin` if None
 		/// `asset_to_sell` - asset ID to sell
 		/// `asset_to_buy` - asset ID to buy
@@ -139,30 +139,30 @@ decl_module! {
 			Ok(())
 		}
 
-
-		/// Convert asset1 to asset2
-		/// Seller specifies exact input (asset 1) and minimum output (asset 2)
-		/// `recipient` - Account to receive asset_bought, defaults to origin if None
-		/// `asset_sold` - asset ID 1 to sell
-		/// `asset_bought` - asset ID 2 to buy
-		/// `sell_amount` - The amount of asset '1' to sell
-		/// `min_receive` - Minimum trade asset '2' to receive from sale
-		pub fn asset_swap_input(
+		/// Sell `asset_to_sell` for `asset_to_buy`.
+		/// User specifies an exact `sell_amount` and a `minimum_buy` amount.
+		///
+		/// `recipient` - Account to receive `buy_amount`, defaults to `origin` if None
+		/// `asset_to_sell` - asset ID to sell
+		/// `asset_to_buy` - asset ID to buy
+		/// `sell_amount` - The amount `asset_to_buy` to purchase
+		/// `minimum_buy` - Maximum `asset_to_sell` to pay
+		pub fn sell_asset(
 			origin,
 			recipient: Option<T::AccountId>,
-			#[compact] asset_sold: T::AssetId,
-			#[compact] asset_bought: T::AssetId,
+			#[compact] asset_to_sell: T::AssetId,
+			#[compact] asset_to_buy: T::AssetId,
 			#[compact] sell_amount: T::Balance,
-			#[compact] min_receive: T::Balance
+			#[compact] minimum_buy: T::Balance
 		) -> DispatchResult {
-			let seller = ensure_signed(origin)?;
+			let trader = ensure_signed(origin)?;
 			let _ = Self::execute_sell(
-				&seller,
-				&recipient.unwrap_or_else(|| seller.clone()),
-				&asset_sold,
-				&asset_bought,
+				&trader,
+				&recipient.unwrap_or_else(|| trader.clone()),
+				&asset_to_sell,
+				&asset_to_buy,
 				sell_amount,
-				min_receive
+				minimum_buy
 			)?;
 			Ok(())
 		}

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -565,14 +565,14 @@ impl<T: Trait> Module<T> {
 
 	/// Buy `amount_to_buy` of `asset_to_buy` with `asset_to_sell`.
 	///
-	/// `seller` - Account selling `asset_to_sell`
+	/// `trader` - Account selling `asset_to_sell`
 	/// `recipient` - Account to receive `asset_to_buy`
 	/// `asset_to_sell` - asset ID to sell
 	/// `asset_to_buy` - asset ID to buy
 	/// `amount_to_buy` - The amount of `asset_to_buy` to buy
-	/// `maximum_sell` - Maximum acceptable amount of `asset_to_sell` the seller will sell
+	/// `maximum_sell` - Maximum acceptable amount of `asset_to_sell` the trader will sell
 	pub fn execute_buy(
-		seller: &T::AccountId,
+		trader: &T::AccountId,
 		recipient: &T::AccountId,
 		asset_to_sell: &T::AssetId,
 		asset_to_buy: &T::AssetId,
@@ -583,14 +583,14 @@ impl<T: Trait> Module<T> {
 		let amount_to_sell = Self::get_buy_price(*asset_to_buy, amount_to_buy, *asset_to_sell)?;
 		ensure!(amount_to_sell <= maximum_sell, Error::<T>::PriceAboveMaxLimit);
 
-		// Check the seller has enough balance
+		// Check the trader has enough balance
 		ensure!(
-			<pallet_generic_asset::Module<T>>::free_balance(&asset_to_sell, seller) >= amount_to_sell,
+			<pallet_generic_asset::Module<T>>::free_balance(&asset_to_sell, trader) >= amount_to_sell,
 			Error::<T>::InsufficientBalance
 		);
 
 		Self::execute_trade(
-			seller,
+			trader,
 			recipient,
 			asset_to_sell,
 			asset_to_buy,
@@ -603,23 +603,23 @@ impl<T: Trait> Module<T> {
 
 	/// Sell `asset_to_sell` for at least `minimum_buy` of `asset_to_buy`.
 	///
-	/// `seller` - Account selling `asset_to_sell`
+	/// `trader` - Account selling `asset_to_sell`
 	/// `recipient` - Account to receive `asset_to_buy`
 	/// `asset_to_sell` - asset ID to sell
 	/// `asset_to_buy` - asset ID to buy
 	/// `amount_to_sell` - The amount of `asset_to_sell` to sell
 	/// `minimum_buy` - The minimum acceptable amount of `asset_to_buy` to receive
 	pub fn execute_sell(
-		seller: &T::AccountId,
+		trader: &T::AccountId,
 		recipient: &T::AccountId,
 		asset_to_sell: &T::AssetId,
 		asset_to_buy: &T::AssetId,
 		amount_to_sell: T::Balance,
 		minimum_buy: T::Balance,
 	) -> sp_std::result::Result<T::Balance, DispatchError> {
-		// Check the seller has enough balance
+		// Check the trader has enough balance
 		ensure!(
-			<pallet_generic_asset::Module<T>>::free_balance(&asset_to_sell, seller) >= amount_to_sell,
+			<pallet_generic_asset::Module<T>>::free_balance(&asset_to_sell, trader) >= amount_to_sell,
 			Error::<T>::InsufficientBalance
 		);
 
@@ -628,7 +628,7 @@ impl<T: Trait> Module<T> {
 		ensure!(amount_to_buy >= minimum_buy, Error::<T>::SaleValueBelowRequiredMinimum);
 
 		Self::execute_trade(
-			seller,
+			trader,
 			recipient,
 			asset_to_sell,
 			asset_to_buy,
@@ -640,7 +640,7 @@ impl<T: Trait> Module<T> {
 	}
 
 	fn execute_trade(
-		seller: &T::AccountId,
+		trader: &T::AccountId,
 		recipient: &T::AccountId,
 		asset_to_sell: &T::AssetId,
 		asset_to_buy: &T::AssetId,
@@ -659,7 +659,7 @@ impl<T: Trait> Module<T> {
 			};
 			let _ = <pallet_generic_asset::Module<T>>::make_transfer(
 				&asset_to_sell,
-				seller,
+				trader,
 				&exchange_address,
 				amount_to_sell,
 			)
@@ -676,7 +676,7 @@ impl<T: Trait> Module<T> {
 
 			let _ = <pallet_generic_asset::Module<T>>::make_transfer(
 				asset_to_sell,
-				seller,
+				trader,
 				&exchange_address_a,
 				amount_to_sell,
 			)
@@ -697,7 +697,7 @@ impl<T: Trait> Module<T> {
 		Self::deposit_event(RawEvent::AssetPurchase(
 			*asset_to_sell,
 			*asset_to_buy,
-			seller.clone(),
+			trader.clone(),
 			amount_to_sell,
 			amount_to_buy,
 		));

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -111,30 +111,30 @@ decl_module! {
 
 		fn deposit_event() = default;
 
-		/// Convert asset1 to asset2. User specifies maximum
-		/// input and exact output.
-		///  origin
-		/// `recipient` - Account to receive asset_bought, defaults to origin if None
-		/// `asset_sold` - asset ID 1 to sell
-		/// `asset_bought` - asset ID 2 to buy
-		/// `buy_amount` - The amount of asset '2' to purchase
-		/// `max_paying_amount` - Maximum trade asset '1' to pay
-		pub fn asset_swap_output(
+		/// Buy `asset_to_buy` with `asset_to_sell`. User specifies an exact `buy_amount` and
+		/// a `maximum_sell` amount.
+		/// `origin`
+		/// `recipient` - Account to receive `buy_amount`, defaults to `origin` if None
+		/// `asset_to_sell` - asset ID to sell
+		/// `asset_to_buy` - asset ID to buy
+		/// `buy_amount` - The amount `asset_to_buy` to purchase
+		/// `maximum_sell` - Maximum `asset_to_sell` to pay
+		pub fn buy_asset(
 			origin,
 			recipient: Option<T::AccountId>,
-			#[compact] asset_sold: T::AssetId,
-			#[compact] asset_bought: T::AssetId,
+			#[compact] asset_to_sell: T::AssetId,
+			#[compact] asset_to_buy: T::AssetId,
 			#[compact] buy_amount: T::Balance,
-			#[compact] max_paying_amount: T::Balance
+			#[compact] maximum_sell: T::Balance
 		) -> DispatchResult {
-			let buyer = ensure_signed(origin)?;
+			let trader = ensure_signed(origin)?;
 			let _ = Self::execute_buy(
-				&buyer,
-				&recipient.unwrap_or_else(|| buyer.clone()),
-				&asset_sold,
-				&asset_bought,
+				&trader,
+				&recipient.unwrap_or_else(|| trader.clone()),
+				&asset_to_sell,
+				&asset_to_buy,
 				buy_amount,
-				max_paying_amount,
+				maximum_sell,
 			)?;
 			Ok(())
 		}

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -672,7 +672,7 @@ fn asset_to_core_sell() {
 		let trader: AccountId = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 
 		// asset to core swap input
-		assert_ok!(CennzXSpot::asset_swap_input(
+		assert_ok!(CennzXSpot::sell_asset(
 			Origin::signed(trader.clone()),
 			None,
 			resolve_asset_id!(TradeAssetCurrencyA),
@@ -693,7 +693,7 @@ fn core_to_asset_sell() {
 		let trader: AccountId = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 
 		// core to asset swap input
-		assert_ok!(CennzXSpot::asset_swap_input(
+		assert_ok!(CennzXSpot::sell_asset(
 			Origin::signed(trader.clone()),
 			None,
 			<CoreAssetId<Test>>::get(),
@@ -763,7 +763,7 @@ fn asset_sell_error_zero_asset_sold() {
 		let trader: AccountId = with_account!(CoreAssetCurrency => 100, TradeAssetCurrencyA => 100);
 		// asset to core swap input
 		assert_err!(
-			CennzXSpot::asset_swap_input(
+			CennzXSpot::sell_asset(
 				Origin::signed(trader.clone()),
 				None,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -775,7 +775,7 @@ fn asset_sell_error_zero_asset_sold() {
 		);
 		// core to asset swap input
 		assert_err!(
-			CennzXSpot::asset_swap_input(
+			CennzXSpot::sell_asset(
 				Origin::signed(trader),
 				None,
 				<CoreAssetId<Test>>::get(),
@@ -796,7 +796,7 @@ fn asset_sell_error_less_than_min_sale() {
 
 		// asset to core swap input
 		assert_err!(
-			CennzXSpot::asset_swap_input(
+			CennzXSpot::sell_asset(
 				Origin::signed(trader.clone()),
 				None,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -808,7 +808,7 @@ fn asset_sell_error_less_than_min_sale() {
 		);
 		// core to asset swap input
 		assert_err!(
-			CennzXSpot::asset_swap_input(
+			CennzXSpot::sell_asset(
 				Origin::signed(trader),
 				None,
 				<CoreAssetId<Test>>::get(),
@@ -829,7 +829,7 @@ fn asset_to_core_transfer_sell() {
 		let recipient: AccountId = with_account!("bob", CoreAssetCurrency => 100, TradeAssetCurrencyA => 100);
 
 		// asset to core swap input
-		assert_ok!(CennzXSpot::asset_swap_input(
+		assert_ok!(CennzXSpot::sell_asset(
 			Origin::signed(trader.clone()),
 			Some(recipient.clone()),
 			resolve_asset_id!(TradeAssetCurrencyA),
@@ -852,7 +852,7 @@ fn core_to_asset_transfer_sell() {
 		let recipient: AccountId = with_account!("bob", CoreAssetCurrency => 100, TradeAssetCurrencyA => 100);
 
 		// core to asset swap input
-		assert_ok!(CennzXSpot::asset_swap_input(
+		assert_ok!(CennzXSpot::sell_asset(
 			Origin::signed(trader.clone()),
 			Some(recipient.clone()),
 			<CoreAssetId<Test>>::get(),
@@ -986,7 +986,7 @@ fn asset_to_asset_sell() {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let trader: AccountId = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 
-		assert_ok!(CennzXSpot::asset_swap_input(
+		assert_ok!(CennzXSpot::sell_asset(
 			Origin::signed(trader.clone()),
 			None,                                   // Trader is also recipient so passing None in this case
 			resolve_asset_id!(TradeAssetCurrencyA), // asset_sold
@@ -1011,7 +1011,7 @@ fn asset_to_asset_swap_sell_error_zero_asset_sold() {
 		let trader = with_account!(CoreAssetCurrency => 100, TradeAssetCurrencyA => 100);
 
 		assert_err!(
-			CennzXSpot::asset_swap_input(
+			CennzXSpot::sell_asset(
 				Origin::signed(trader),
 				None,                                   // Trader is also recipient so passing None in this case
 				resolve_asset_id!(TradeAssetCurrencyA), // asset_sold
@@ -1032,7 +1032,7 @@ fn asset_to_asset_sell_error_insufficient_balance() {
 		let trader = with_account!(CoreAssetCurrency => 100, TradeAssetCurrencyA => 50);
 
 		assert_err!(
-			CennzXSpot::asset_swap_input(
+			CennzXSpot::sell_asset(
 				Origin::signed(trader),
 				None,                                   // Account to receive asset_bought, defaults to origin if None
 				resolve_asset_id!(TradeAssetCurrencyA), // asset_sold
@@ -1053,7 +1053,7 @@ fn asset_to_asset_sell_error_less_than_min_sale() {
 		let trader = with_account!(CoreAssetCurrency => 100, TradeAssetCurrencyA => 200);
 
 		assert_err!(
-			CennzXSpot::asset_swap_input(
+			CennzXSpot::sell_asset(
 				Origin::signed(trader),
 				None,                                   // Account to receive asset_bought, defaults to origin if None
 				resolve_asset_id!(TradeAssetCurrencyA), // asset_sold
@@ -1074,7 +1074,7 @@ fn asset_to_asset_transfer_sell() {
 		let trader: AccountId = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 		let recipient: AccountId = with_account!("bob", CoreAssetCurrency => 100, TradeAssetCurrencyB => 100);
 
-		assert_ok!(CennzXSpot::asset_swap_input(
+		assert_ok!(CennzXSpot::sell_asset(
 			Origin::signed(trader.clone()),
 			Some(recipient.clone()), // Account to receive asset_bought, defaults to origin if None
 			resolve_asset_id!(TradeAssetCurrencyA), // asset_sold

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -203,13 +203,13 @@ fn asset_buy_insufficient_reserve_error() {
 }
 
 #[test]
-fn asset_to_core_execute_buy_with_none_for_recipient() {
+fn asset_to_core_buy_with_none_for_recipient() {
 	ExtBuilder::default().build().execute_with(|| {
 		with_exchange!(CoreAssetCurrency => 10, TradeAssetCurrencyA => 1000);
 		let trader: AccountId = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 
 		// asset to core swap output
-		assert_ok!(CennzXSpot::asset_swap_output(
+		assert_ok!(CennzXSpot::buy_asset(
 			Origin::signed(trader.clone()),
 			None,
 			resolve_asset_id!(TradeAssetCurrencyA),
@@ -254,7 +254,7 @@ fn asset_buy_error_zero_asset_sold() {
 
 		// asset to core swap output
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader.clone()),
 				None,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -266,7 +266,7 @@ fn asset_buy_error_zero_asset_sold() {
 		);
 		// core to asset swap output
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader),
 				None,
 				<CoreAssetId<Test>>::get(),
@@ -287,7 +287,7 @@ fn asset_buy_error_insufficient_balance() {
 
 		// asset to core swap output
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader.clone()),
 				None,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -299,7 +299,7 @@ fn asset_buy_error_insufficient_balance() {
 		);
 		// core to asset swap output
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader),
 				None,
 				<CoreAssetId<Test>>::get(),
@@ -320,7 +320,7 @@ fn asset_buy_error_exceed_max_sale() {
 
 		// asset to core swap output
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader.clone()),
 				None,
 				resolve_asset_id!(TradeAssetCurrencyA),
@@ -333,7 +333,7 @@ fn asset_buy_error_exceed_max_sale() {
 
 		// core to asset swap output
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader),
 				None,
 				<CoreAssetId<Test>>::get(),
@@ -353,7 +353,7 @@ fn core_to_asset_buy() {
 		let trader: AccountId = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 
 		// core to asset swap output
-		assert_ok!(CennzXSpot::asset_swap_output(
+		assert_ok!(CennzXSpot::buy_asset(
 			Origin::signed(trader.clone()),
 			None,
 			<CoreAssetId<Test>>::get(),
@@ -518,7 +518,7 @@ fn asset_to_core_buy() {
 		let recipient = with_account!("bob", CoreAssetCurrency => 100, TradeAssetCurrencyA => 100);
 
 		// asset to core swap output
-		assert_ok!(CennzXSpot::asset_swap_output(
+		assert_ok!(CennzXSpot::buy_asset(
 			Origin::signed(buyer.clone()),
 			Some(recipient.clone()),
 			resolve_asset_id!(TradeAssetCurrencyA),
@@ -541,7 +541,7 @@ fn core_to_asset_transfer_buy_10_to_1000() {
 		let recipient: AccountId = with_account!("bob", CoreAssetCurrency => 100, TradeAssetCurrencyA => 100);
 
 		// core to asset swap output
-		assert_ok!(CennzXSpot::asset_swap_output(
+		assert_ok!(CennzXSpot::buy_asset(
 			Origin::signed(buyer.clone()),
 			Some(recipient.clone()),
 			<CoreAssetId<Test>>::get(),
@@ -874,7 +874,7 @@ fn asset_to_asset_buy() {
 		with_exchange!(CoreAssetCurrency => 1000, TradeAssetCurrencyB => 1000);
 		let trader: AccountId = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 
-		assert_ok!(CennzXSpot::asset_swap_output(
+		assert_ok!(CennzXSpot::buy_asset(
 			Origin::signed(trader.clone()),
 			None,                                   // Account to receive asset_bought, defaults to origin if None
 			resolve_asset_id!(TradeAssetCurrencyA), // asset_sold
@@ -899,7 +899,7 @@ fn asset_to_asset_buy_error_zero_asset_sold() {
 		let trader = with_account!(CoreAssetCurrency => 100, TradeAssetCurrencyA => 100);
 
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader),
 				None,                                   // Account to receive asset_bought, defaults to origin if None
 				resolve_asset_id!(TradeAssetCurrencyA), // asset_sold
@@ -920,7 +920,7 @@ fn asset_to_asset_buy_error_insufficient_balance() {
 		let trader = with_account!(CoreAssetCurrency => 100, TradeAssetCurrencyA => 50);
 
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader),
 				None,                                   // Account to receive asset_bought, defaults to origin if None
 				resolve_asset_id!(TradeAssetCurrencyA), // asset_sold
@@ -941,7 +941,7 @@ fn asset_to_asset_buy_error_exceed_max_sale() {
 		let trader = with_account!(CoreAssetCurrency => 100, TradeAssetCurrencyA => 100);
 
 		assert_err!(
-			CennzXSpot::asset_swap_output(
+			CennzXSpot::buy_asset(
 				Origin::signed(trader),
 				None,                                   // Account to receive asset_bought, defaults to origin if None
 				resolve_asset_id!(TradeAssetCurrencyA), // asset_sold
@@ -962,7 +962,7 @@ fn asset_to_asset_transfer_buy() {
 		let trader: AccountId = with_account!(CoreAssetCurrency => 2200, TradeAssetCurrencyA => 2200);
 		let recipient: AccountId = with_account!("bob", CoreAssetCurrency => 100, TradeAssetCurrencyB => 100);
 
-		assert_ok!(CennzXSpot::asset_swap_output(
+		assert_ok!(CennzXSpot::buy_asset(
 			Origin::signed(trader.clone()),
 			Some(recipient.clone()), // Account to receive asset_bought, defaults to origin if None
 			resolve_asset_id!(TradeAssetCurrencyA), // asset_sold


### PR DESCRIPTION
This PR addresses opportunities identified in an audit of the cennzxspot module

## Addresses

- Reconsider names for `asset_swap_output` and `asset_swap_input` extrinsics
- Rename all seller and buyer to trader

## Concerns:

- This will change the API