### PR TITLE
CENNZxSpot Types Audit Refactors

### DIFF
--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -22,7 +22,7 @@ use cennznet_runtime::{
 	GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
 	TechnicalCommitteeConfig, WASM_BINARY,
 };
-use cennznet_runtime::{Block, FeeRate, PerMilli, PerMillion};
+use cennznet_runtime::{Block, FeeRate, PerThousand, PerMillion};
 use core::convert::TryFrom;
 use grandpa_primitives::AuthorityId as GrandpaId;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
@@ -213,7 +213,7 @@ pub fn config_genesis(network_keys: NetworkKeys, enable_println: bool) -> Genesi
 			spending_asset_id: SPENDING_ASSET_ID,
 		}),
 		crml_cennzx_spot: Some(CennzxSpotConfig {
-			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(),
+			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}),
 	}

--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -22,7 +22,7 @@ use cennznet_runtime::{
 	GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
 	TechnicalCommitteeConfig, WASM_BINARY,
 };
-use cennznet_runtime::{Block, FeeRate, PerThousand, PerMillion};
+use cennznet_runtime::{Block, FeeRate, PerMillion, PerThousand};
 use core::convert::TryFrom;
 use grandpa_primitives::AuthorityId as GrandpaId;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -25,7 +25,7 @@ mod tests;
 mod impls;
 mod types;
 pub use impls::{ExchangeAddressFor, ExchangeAddressGenerator};
-pub use types::{FeeRate, HighPrecisionUnsigned, LowPrecisionUnsigned, PerThousand, PerMillion};
+pub use types::{FeeRate, HighPrecisionUnsigned, LowPrecisionUnsigned, PerMillion, PerThousand};
 
 #[macro_use]
 extern crate frame_support;

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -25,7 +25,7 @@ mod tests;
 mod impls;
 mod types;
 pub use impls::{ExchangeAddressFor, ExchangeAddressGenerator};
-pub use types::{FeeRate, HighPrecisionUnsigned, LowPrecisionUnsigned, PerMilli, PerMillion};
+pub use types::{FeeRate, HighPrecisionUnsigned, LowPrecisionUnsigned, PerThousand, PerMillion};
 
 #[macro_use]
 extern crate frame_support;

--- a/crml/cennzx-spot/src/mock.rs
+++ b/crml/cennzx-spot/src/mock.rs
@@ -23,7 +23,7 @@ use pallet_generic_asset::AssetCurrency;
 
 use crate::{
 	impls::ExchangeAddressGenerator,
-	types::{FeeRate, LowPrecisionUnsigned, PerMilli, PerMillion},
+	types::{FeeRate, LowPrecisionUnsigned, PerThousand, PerMillion},
 	Call, GenesisConfig, Module, Trait,
 };
 use core::convert::TryFrom;
@@ -159,7 +159,7 @@ impl Default for ExtBuilder {
 	fn default() -> Self {
 		Self {
 			core_asset_id: 0,
-			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(),
+			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(3u128)).unwrap(),
 		}
 	}
 }

--- a/crml/cennzx-spot/src/mock.rs
+++ b/crml/cennzx-spot/src/mock.rs
@@ -23,7 +23,7 @@ use pallet_generic_asset::AssetCurrency;
 
 use crate::{
 	impls::ExchangeAddressGenerator,
-	types::{FeeRate, LowPrecisionUnsigned, PerThousand, PerMillion},
+	types::{FeeRate, LowPrecisionUnsigned, PerMillion, PerThousand},
 	Call, GenesisConfig, Module, Trait,
 };
 use core::convert::TryFrom;

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -19,7 +19,7 @@
 use crate::{
 	impls::ExchangeAddressFor,
 	mock::{self, CORE_ASSET_ID, TRADE_ASSET_A_ID, TRADE_ASSET_B_ID},
-	types::{FeeRate, LowPrecisionUnsigned, PerThousand, PerMillion},
+	types::{FeeRate, LowPrecisionUnsigned, PerMillion, PerThousand},
 	CoreAssetId, Error, Trait,
 };
 use core::convert::TryFrom;

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -19,7 +19,7 @@
 use crate::{
 	impls::ExchangeAddressFor,
 	mock::{self, CORE_ASSET_ID, TRADE_ASSET_A_ID, TRADE_ASSET_B_ID},
-	types::{FeeRate, LowPrecisionUnsigned, PerMilli, PerMillion},
+	types::{FeeRate, LowPrecisionUnsigned, PerThousand, PerMillion},
 	CoreAssetId, Error, Trait,
 };
 use core::convert::TryFrom;
