### PR TITLE
CENNZxSpot Liquidity Check RPC

### DIFF
--- a/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
+++ b/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
@@ -55,7 +55,7 @@ sp_api::decl_runtime_apis! {
 			account: AccountId,
 			asset_id: AssetId,
 		) -> (Balance, Balance, Balance);
-		/// Query the price of liquidity for a particular asset_id
+		/// Query the price of liquidity for a particular `asset_id`
 		fn liquidity_price(
 			asset_id: AssetId,
 			liquidity_to_buy: Balance,

--- a/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
+++ b/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
@@ -55,5 +55,10 @@ sp_api::decl_runtime_apis! {
 			account: AccountId,
 			asset_id: AssetId,
 		) -> (Balance, Balance, Balance);
+		/// Query the price of liquidity for a particular asset_id
+		fn liquidity_price(
+			asset_id: AssetId,
+			liquidity_to_buy: Balance,
+		) -> (Balance, Balance);
 	}
 }

--- a/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
+++ b/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
@@ -33,9 +33,10 @@ pub enum CennzxSpotResult<Balance> {
 
 sp_api::decl_runtime_apis! {
 	/// The RPC API to interact with CENNZX Spot Exchange
-	pub trait CennzxSpotApi<AssetId, Balance> where
+	pub trait CennzxSpotApi<AssetId, Balance, AccountId> where
 		AssetId: Codec,
 		Balance: Codec + BaseArithmetic,
+		AccountId: Codec,
 	{
 		/// Query how much `asset_to_buy` will be given in exchange for `amount` of `asset_to_sell`
 		fn buy_price(
@@ -49,5 +50,10 @@ sp_api::decl_runtime_apis! {
 			amount: Balance,
 			asset_to_buy: AssetId,
 		) -> CennzxSpotResult<Balance>;
+		/// Query the value of liquidity in the exchange for `asset_id` for `account`
+		fn liquidity_value(
+			account: AccountId,
+			asset_id: AssetId,
+		) -> (Balance, Balance, Balance);
 	}
 }

--- a/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
+++ b/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
@@ -51,11 +51,13 @@ sp_api::decl_runtime_apis! {
 			asset_to_buy: AssetId,
 		) -> CennzxSpotResult<Balance>;
 		/// Query the value of liquidity in the exchange for `asset_id` for `account`
+		/// Returns (liquidity_volume, core_value, asset_value)
 		fn liquidity_value(
 			account: AccountId,
 			asset_id: AssetId,
 		) -> (Balance, Balance, Balance);
 		/// Query the price of liquidity for a particular `asset_id`
+		/// Returns price as a combination of (core, asset)
 		fn liquidity_price(
 			asset_id: AssetId,
 			liquidity_to_buy: Balance,

--- a/crml/cennzx-spot/rpc/src/lib.rs
+++ b/crml/cennzx-spot/rpc/src/lib.rs
@@ -194,7 +194,7 @@ where
 			})?;
 
 		let core = TryInto::<u64>::try_into(result.0.saturated_into::<u128>()).map_err(|e| RpcError {
-				code: ErrorCode::ServerError(Error::PriceOverflow.into()),
+			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
 			message: "Core asset too large.".into(),
 			data: Some(format!("{:?}", e).into()),
 		})?;

--- a/crml/cennzx-spot/rpc/src/lib.rs
+++ b/crml/cennzx-spot/rpc/src/lib.rs
@@ -166,18 +166,18 @@ where
 			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
 			message: "Liquidity too large.".into(),
 			data: Some(format!("{:?}", e).into()),
-		});
+		})?;
 		let core = TryInto::<u64>::try_into(result.1.saturated_into::<u128>()).map_err(|e| RpcError {
 			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
 			message: "Core asset too large.".into(),
 			data: Some(format!("{:?}", e).into()),
-		});
+		})?;
 		let asset = TryInto::<u64>::try_into(result.2.saturated_into::<u128>()).map_err(|e| RpcError {
 			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
 			message: "Trade asset too large.".into(),
 			data: Some(format!("{:?}", e).into()),
-		});
-		Ok((liquidity.unwrap(), core.unwrap(), asset.unwrap()))
+		})?;
+		Ok((liquidity, core, asset))
 	}
 
 	fn liquidity_price(&self, asset_id: AssetId, liquidity_to_buy: Balance) -> Result<(u64, u64)> {
@@ -194,15 +194,15 @@ where
 			})?;
 
 		let core = TryInto::<u64>::try_into(result.0.saturated_into::<u128>()).map_err(|e| RpcError {
-			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
+				code: ErrorCode::ServerError(Error::PriceOverflow.into()),
 			message: "Core asset too large.".into(),
 			data: Some(format!("{:?}", e).into()),
-		});
+		})?;
 		let asset = TryInto::<u64>::try_into(result.1.saturated_into::<u128>()).map_err(|e| RpcError {
 			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
 			message: "Trade asset too large.".into(),
 			data: Some(format!("{:?}", e).into()),
-		});
-		Ok((core.unwrap(), asset.unwrap()))
+		})?;
+		Ok((core, asset))
 	}
 }

