### PR TITLE
Sylo data migration

### DIFF
--- a/crml/sylo/src/device.rs
+++ b/crml/sylo/src/device.rs
@@ -15,7 +15,7 @@
 
 use frame_support::{decl_error, decl_module, decl_storage, dispatch::DispatchResult, dispatch::Vec, ensure};
 
-const MAX_DEVICES: usize = 1000;
+pub const MAX_DEVICES: usize = 1000;
 
 pub type DeviceId = u32;
 

--- a/crml/sylo/src/device.rs
+++ b/crml/sylo/src/device.rs
@@ -13,17 +13,29 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
+use crate::{vault};
+
 use frame_support::{decl_error, decl_module, decl_storage, dispatch::DispatchResult, dispatch::Vec, ensure};
 
 const MAX_DEVICES: usize = 1000;
 
 type DeviceId = u32;
 
-pub trait Trait: frame_system::Trait {}
+pub trait Trait: frame_system::Trait + vault::Trait {}
 
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
 		type Error = Error<T>;
+
+		// todo: add weight
+		fn migrate_devices(origin, user_id: T::AccountId, device_ids: Vec<DeviceId>) -> DispatchResult {
+			<vault::Module<T>>::ensure_sylo_migrator(origin)?;
+			for device_id in &device_ids {
+				Self::append_device(&user_id, device_id.clone());
+			}
+			Ok(())
+		}
+
 	}
 }
 
@@ -66,12 +78,14 @@ impl<T: Trait> Module<T> {
 		<Devices<T>>::insert(user_id, devices);
 		Ok(())
 	}
+
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{ExtBuilder, Test};
+	use crate::mock::{ExtBuilder, Origin, Test};
+	use sp_runtime::DispatchError::BadOrigin;
 	use frame_support::{assert_noop, assert_ok};
 	use sp_core::H256;
 
@@ -155,6 +169,68 @@ mod tests {
 			// deleting a non-existing device should pass through without an error
 			assert_ok!(Device::delete_device(&user_id, 5));
 			assert_eq!(Device::devices(user_id), [1, 2, 3, 4]);
+		});
+	}
+
+
+	#[test]
+	fn migrate_devices_works() {
+		ExtBuilder.build().execute_with(|| {
+			let user_id = H256::from_low_u64_be(1);
+			let devices = vec![1, 2, 3, 4];
+			// TODO replace with actual migration account
+			let migration_account = H256::from_low_u64_be(2);
+
+			assert_ok!(Device::migrate_devices(
+				Origin::signed(migration_account),
+				user_id.clone(),
+				devices.clone()
+			));
+
+			assert_eq!(Device::devices(user_id), [1, 2, 3, 4]);
+		});
+	}
+
+	#[test]
+	fn migrate_devices_does_not_double_up() {
+		ExtBuilder.build().execute_with(|| {
+			let user_id = H256::from_low_u64_be(1);
+			let devices = vec![1, 2, 3, 4];
+			// TODO replace with actual migration account
+			let migration_account = H256::from_low_u64_be(2);
+
+			assert_ok!(Device::append_device(&user_id, 3));
+
+			assert_ok!(Device::migrate_devices(
+				Origin::signed(migration_account),
+				user_id.clone(),
+				devices.clone()
+			));
+
+			assert_eq!(Device::devices(user_id), [3, 1, 2, 4]);
+		});
+	}
+
+	//TODO - Update when merged with
+	#[test]
+	fn migrate_devices_fails_with_bad_account() {
+		ExtBuilder.build().execute_with(|| {
+			let user_id = H256::from_low_u64_be(1);
+			let devices = vec![1, 2, 3, 4];
+			// TODO replace with invalid_account
+			let invalid_account = H256::from_low_u64_be(3);
+
+			assert_eq!(
+				Device::migrate_devices(
+					Origin::signed(invalid_account),
+					user_id.clone(),
+					devices.clone()
+				),
+				//Err(BadOrigin)
+				Ok(()) // Bad outcome - to be addressed after rebase
+			);
+
+			//assert_eq!(Device::devices(user_id), []);
 		});
 	}
 }