@@ -1094,7 +1094,7 @@ fn asset_to_asset_transfer_sell() {
 #[test]
 fn set_fee_rate() {
 	ExtBuilder::default().build().execute_with(|| {
-		let new_fee_rate = FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(5u128)).unwrap();
+		let new_fee_rate = FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(5u128)).unwrap();
 		assert_ok!(CennzXSpot::set_fee_rate(Origin::ROOT, new_fee_rate), ());
 		assert_eq!(CennzXSpot::fee_rate(), new_fee_rate);
 	});

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -43,13 +43,6 @@ impl Scaled for PerThousand {
 	const SCALE: LowPrecisionUnsigned = 1_000;
 }
 
-/// Per hundredth of unit price
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PerCent {}
-impl Scaled for PerCent {
-	const SCALE: LowPrecisionUnsigned = 100;
-}
-
 #[derive(Debug)]
 pub enum FeeRateError {
 	Overflow,
@@ -88,17 +81,6 @@ impl TryFrom<FeeRate<PerThousand>> for FeeRate<PerMillion> {
 	type Error = FeeRateError;
 	fn try_from(f: FeeRate<PerThousand>) -> Result<Self, Self::Error> {
 		let rate = PerMillion::SCALE / PerThousand::SCALE;
-		match f.0.checked_mul(rate) {
-			Some(x) => Ok(FeeRate::<PerMillion>::from(x)),
-			None => Err(Self::Error::Overflow),
-		}
-	}
-}
-
-impl TryFrom<FeeRate<PerCent>> for FeeRate<PerMillion> {
-	type Error = FeeRateError;
-	fn try_from(f: FeeRate<PerCent>) -> Result<Self, Self::Error> {
-		let rate = PerMillion::SCALE / PerCent::SCALE;
 		match f.0.checked_mul(rate) {
 			Some(x) => Ok(FeeRate::<PerMillion>::from(x)),
 			None => Err(Self::Error::Overflow),

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -141,7 +141,10 @@ mod tests {
 	fn fee_rate_div_when_indivisible() {
 		let fee_rate = FeeRate::<PerMillion>::from(1_100_000u128);
 		let input = FeeRate::<PerMillion>::from(100_000u128);
-		assert_eq!(input.checked_div(fee_rate).unwrap(), FeeRate::<PerMillion>::from(90_909u128));
+		assert_eq!(
+			input.checked_div(fee_rate).unwrap(),
+			FeeRate::<PerMillion>::from(90_909u128)
+		);
 	}
 
 	#[test]

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -157,46 +157,46 @@ mod tests {
 
 	#[test]
 	fn fee_rate_div_when_indivisible() {
-		let fee_rate = FeeRate::<PerCent>::from(110u128);
-		let input = FeeRate::<PerCent>::from(10u128);
-		assert_eq!(input.checked_div(fee_rate).unwrap(), FeeRate::<PerCent>::from(9u128));
+		let fee_rate = FeeRate::<PerMillion>::from(1_100_000u128);
+		let input = FeeRate::<PerMillion>::from(100_000u128);
+		assert_eq!(input.checked_div(fee_rate).unwrap(), FeeRate::<PerMillion>::from(90_909u128));
 	}
 
 	#[test]
 	fn fee_rate_div_when_divisible() {
-		let fee_rate = FeeRate::<PerCent>::from(10u128);
-		let input = FeeRate::<PerCent>::from(10u128);
-		assert_eq!(input.checked_div(fee_rate).unwrap(), FeeRate::<PerCent>::one());
+		let fee_rate = FeeRate::<PerMillion>::from(100_000u128);
+		let input = FeeRate::<PerMillion>::from(100_000u128);
+		assert_eq!(input.checked_div(fee_rate).unwrap(), FeeRate::<PerMillion>::one());
 	}
 
 	#[test]
 	fn fee_rate_div_when_divide_by_zero() {
-		let fee_rate = FeeRate::<PerCent>::from(0);
-		let input = FeeRate::<PerCent>::from(10u128);
+		let fee_rate = FeeRate::<PerMillion>::from(0);
+		let input = FeeRate::<PerMillion>::from(100_000u128);
 		assert_eq!(input.checked_div(fee_rate), None);
 	}
 
 	#[test]
 	fn fee_rate_div_when_overflow() {
-		let fee_rate = FeeRate::<PerCent>::from(10);
-		let input = FeeRate::<PerCent>::from(LowPrecisionUnsigned::max_value());
+		let fee_rate = FeeRate::<PerMillion>::from(100_000u128);
+		let input = FeeRate::<PerMillion>::from(LowPrecisionUnsigned::max_value());
 		assert_eq!(input.checked_div(fee_rate), None);
 	}
 
 	#[test]
 	fn fee_rate_mul_no_overflow() {
 		assert_eq!(
-			FeeRate::<PerCent>::from(50u128)
-				.checked_mul(FeeRate::<PerCent>::from(2u128))
+			FeeRate::<PerMillion>::from(500_000u128)
+				.checked_mul(FeeRate::<PerMillion>::from(20_000u128))
 				.unwrap(),
-			FeeRate::<PerCent>::from(1u128)
+			FeeRate::<PerMillion>::from(10_000u128)
 		);
 	}
 
 	#[test]
 	fn fee_rate_mul_when_overflow() {
-		let fee_rate = FeeRate::<PerCent>::from(200u128);
-		let rhs = FeeRate::<PerCent>::from(LowPrecisionUnsigned::max_value());
+		let fee_rate = FeeRate::<PerMillion>::from(2_000_000u128);
+		let rhs = FeeRate::<PerMillion>::from(LowPrecisionUnsigned::max_value());
 		assert_eq!(fee_rate.checked_mul(rhs), None);
 	}
 }

--- a/crml/cennzx-spot/src/types.rs
+++ b/crml/cennzx-spot/src/types.rs
@@ -38,8 +38,8 @@ impl Scaled for PerMillion {
 
 /// Per thousandth of unit price
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PerMilli {}
-impl Scaled for PerMilli {
+pub enum PerThousand {}
+impl Scaled for PerThousand {
 	const SCALE: LowPrecisionUnsigned = 1_000;
 }
 
@@ -84,10 +84,10 @@ impl<S: Scaled> TryFrom<HighPrecisionUnsigned> for FeeRate<S> {
 	}
 }
 
-impl TryFrom<FeeRate<PerMilli>> for FeeRate<PerMillion> {
+impl TryFrom<FeeRate<PerThousand>> for FeeRate<PerMillion> {
 	type Error = FeeRateError;
-	fn try_from(f: FeeRate<PerMilli>) -> Result<Self, Self::Error> {
-		let rate = PerMillion::SCALE / PerMilli::SCALE;
+	fn try_from(f: FeeRate<PerThousand>) -> Result<Self, Self::Error> {
+		let rate = PerMillion::SCALE / PerThousand::SCALE;
 		match f.0.checked_mul(rate) {
 			Some(x) => Ok(FeeRate::<PerMillion>::from(x)),
 			None => Err(Self::Error::Overflow),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -24,7 +24,7 @@
 use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash, Index, Moment, Signature};
 use cennznut::{CENNZnut, Domain, Validate, ValidationErr};
 use codec::Decode;
-pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMilli, PerMillion};
+pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerThousand, PerMillion};
 use crml_cennzx_spot_rpc_runtime_api::CennzxSpotResult;
 use frame_support::{
 	additional_traits::{self, MultiCurrencyAccounting},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -24,7 +24,7 @@
 use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash, Index, Moment, Signature};
 use cennznut::{CENNZnut, Domain, Validate, ValidationErr};
 use codec::Decode;
-pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerThousand, PerMillion};
+pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMillion, PerThousand};
 use crml_cennzx_spot_rpc_runtime_api::CennzxSpotResult;
 use frame_support::{
 	additional_traits::{self, MultiCurrencyAccounting},

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -19,7 +19,7 @@ use cennznet_primitives::types::{AccountId, Balance};
 use cennznet_runtime::{constants::asset::*, Runtime, StakerStatus, VERSION};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
-use crml_cennzx_spot::{FeeRate, PerMilli, PerMillion};
+use crml_cennzx_spot::{FeeRate, PerThousand, PerMillion};
 use pallet_contracts::{Gas, Schedule};
 use sp_runtime::Perbill;
 
@@ -104,7 +104,7 @@ impl ExtBuilder {
 			.build_storage::<Runtime>()
 			.unwrap();
 		crml_cennzx_spot::GenesisConfig::<Runtime> {
-			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(),
+			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}
 		.assimilate_storage(&mut t)

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -19,7 +19,7 @@ use cennznet_primitives::types::{AccountId, Balance};
 use cennznet_runtime::{constants::asset::*, Runtime, StakerStatus, VERSION};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
-use crml_cennzx_spot::{FeeRate, PerThousand, PerMillion};
+use crml_cennzx_spot::{FeeRate, PerMillion, PerThousand};
 use pallet_contracts::{Gas, Schedule};
 use sp_runtime::Perbill;
 

--- a/testing/src/genesis.rs
+++ b/testing/src/genesis.rs
@@ -20,7 +20,7 @@ use crate::keyring::*;
 use cennznet_primitives::types::AccountId;
 use cennznet_runtime::{
 	constants::{asset::*, currency::*},
-	FeeRate, PerThousand, PerMillion,
+	FeeRate, PerMillion, PerThousand,
 };
 use cennznet_runtime::{
 	CennzxSpotConfig, ContractsConfig, GenericAssetConfig, GenesisConfig, GrandpaConfig, SessionConfig, StakingConfig,

--- a/testing/src/genesis.rs
+++ b/testing/src/genesis.rs
@@ -20,7 +20,7 @@ use crate::keyring::*;
 use cennznet_primitives::types::AccountId;
 use cennznet_runtime::{
 	constants::{asset::*, currency::*},
-	FeeRate, PerMilli, PerMillion,
+	FeeRate, PerThousand, PerMillion,
 };
 use cennznet_runtime::{
 	CennzxSpotConfig, ContractsConfig, GenericAssetConfig, GenesisConfig, GrandpaConfig, SessionConfig, StakingConfig,
@@ -129,7 +129,7 @@ pub fn config_endowed(support_changes_trie: bool, code: Option<&[u8]>, extra_end
 		pallet_sudo: Some(Default::default()),
 		pallet_treasury: Some(Default::default()),
 		crml_cennzx_spot: Some(CennzxSpotConfig {
-			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerMilli>::from(3u128)).unwrap(),
+			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}),
 	}


### PR DESCRIPTION
This PR addresses opportunities identified in an audit of the cennzxspot module

## Addresses

- Rename `PerMilli` to `PerThousand` to describe its intent accurately
- Make all `FeeRate` tests use `PerMillion` instead of `PerCent`
- Remove the unnecessary `PerCent` enum

## Concerns:

- None