--- a/crml/cennzx-spot/rpc/src/lib.rs
+++ b/crml/cennzx-spot/rpc/src/lib.rs
@@ -185,11 +185,13 @@ where
 		let best = self.client.info().best_hash;
 		let at = BlockId::hash(best);
 
-		let result = api.liquidity_price(&at, asset_id, liquidity_to_buy).map_err(|e| RpcError {
-			code: ErrorCode::ServerError(Error::Runtime.into()),
-			message: "Unable to query liquidity price.".into(),
-			data: Some(format!("{:?}", e).into()),
-		})?;
+		let result = api
+			.liquidity_price(&at, asset_id, liquidity_to_buy)
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(Error::Runtime.into()),
+				message: "Unable to query liquidity price.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})?;
 
 		let core = TryInto::<u64>::try_into(result.0.saturated_into::<u128>()).map_err(|e| RpcError {
 			code: ErrorCode::ServerError(Error::PriceOverflow.into()),

--- a/crml/cennzx-spot/rpc/src/lib.rs
+++ b/crml/cennzx-spot/rpc/src/lib.rs
@@ -33,7 +33,7 @@ pub use crml_cennzx_spot_rpc_runtime_api::{
 
 /// Contracts RPC methods.
 #[rpc]
-pub trait CennzxSpotApi<AssetId, Balance> {
+pub trait CennzxSpotApi<AssetId, Balance, AccountId> {
 	#[rpc(name = "cennzx_buyPrice")]
 	// TODO: prefer to return Result<Balance>, however Serde JSON library only allows u64.
 	//  - change to Result<Balance> once https://github.com/serde-rs/serde/pull/1679 is merged
@@ -42,6 +42,10 @@ pub trait CennzxSpotApi<AssetId, Balance> {
 	#[rpc(name = "cennzx_sellPrice")]
 	// TODO: change to Result<Balance> once https://github.com/serde-rs/serde/pull/1679 is merged
 	fn sell_price(&self, asset_to_sell: AssetId, amount_to_buy: Balance, asset_to_payout: AssetId) -> Result<u64>;
+
+	#[rpc(name = "cennzx_liquidityValue")]
+	// TODO: change to Result<Balance> once https://github.com/serde-rs/serde/pull/1679 is merged
+	fn liquidity_value(&self, account_id: AccountId, asset_id: AssetId) -> Result<(u64, u64, u64)>;
 }
 
 /// An implementation of CENNZX Spot Exchange specific RPC methods.
@@ -78,13 +82,14 @@ impl From<Error> for i64 {
 	}
 }
 
-impl<C, Block, AssetId, Balance> CennzxSpotApi<AssetId, Balance> for CennzxSpot<C, Block>
+impl<C, Block, AssetId, Balance, AccountId> CennzxSpotApi<AssetId, Balance, AccountId> for CennzxSpot<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
-	C::Api: CennzxSpotRuntimeApi<Block, AssetId, Balance>,
+	C::Api: CennzxSpotRuntimeApi<Block, AssetId, Balance, AccountId>,
 	AssetId: Codec,
 	Balance: Codec + BaseArithmetic,
+	AccountId: Codec,
 {
 	fn buy_price(&self, asset_to_buy: AssetId, amount_to_buy: Balance, asset_to_pay: AssetId) -> Result<u64> {
 		let api = self.client.runtime_api();
@@ -140,5 +145,34 @@ where
 				data: Some("".into()),
 			}),
 		}
+	}
+
+	fn liquidity_value(&self, account: AccountId, asset_id: AssetId) -> Result<(u64, u64, u64)> {
+		let api = self.client.runtime_api();
+		let best = self.client.info().best_hash;
+		let at = BlockId::hash(best);
+
+		let result = api.liquidity_value(&at, account, asset_id).map_err(|e| RpcError {
+			code: ErrorCode::ServerError(Error::Runtime.into()),
+			message: "Unable to query liquidity value.".into(),
+			data: Some(format!("{:?}", e).into()),
+		})?;
+
+		let liquidity = TryInto::<u64>::try_into(result.0.saturated_into::<u128>()).map_err(|e| RpcError {
+			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
+			message: "Liquidity too large.".into(),
+			data: Some(format!("{:?}", e).into()),
+		});
+		let core = TryInto::<u64>::try_into(result.1.saturated_into::<u128>()).map_err(|e| RpcError {
+			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
+			message: "Core asset too large.".into(),
+			data: Some(format!("{:?}", e).into()),
+		});
+		let asset = TryInto::<u64>::try_into(result.2.saturated_into::<u128>()).map_err(|e| RpcError {
+			code: ErrorCode::ServerError(Error::PriceOverflow.into()),
+			message: "Trade asset too large.".into(),
+			data: Some(format!("{:?}", e).into()),
+		});
+		Ok((liquidity.unwrap(), core.unwrap(), asset.unwrap()))
 	}
 }

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -439,7 +439,7 @@ impl<T: Trait> Module<T> {
 		liquidity_to_withdraw: T::Balance,
 		total_liquidity: T::Balance,
 	) -> LiquidityValue<T::Balance> {
-		if total_liquidity == Zero::zero() {
+		if total_liquidity.is_zero() {
 			LiquidityValue {
 				liquidity: Zero::zero(),
 				core: Zero::zero(),

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -373,9 +373,9 @@ impl<T: Trait> Module<T> {
 
 			(core_amount, asset_amount)
 		};
-		LiquidityPrice{
+		LiquidityPrice {
 			core: core_amount,
-			asset: asset_amount
+			asset: asset_amount,
 		}
 	}
 

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -45,9 +45,9 @@ pub type ExchangeKey<T> = (
 );
 
 pub struct LiquidityValue<Balance> {
-	liquidity: Balance,
-	core: Balance,
-	asset: Balance,
+	pub liquidity: Balance,
+	pub core: Balance,
+	pub asset: Balance,
 }
 
 pub trait Trait: frame_system::Trait + pallet_generic_asset::Trait {
@@ -357,7 +357,7 @@ impl<T: Trait> Module<T> {
 	///   * the total liquidity in an account for a given asset ID
 	///   * the total withdrawable core asset
 	///   * the total withdrawable trade asset
-	fn liquidity_value(who: &T::AccountId, asset_id: T::AssetId) -> LiquidityValue<T::Balance> {
+	pub fn liquidity_value(who: &T::AccountId, asset_id: T::AssetId) -> LiquidityValue<T::Balance> {
 		let core_asset_id = Self::core_asset_id();
 		let exchange_key = (core_asset_id, asset_id);
 		let account_liquidity = <LiquidityBalance<T>>::get(&exchange_key, who);

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -44,12 +44,23 @@ pub type ExchangeKey<T> = (
 	<T as pallet_generic_asset::Trait>::AssetId,
 );
 
+/// Represents the value of an amount of liquidity in an exchange
+/// Liqudity is always traded for a combination of `core_asset` and `trade_asset`
+///
+/// `liquidity` represents the volume of liquidity holdings being valued
+/// `core` represents the balance of `core_asset` that the liquidity would yield
+/// `asset` represents the balance of `trade_asset` that the liquidity
 pub struct LiquidityValue<Balance> {
 	pub liquidity: Balance,
 	pub core: Balance,
 	pub asset: Balance,
 }
 
+/// Represents the price to buy liqudiity from an exchange
+/// Liqudity is always traded for a combination of `core_asset` and `trade_asset`
+///
+/// `core` represents the balance of `core_asset` required
+/// `asset` represents the balance of `trade_asset` required
 pub struct LiquidityPrice<Balance> {
 	pub core: Balance,
 	pub asset: Balance,
@@ -356,13 +367,13 @@ impl<T: Trait> Module<T> {
 		<TotalLiquidity<T>>::mutate(exchange_key, |balance| *balance = balance.saturating_sub(decrease));
 	}
 
-	/// The Price of Liquidity for a particular `asset` exchange
+	/// The Price of Liquidity for a particular `asset_id` exchange
 	///
 	/// The price includes
 	///   * a required amount of core asset
-	///   * a required amount of `asset`
+	///   * a required amount of `asset_id`
 	///
-	/// Note: if the exchange does not exist, the cost in `asset` is 1, because the invester
+	/// Note: if the exchange does not exist, the cost in `asset` is 1, because the investor
 	///       determines the exchange rate
 	pub fn liquidity_price(asset_id: T::AssetId, liquidity_to_buy: T::Balance) -> LiquidityPrice<T::Balance> {
 		let core_asset_id = Self::core_asset_id();

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -356,6 +356,14 @@ impl<T: Trait> Module<T> {
 		<TotalLiquidity<T>>::mutate(exchange_key, |balance| *balance = balance.saturating_sub(decrease));
 	}
 
+	/// The Price of Liquidity for a particular `asset` exchange
+	///
+	/// The price includes
+	///   * a required amount of core asset
+	///   * a required amount of `asset`
+	///
+	/// Note: if the exchange does not exist, the cost in `asset` is 1, because the invester
+	///       determines the exchange rate
 	pub fn liquidity_price(asset_id: T::AssetId, liquidity_to_buy: T::Balance) -> LiquidityPrice<T::Balance> {
 		let core_asset_id = Self::core_asset_id();
 		let exchange_key = (core_asset_id, asset_id);

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -56,7 +56,7 @@ pub struct LiquidityValue<Balance> {
 	pub asset: Balance,
 }
 
-/// Represents the price to buy liqudiity from an exchange
+/// Represents the price to buy liquidity from an exchange
 /// Liqudity is always traded for a combination of `core_asset` and `trade_asset`
 ///
 /// `core` represents the balance of `core_asset` required

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -216,16 +216,17 @@ decl_module! {
 				let trade_asset_reserve = <pallet_generic_asset::Module<T>>::free_balance(&asset_id, &exchange_address);
 				let trade_asset_amount = core_amount * trade_asset_reserve / core_asset_reserve + One::one();
 				let liquidity_minted = core_amount * total_liquidity / core_asset_reserve;
-				ensure!(
-					liquidity_minted >= min_liquidity,
-					Error::<T>::LiquidityMintableLowerThanRequired
-				);
-				ensure!(
-					max_asset_amount >= trade_asset_amount,
-					Error::<T>::TradeAssetToAddLiquidityAboveMaxAmount
-				);
+
 				(trade_asset_amount, liquidity_minted)
 			};
+			ensure!(
+				liquidity_minted >= min_liquidity,
+				Error::<T>::LiquidityMintableLowerThanRequired
+			);
+			ensure!(
+				max_asset_amount >= trade_asset_amount,
+				Error::<T>::TradeAssetToAddLiquidityAboveMaxAmount
+			);
 
 			<pallet_generic_asset::Module<T>>::make_transfer(&core_asset_id, &from_account, &exchange_address, core_amount)?;
 			<pallet_generic_asset::Module<T>>::make_transfer(&asset_id, &from_account, &exchange_address, trade_asset_amount)?;

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -649,7 +649,7 @@ fn calculate_liquidity_value_ratio() {
 }
 
 #[test]
-fn liquidity_value_simple() {
+fn account_liquidity_value_simple() {
 	ExtBuilder::default().build().execute_with(|| {
 		let investor: AccountId = with_account!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
@@ -661,7 +661,7 @@ fn liquidity_value_simple() {
 			250, // core_amount: T::Balance,
 		));
 
-		let value = CennzXSpot::liquidity_value(&investor, resolve_asset_id!(TradeAssetCurrencyA));
+		let value = CennzXSpot::account_liquidity_value(&investor, resolve_asset_id!(TradeAssetCurrencyA));
 
 		assert_eq!(value.liquidity, 250);
 		assert_eq!(value.core, 250);
@@ -670,7 +670,7 @@ fn liquidity_value_simple() {
 }
 
 #[test]
-fn liquidity_value_accrued() {
+fn account_liquidity_value_accrued() {
 	ExtBuilder::default().build().execute_with(|| {
 		let investor: AccountId = with_account!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 
@@ -686,7 +686,7 @@ fn liquidity_value_accrued() {
 		with_exchange!(CoreAssetCurrency => 750, TradeAssetCurrencyA => 850);
 		assert_exchange_balance_eq!(CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1200);
 
-		let value = CennzXSpot::liquidity_value(&investor, resolve_asset_id!(TradeAssetCurrencyA));
+		let value = CennzXSpot::account_liquidity_value(&investor, resolve_asset_id!(TradeAssetCurrencyA));
 
 		assert_eq!(value.liquidity, 250);
 		assert_eq!(value.core, 1000);
@@ -695,7 +695,7 @@ fn liquidity_value_accrued() {
 }
 
 #[test]
-fn liquidity_value_multi_investor_accrued() {
+fn account_liquidity_value_multi_investor_accrued() {
 	ExtBuilder::default().build().execute_with(|| {
 		let investor_1: AccountId = with_account!("andrea", CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
 		let investor_2: AccountId = with_account!("bob", CoreAssetCurrency => 1000, TradeAssetCurrencyA => 1000);
@@ -720,12 +720,12 @@ fn liquidity_value_multi_investor_accrued() {
 		with_exchange!(CoreAssetCurrency => 300, TradeAssetCurrencyA => 599);
 		assert_exchange_balance_eq!(CoreAssetCurrency => 500, TradeAssetCurrencyA => 1000);
 
-		let value_1 = CennzXSpot::liquidity_value(&investor_1, resolve_asset_id!(TradeAssetCurrencyA));
+		let value_1 = CennzXSpot::account_liquidity_value(&investor_1, resolve_asset_id!(TradeAssetCurrencyA));
 		assert_eq!(value_1.liquidity, 150);
 		assert_eq!(value_1.core, 375);
 		assert_eq!(value_1.asset, 750);
 
-		let value_2 = CennzXSpot::liquidity_value(&investor_2, resolve_asset_id!(TradeAssetCurrencyA));
+		let value_2 = CennzXSpot::account_liquidity_value(&investor_2, resolve_asset_id!(TradeAssetCurrencyA));
 		assert_eq!(value_2.liquidity, 50);
 		assert_eq!(value_2.core, 125);
 		assert_eq!(value_2.asset, 250);

--- a/crml/cennzx-spot/src/tests.rs
+++ b/crml/cennzx-spot/src/tests.rs
@@ -497,10 +497,7 @@ fn add_liquidity_fails_with_too_low_trade_asset() {
 #[test]
 fn liquidity_price_new_exchange() {
 	ExtBuilder::default().build().execute_with(|| {
-		let price = CennzXSpot::liquidity_price(
-			resolve_asset_id!(TradeAssetCurrencyA),
-			1_000_000,
-		);
+		let price = CennzXSpot::liquidity_price(resolve_asset_id!(TradeAssetCurrencyA), 1_000_000);
 
 		assert_eq!(price.core, 1_000_000);
 		assert_eq!(price.asset, 1);
@@ -515,15 +512,12 @@ fn liquidity_price_exisiting_exchange_one_to_one() {
 		assert_ok!(CennzXSpot::add_liquidity(
 			Origin::signed(investor.clone()),
 			resolve_asset_id!(TradeAssetCurrencyA),
-			1,   // min_liquidity: T::Balance,
+			1,     // min_liquidity: T::Balance,
 			1_000, // max_asset_amount: T::Balance,
 			1_000, // core_amount: T::Balance,
 		));
 
-		let price = CennzXSpot::liquidity_price(
-			resolve_asset_id!(TradeAssetCurrencyA),
-			1_000_000,
-		);
+		let price = CennzXSpot::liquidity_price(resolve_asset_id!(TradeAssetCurrencyA), 1_000_000);
 
 		assert_eq!(price.asset, 1_000_000 + 1);
 		assert_eq!(price.core, 1_000_000);
@@ -538,15 +532,12 @@ fn liquidity_price_exisiting_exchange_one_to_three() {
 		assert_ok!(CennzXSpot::add_liquidity(
 			Origin::signed(investor.clone()),
 			resolve_asset_id!(TradeAssetCurrencyA),
-			1,   // min_liquidity: T::Balance,
+			1,     // min_liquidity: T::Balance,
 			3_000, // max_asset_amount: T::Balance,
 			1_000, // core_amount: T::Balance,
 		));
 
-		let price = CennzXSpot::liquidity_price(
-			resolve_asset_id!(TradeAssetCurrencyA),
-			1_000_000,
-		);
+		let price = CennzXSpot::liquidity_price(resolve_asset_id!(TradeAssetCurrencyA), 1_000_000);
 
 		assert_eq!(price.asset, 3_000_000 + 1);
 		assert_eq!(price.core, 1_000_000);
@@ -561,7 +552,7 @@ fn liquidity_price_exisiting_exchange_accrued() {
 		assert_ok!(CennzXSpot::add_liquidity(
 			Origin::signed(investor.clone()),
 			resolve_asset_id!(TradeAssetCurrencyA),
-			1,   // min_liquidity: T::Balance,
+			1,     // min_liquidity: T::Balance,
 			1_000, // max_asset_amount: T::Balance,
 			1_000, // core_amount: T::Balance,
 		));
@@ -570,10 +561,7 @@ fn liquidity_price_exisiting_exchange_accrued() {
 		with_exchange!(CoreAssetCurrency => 999_000, TradeAssetCurrencyA => 499_000);
 		assert_exchange_balance_eq!(CoreAssetCurrency => 1_000_000, TradeAssetCurrencyA => 500_000);
 
-		let price = CennzXSpot::liquidity_price(
-			resolve_asset_id!(TradeAssetCurrencyA),
-			1_000,
-		);
+		let price = CennzXSpot::liquidity_price(resolve_asset_id!(TradeAssetCurrencyA), 1_000);
 
 		assert_eq!(price.asset, 500_000 + 1);
 		assert_eq!(price.core, 1_000_000);

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -86,7 +86,7 @@ where
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance, UncheckedExtrinsic>,
-	C::Api: crml_cennzx_spot_rpc::CennzxSpotRuntimeApi<Block, AssetId, Balance>,
+	C::Api: crml_cennzx_spot_rpc::CennzxSpotRuntimeApi<Block, AssetId, Balance, AccountId>,
 	C::Api: BabeApi<Block>,
 	<C::Api as sp_api::ApiErrorExt>::Error: fmt::Debug,
 	P: TransactionPool + 'static,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -830,6 +830,14 @@ impl_runtime_apis! {
 			let value = CennzxSpot::liquidity_value(&account, asset_id);
 			(value.liquidity, value.core, value.asset)
 		}
+
+		fn liquidity_price(
+			asset_id: AssetId,
+			liquidity_to_buy: Balance
+		) -> (Balance, Balance) {
+			let value = CennzxSpot::liquidity_price(asset_id, liquidity_to_buy);
+			(value.core, value.asset)
+		}
 	}
 
 	impl sp_session::SessionKeys<Block> for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -797,6 +797,7 @@ impl_runtime_apis! {
 		Block,
 		AssetId,
 		Balance,
+		AccountId,
 	> for Runtime {
 		fn buy_price(
 			buy_asset: AssetId,
@@ -820,6 +821,14 @@ impl_runtime_apis! {
 				Ok(value) => CennzxSpotResult::Success(value),
 				Err(_) => CennzxSpotResult::Error,
 			}
+		}
+
+		fn liquidity_value(
+			account: AccountId,
+			asset_id: AssetId,
+		) -> (Balance, Balance, Balance) {
+			let value = CennzxSpot::liquidity_value(&account, asset_id);
+			(value.liquidity, value.core, value.asset)
 		}
 	}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -827,7 +827,7 @@ impl_runtime_apis! {
 			account: AccountId,
 			asset_id: AssetId,
 		) -> (Balance, Balance, Balance) {
-			let value = CennzxSpot::liquidity_value(&account, asset_id);
+			let value = CennzxSpot::account_liquidity_value(&account, asset_id);
 			(value.liquidity, value.core, value.asset)
 		}
 


### PR DESCRIPTION
This PR allows:
* a user to check the value of any account's liquidity using an RPC call `cennzx_liquidityValue` with arguments `[account_id, asset_id]`
* a user to check the price of an exchanges liquidity using an RPC call `cennzx_liquidityPrice` with arguments `[asset_id, liquidity_to_buy]`

## Changes

- Add a public function `account_liquidity_value` which gives the value of an account's liquidity for a particular `asset_id`
- Refactor calculation of liquidity value so that both `account_liquidity_value` and `remove_liquidity` use the same calculation
- Add a public function `liquidity_price` which gives the price of liquidity in terms of `core` and `asset`
- More thorough testing around liquidity value calculations
- RPC interface for `cennzx_liquidityValue` and `cennznet_liquidityPrice`

## Concerns:

- The wording around `Liquidity` storage and types in `cennzx-spot` is getting a little difficult to distinguish between what is being communicated

## Cool things:

A basic test after running a node and adding liquidity using the UI resulted in:

**liqudityValue**
```
cennznet % curl -H "Content-Type: application/json" --data '{"id": 1,"jsonrpc": "2.0","method": "cennzx_liquidityValue","params": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 16000]}' localhost:9933
{"jsonrpc":"2.0","result":[7357000000000000,7357000000000000,1337000000000000],"id":1}
```

**liqudityPrice**
```
cennznet % curl -H "Content-Type: application/json" --data '{"id": 1,"jsonrpc": "2.0","method": "cennzx_liquidityPrice","params": [16000, 1000]}' localhost:9933
{"jsonrpc":"2.0","result":[1000,182],"id":1}
```

The liquidityValue rpc call is listed under rpc.methods():

```
...
    "babe_epochAuthorship",
    "cennzx_buyPrice",
    "cennzx_liquidityPrice",
    "cennzx_liquidityValue",
    "cennzx_sellPrice",
    "chain_getBlock",
...
```