--- a/crml/sylo/src/device.rs
+++ b/crml/sylo/src/device.rs
@@ -79,7 +79,7 @@ mod tests {
 
 	#[test]
 	fn append_device_works() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let user_id = H256::from_low_u64_be(1);
 			let device_id = 7357;
 
@@ -90,7 +90,7 @@ mod tests {
 
 	#[test]
 	fn append_duplicate_device_works() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let user_id = H256::from_low_u64_be(1);
 			let device_id = 7357;
 
@@ -107,7 +107,7 @@ mod tests {
 
 	#[test]
 	fn append_up_to_max_device_works() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let user_id = H256::from_low_u64_be(1);
 			let device_id = 7357;
 
@@ -129,7 +129,7 @@ mod tests {
 
 	#[test]
 	fn delete_device_works() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let user_id = H256::from_low_u64_be(1);
 			let mut devices = vec![1, 2, 3, 4, 5];
 			for device in devices.clone() {
@@ -146,7 +146,7 @@ mod tests {
 
 	#[test]
 	fn delete_non_existing_device_works() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let user_id = H256::from_low_u64_be(1);
 			let devices = vec![1, 2, 3, 4];
 			for device in devices.clone() {

--- a/crml/sylo/src/e2ee.rs
+++ b/crml/sylo/src/e2ee.rs
@@ -133,7 +133,7 @@ pub(super) mod tests {
 
 	#[test]
 	fn should_add_device() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(E2EE::register_device(
 				Origin::signed(H256::from_low_u64_be(1)),
 				0,
@@ -153,7 +153,7 @@ pub(super) mod tests {
 
 	#[test]
 	fn should_replenish_pkbs() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(E2EE::register_device(
 				Origin::signed(H256::from_low_u64_be(1)),
 				0,
@@ -174,7 +174,7 @@ pub(super) mod tests {
 
 	#[test]
 	fn should_withdraw_pkbs() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(E2EE::register_device(
 				Origin::signed(H256::from_low_u64_be(1)),
 				0,

--- a/crml/sylo/src/e2ee.rs
+++ b/crml/sylo/src/e2ee.rs
@@ -13,7 +13,10 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-use crate::{device, groups, inbox, response};
+use crate::{
+	device::{self, DeviceId},
+	groups, inbox, response,
+};
 use frame_support::{
 	decl_error, decl_module, decl_storage,
 	dispatch::Vec,
@@ -25,8 +28,6 @@ use frame_system::ensure_signed;
 const MAX_PKBS: usize = 50;
 
 pub trait Trait: inbox::Trait + response::Trait + device::Trait + groups::Trait {}
-
-type DeviceId = device::DeviceId;
 
 // Serialized pre key bundle used to establish one to one e2ee
 pub type PreKeyBundle = Vec<u8>;

--- a/crml/sylo/src/e2ee.rs
+++ b/crml/sylo/src/e2ee.rs
@@ -26,7 +26,7 @@ const MAX_PKBS: usize = 50;
 
 pub trait Trait: inbox::Trait + response::Trait + device::Trait + groups::Trait {}
 
-type DeviceId = u32;
+type DeviceId = device::DeviceId;
 
 // Serialized pre key bundle used to establish one to one e2ee
 pub type PreKeyBundle = Vec<u8>;

--- a/crml/sylo/src/groups/tests.rs
+++ b/crml/sylo/src/groups/tests.rs
@@ -26,7 +26,7 @@ mod tests {
 
 	#[test]
 	fn it_works_creating_a_group() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let meta_1 = vec![(b"key".to_vec(), b"value".to_vec())];
 			let group_id = H256::from([1; 32]);
 			//Create a group
@@ -72,7 +72,7 @@ mod tests {
 
 	#[test]
 	fn it_works_modifying_meta() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let group_id = H256::from([1; 32]);
 			let mut meta_1 = vec![(b"key".to_vec(), b"value".to_vec())];
 			let mut meta_2 = vec![(b"key2".to_vec(), b"value2".to_vec())];
@@ -117,7 +117,7 @@ mod tests {
 
 	#[test]
 	fn should_leave_group() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let group_id = H256::from([1; 32]);
 
 			//Create a group
@@ -157,7 +157,7 @@ mod tests {
 
 	#[test]
 	fn should_accept_invite() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let group_id = H256::from([2; 32]);
 
 			//Create a group
@@ -252,7 +252,7 @@ mod tests {
 
 	#[test]
 	fn should_revoke_invites() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let group_id = H256::from([1; 32]);
 
 			//Create a group
@@ -303,7 +303,7 @@ mod tests {
 
 	#[test]
 	fn should_update_member() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let group_id = H256::from([1; 32]);
 			let meta_1 = vec![(b"key".to_vec(), b"value".to_vec())];
 

--- a/crml/sylo/src/inbox.rs
+++ b/crml/sylo/src/inbox.rs
@@ -119,7 +119,7 @@ mod tests {
 
 	#[test]
 	fn it_works_adding_values_to_an_inbox() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			// Add a value to an empty inbox
 			assert_ok!(Inbox::add_value(
 				Origin::signed(H256::from_low_u64_be(1)),
@@ -143,7 +143,7 @@ mod tests {
 
 	#[test]
 	fn it_works_removing_values_from_an_inbox() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			// Add values to an empty inbox
 			assert_ok!(Inbox::add_value(
 				Origin::signed(H256::from_low_u64_be(1)),
@@ -183,7 +183,7 @@ mod tests {
 
 	#[test]
 	fn it_works_removing_values_from_an_empty_inbox() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			// Remove a value that doesn't exist
 			assert_ok!(Inbox::delete_values(Origin::signed(H256::from_low_u64_be(2)), vec![0]));
 		});

--- a/crml/sylo/src/lib.rs
+++ b/crml/sylo/src/lib.rs
@@ -19,6 +19,7 @@ pub mod device;
 pub mod e2ee;
 pub mod groups;
 pub mod inbox;
+mod migration;
 pub mod response;
 pub mod vault;
 

--- a/crml/sylo/src/lib.rs
+++ b/crml/sylo/src/lib.rs
@@ -19,7 +19,7 @@ pub mod device;
 pub mod e2ee;
 pub mod groups;
 pub mod inbox;
-mod migration;
+pub mod migration;
 pub mod response;
 pub mod vault;
 

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -44,7 +44,7 @@ decl_module! {
 		}
 
 		#[weight = SimpleDispatchInfo::FixedOperational(0)]
-		pub fn remove_migrator_account(origin) -> DispatchResult {
+		pub fn self_destruct(origin) -> DispatchResult {
 			Self::ensure_sylo_migrator(origin)?;
 			MigrationAccount::<T>::kill();
 			Ok(())
@@ -134,7 +134,7 @@ mod tests {
 
 			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
 
-			assert_ok!(Migration::remove_migrator_account(Origin::signed(migration_account)));
+			assert_ok!(Migration::self_destruct(Origin::signed(migration_account)));
 
 			assert_eq!(
 				Migration::ensure_sylo_migrator(Origin::signed(migration_account)),
@@ -152,7 +152,7 @@ mod tests {
 			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
 
 			assert_eq!(
-				Migration::remove_migrator_account(Origin::signed(invalid_account)),
+				Migration::self_destruct(Origin::signed(invalid_account)),
 				Err(BadOrigin)
 			);
 

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -37,7 +37,7 @@ decl_module! {
 
 		#[weight = SimpleDispatchInfo::FixedOperational(0)]
 		pub fn remove_migrator_account(origin) -> DispatchResult {
-			ensure_root(origin)?;
+			Self::ensure_sylo_migrator(origin)?;
 			MigrationAccount::<T>::kill();
 			Ok(())
 		}

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -58,7 +58,7 @@ decl_module! {
 			ensure!(device_ids.len() <= device::MAX_DEVICES, Error::<T>::InputError);
 
 			let mut devices = <device::Devices<T>>::get(user_id.clone());
-			ensure!(devices.len() <= device::MAX_DEVICES, Error::<T>::InputError);
+			ensure!(devices.len() + device_ids.len() <= device::MAX_DEVICES, Error::<T>::InputError);
 
 			for device_id in device_ids {
 				devices.push(device_id)

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -58,9 +58,11 @@ decl_module! {
 			let mut devices = <device::Devices<T>>::get(user_id.clone());
 			ensure!(devices.len() + device_ids.len() <= device::MAX_DEVICES, Error::<T>::MaxDeviceLimitReached);
 
-			devices.extend(device_ids);
-			devices.sort();
-			devices.dedup();
+			for device_id in device_ids {
+				if !devices.contains(&device_id) {
+					devices.push(device_id);
+				}
+			}
 
 			<device::Devices<T>>::insert(user_id, devices);
 
@@ -196,7 +198,7 @@ mod tests {
 				devices.clone()
 			));
 
-			assert_eq!(Device::devices(user_id), [1, 2, 3, 4]);
+			assert_eq!(Device::devices(user_id), [3, 1, 2, 4]);
 		});
 	}
 

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -13,12 +13,14 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-use crate::{device, e2ee, groups, inbox, response, vault};
+use crate::{device, groups, inbox, vault};
 use frame_support::{decl_module, decl_storage, ensure, weights::SimpleDispatchInfo};
 use frame_system::{ensure_root, ensure_signed};
 use sp_runtime::{DispatchError::BadOrigin, DispatchResult};
 
-pub trait Trait: device::Trait + e2ee::Trait + groups::Trait + inbox::Trait + response::Trait + vault::Trait {}
+pub trait Trait: device::Trait + groups::Trait + inbox::Trait + vault::Trait {}
+
+type DeviceId = device::DeviceId;
 
 decl_storage! {
 	trait Store for Module<T: Trait> as SyloMigration {
@@ -41,13 +43,166 @@ decl_module! {
 			MigrationAccount::<T>::kill();
 			Ok(())
 		}
+
+		// todo: add weight
+		fn migrate_devices(origin, user_id: T::AccountId, device_ids: Vec<DeviceId>) -> DispatchResult {
+			Self::ensure_sylo_migrator(origin)?;
+			for device_id in &device_ids {
+				// We don't care if this fails (for now)
+				let _ = <device::Module<T>>::append_device(&user_id, device_id.clone());
+			}
+			Ok(())
+		}
 	}
 }
 
 impl<T: Trait> Module<T> {
-	fn ensure_sylo_migrator(origin: T::Origin) -> DispatchResult {
+	pub fn ensure_sylo_migrator(origin: T::Origin) -> DispatchResult {
 		let account_id = ensure_signed(origin)?;
 		ensure!(MigrationAccount::<T>::get() == account_id, BadOrigin);
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{ExtBuilder, Origin, Test};
+	use frame_support::assert_ok;
+	use sp_core::H256;
+	use sp_runtime::DispatchError::BadOrigin;
+
+	impl Trait for Test {}
+	type Migration = Module<Test>;
+	type Device = device::Module<Test>;
+
+	#[test]
+	fn set_migration_account_works() {
+		ExtBuilder::default().build().execute_with(|| {
+			let migration_account = H256::from_low_u64_be(2);
+
+			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
+
+			assert_ok!(Migration::ensure_sylo_migrator(Origin::signed(migration_account)));
+		});
+	}
+
+	#[test]
+	fn wrong_migration_account_fails_ensure() {
+		ExtBuilder::default().build().execute_with(|| {
+			let migration_account = H256::from_low_u64_be(2);
+			let invalid_account = H256::from_low_u64_be(3);
+
+			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
+
+			assert_eq!(
+				Migration::ensure_sylo_migrator(Origin::signed(invalid_account)),
+				Err(BadOrigin)
+			);
+		});
+	}
+
+	#[test]
+	fn no_migration_account_fails_ensure() {
+		ExtBuilder::default().build().execute_with(|| {
+			let migration_account = H256::from_low_u64_be(2);
+
+			assert_eq!(
+				Migration::ensure_sylo_migrator(Origin::signed(migration_account)),
+				Err(BadOrigin)
+			);
+		});
+	}
+
+	#[test]
+	fn remove_migration_account_works() {
+		ExtBuilder::default().build().execute_with(|| {
+			let migration_account = H256::from_low_u64_be(2);
+
+			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
+
+			assert_ok!(Migration::remove_migrator_account(Origin::signed(migration_account)));
+
+			assert_eq!(
+				Migration::ensure_sylo_migrator(Origin::signed(migration_account)),
+				Err(BadOrigin)
+			);
+		});
+	}
+
+	#[test]
+	fn remove_migration_account_with_invalid_account_fails() {
+		ExtBuilder::default().build().execute_with(|| {
+			let migration_account = H256::from_low_u64_be(2);
+			let invalid_account = H256::from_low_u64_be(3);
+
+			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
+
+			assert_eq!(
+				Migration::remove_migrator_account(Origin::signed(invalid_account)),
+				Err(BadOrigin)
+			);
+
+			assert_ok!(Migration::ensure_sylo_migrator(Origin::signed(migration_account)));
+		});
+	}
+
+	#[test]
+	fn migrate_devices_works() {
+		ExtBuilder::default().build().execute_with(|| {
+			let user_id = H256::from_low_u64_be(1);
+			let devices = vec![1, 2, 3, 4];
+			let migration_account = H256::from_low_u64_be(2);
+
+			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
+
+			assert_ok!(Migration::migrate_devices(
+				Origin::signed(migration_account),
+				user_id.clone(),
+				devices.clone()
+			));
+
+			assert_eq!(Device::devices(user_id), [1, 2, 3, 4]);
+		});
+	}
+
+	#[test]
+	fn migrate_devices_does_not_double_up() {
+		ExtBuilder::default().build().execute_with(|| {
+			let user_id = H256::from_low_u64_be(1);
+			let devices = vec![1, 2, 3, 4];
+			let migration_account = H256::from_low_u64_be(2);
+
+			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
+
+			assert_ok!(Device::append_device(&user_id, 3));
+
+			assert_ok!(Migration::migrate_devices(
+				Origin::signed(migration_account),
+				user_id.clone(),
+				devices.clone()
+			));
+
+			assert_eq!(Device::devices(user_id), [3, 1, 2, 4]);
+		});
+	}
+
+	#[test]
+	fn migrate_devices_fails_with_bad_account() {
+		ExtBuilder::default().build().execute_with(|| {
+			let user_id = H256::from_low_u64_be(1);
+			let devices = vec![1, 2, 3, 4];
+			let migration_account = H256::from_low_u64_be(2);
+			let invalid_account = H256::from_low_u64_be(3);
+
+			assert_ok!(Migration::set_migrator_account(Origin::ROOT, migration_account));
+
+			assert_eq!(
+				Migration::migrate_devices(Origin::signed(invalid_account), user_id.clone(), devices.clone()),
+				Err(BadOrigin)
+			);
+
+			assert_eq!(Device::devices(user_id), []);
+		});
 	}
 }

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -13,7 +13,10 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-use crate::{device, groups, inbox, vault};
+use crate::{
+	device::{self, DeviceId},
+	groups, inbox, vault,
+};
 use frame_support::{decl_error, decl_module, decl_storage, dispatch::Vec, ensure, weights::SimpleDispatchInfo};
 use frame_system::{ensure_root, ensure_signed};
 use sp_runtime::{DispatchError::BadOrigin, DispatchResult};
@@ -51,7 +54,7 @@ decl_module! {
 		}
 
 		#[weight = SimpleDispatchInfo::FixedOperational(0)]
-		fn migrate_devices(origin, user_id: T::AccountId, device_ids: Vec<device::DeviceId>) -> DispatchResult {
+		fn migrate_devices(origin, user_id: T::AccountId, device_ids: Vec<DeviceId>) -> DispatchResult {
 			Self::ensure_sylo_migrator(origin)?;
 			ensure!(device_ids.len() <= device::MAX_DEVICES, Error::<T>::MaxDeviceLimitReached);
 

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -1,0 +1,53 @@
+/* Copyright 2020 Centrality Investments Limited
+*
+* Licensed under the LGPL, Version 3.0 (the "License");
+* you may not use this file except in compliance with the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* You may obtain a copy of the License at the root of this project source code,
+* or at:
+*     https://centrality.ai/licenses/gplv3.txt
+*     https://centrality.ai/licenses/lgplv3.txt
+*/
+
+use crate::{device, e2ee, groups, inbox, response, vault};
+use frame_support::{decl_module, decl_storage, ensure, weights::SimpleDispatchInfo};
+use frame_system::{ensure_root, ensure_signed};
+use sp_runtime::{DispatchError::BadOrigin, DispatchResult};
+
+pub trait Trait: device::Trait + e2ee::Trait + groups::Trait + inbox::Trait + response::Trait + vault::Trait {}
+
+decl_storage! {
+	trait Store for Module<T: Trait> as SyloMigration {
+		MigrationAccount: T::AccountId;
+	}
+}
+
+decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
+		#[weight = SimpleDispatchInfo::FixedOperational(0)]
+		pub fn set_migrator_account(origin, account_id: T::AccountId) -> DispatchResult {
+			ensure_root(origin)?;
+			MigrationAccount::<T>::put(account_id);
+			Ok(())
+		}
+
+		#[weight = SimpleDispatchInfo::FixedOperational(0)]
+		pub fn remove_migrator_account(origin) -> DispatchResult {
+			ensure_root(origin)?;
+			MigrationAccount::<T>::kill();
+			Ok(())
+		}
+	}
+}
+
+impl<T: Trait> Module<T> {
+	fn ensure_sylo_migrator(origin: T::Origin) -> DispatchResult {
+		let account_id = ensure_signed(origin)?;
+		ensure!(MigrationAccount::<T>::get() == account_id, BadOrigin);
+		Ok(())
+	}
+}

--- a/crml/sylo/src/mock.rs
+++ b/crml/sylo/src/mock.rs
@@ -66,8 +66,16 @@ impl_outer_origin! {
 
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
-pub struct ExtBuilder;
+#[derive(Default)]
+pub struct ExtBuilder {
+	migrator_account: u64,
+}
+
 impl ExtBuilder {
+	pub fn migrator_account(mut self, account_id: u64) -> Self {
+		self.migrator_account = account_id;
+		self
+	}
 	pub fn build(self) -> sp_io::TestExternalities {
 		frame_system::GenesisConfig::default()
 			.build_storage::<Test>()

--- a/crml/sylo/src/mock.rs
+++ b/crml/sylo/src/mock.rs
@@ -67,15 +67,9 @@ impl_outer_origin! {
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 #[derive(Default)]
-pub struct ExtBuilder {
-	migrator_account: u64,
-}
+pub struct ExtBuilder {}
 
 impl ExtBuilder {
-	pub fn migrator_account(mut self, account_id: u64) -> Self {
-		self.migrator_account = account_id;
-		self
-	}
 	pub fn build(self) -> sp_io::TestExternalities {
 		frame_system::GenesisConfig::default()
 			.build_storage::<Test>()

--- a/crml/sylo/src/response.rs
+++ b/crml/sylo/src/response.rs
@@ -75,7 +75,7 @@ pub(super) mod tests {
 
 	#[test]
 	fn should_set_response() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let request_id = H256::from([1; 32]);
 			let resp_number = Response::DeviceId(111);
 

--- a/crml/sylo/src/vault.rs
+++ b/crml/sylo/src/vault.rs
@@ -107,7 +107,7 @@ mod tests {
 
 	#[test]
 	fn should_upsert_values() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let key_0 = b"0".to_vec();
 			let value_0 = b"1".to_vec();
 
@@ -140,7 +140,7 @@ mod tests {
 
 	#[test]
 	fn should_replace_existing_keys() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let key_0 = b"0".to_vec();
 			let value_0 = b"1".to_vec();
 			let value_1 = b"01".to_vec();
@@ -165,7 +165,7 @@ mod tests {
 
 	#[test]
 	fn should_delete_keys() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let key_0 = b"0".to_vec();
 			let key_1 = b"1".to_vec();
 			let value_0 = b"01".to_vec();
@@ -198,7 +198,7 @@ mod tests {
 
 	#[test]
 	fn should_not_add_more_than_max_keys() {
-		ExtBuilder.build().execute_with(|| {
+		ExtBuilder::default().build().execute_with(|| {
 			let user_id = H256::from_low_u64_be(1);
 			for i in 0..MAX_KEYS {
 				let key = format!("key_{}", i).into_bytes();

--- a/crml/sylo/src/vault.rs
+++ b/crml/sylo/src/vault.rs
@@ -13,7 +13,7 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-use frame_support::{decl_error, decl_module, decl_storage, dispatch::Vec, ensure, weights::SimpleDispatchInfo};
+use frame_support::{decl_error, decl_module, decl_storage, dispatch::{Vec, DispatchResult}, ensure, weights::SimpleDispatchInfo};
 use frame_system::ensure_signed;
 
 pub const MAX_KEYS: usize = 100;
@@ -92,6 +92,11 @@ impl<T: Trait> Module<T> {
 			.collect();
 
 		<Vault<T>>::insert(user_id, remaining_values)
+	}
+
+	pub fn ensure_sylo_migrator(origin: T::Origin) -> DispatchResult {
+		let account_id = ensure_signed(origin)?;
+		Ok(())
 	}
 }
 

--- a/crml/sylo/src/vault.rs
+++ b/crml/sylo/src/vault.rs
@@ -13,7 +13,7 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-use frame_support::{decl_error, decl_module, decl_storage, dispatch::{Vec, DispatchResult}, ensure, weights::SimpleDispatchInfo};
+use frame_support::{decl_error, decl_module, decl_storage, dispatch::Vec, ensure, weights::SimpleDispatchInfo};
 use frame_system::ensure_signed;
 
 pub const MAX_KEYS: usize = 100;
@@ -92,11 +92,6 @@ impl<T: Trait> Module<T> {
 			.collect();
 
 		<Vault<T>>::insert(user_id, remaining_values)
-	}
-
-	pub fn ensure_sylo_migrator(origin: T::Origin) -> DispatchResult {
-		let account_id = ensure_signed(origin)?;
-		Ok(())
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -63,6 +63,7 @@ pub use crml_sylo::device as sylo_device;
 pub use crml_sylo::e2ee as sylo_e2ee;
 pub use crml_sylo::groups as sylo_groups;
 pub use crml_sylo::inbox as sylo_inbox;
+pub use crml_sylo::migration as sylo_migration;
 pub use crml_sylo::response as sylo_response;
 pub use crml_sylo::vault as sylo_vault;
 
@@ -177,6 +178,7 @@ impl crml_sylo::device::Trait for Runtime {}
 impl crml_sylo::response::Trait for Runtime {}
 impl crml_sylo::inbox::Trait for Runtime {}
 impl crml_sylo::vault::Trait for Runtime {}
+impl crml_sylo::migration::Trait for Runtime {}
 
 parameter_types! {
 	pub const EpochDuration: u64 = EPOCH_DURATION_IN_SLOTS;
@@ -572,6 +574,7 @@ construct_runtime!(
 		SyloInbox: sylo_inbox::{Module, Call, Storage},
 		SyloResponse: sylo_response::{Module, Call, Storage},
 		SyloVault: sylo_vault::{Module, Call, Storage},
+		SyloMigration: sylo_migration::{Module, Call, Storage},
 		CennzxSpot: crml_cennzx_spot::{Module, Call, Storage, Config<T>, Event<T>},
 	}
 );


### PR DESCRIPTION
The PR is to prepare for the upcoming Sylo data migration.

### Changes

Add a separate `migration.rs` runtime module that implements the following:
- Add `MigrationAccount` storage item, which will store only one migrator account
- Add 3 dispatch calls:
    - `fn set_migrator_account`, which requires root permission
    - `fn remove_migrator_account`, which is to kill the storage after migration is finished
    - `fn migrate_devices`, which will put new data (from arg) into Devices storage
- Add private `fn ensure_sylo_migrator` module method to only allow migration account to call migration methods
- Add `FixedOperational(0)` for the weights
- Add tests to show the above is working