### PR TITLE
Support for Sylo data migration

### DIFF
--- a/crml/sylo/src/inbox.rs
+++ b/crml/sylo/src/inbox.rs
@@ -21,8 +21,8 @@ use frame_system::ensure_signed;
 const MAX_MESSAGE_LENGTH: usize = 100_000;
 const MAX_DELETE_MESSAGES: usize = 10_000;
 
-type MessageId = u32;
-type Message = Vec<u8>;
+pub type MessageId = u32;
+pub type Message = Vec<u8>;
 
 pub trait Trait: frame_system::Trait {}
 
@@ -69,8 +69,8 @@ decl_module! {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as SyloInbox {
-		NextIndexes: map hasher(blake2_128_concat) T::AccountId => MessageId;
-		Values get(values): map hasher(blake2_128_concat) T::AccountId => Vec<(MessageId, Message)>;
+		pub NextIndexes: map hasher(blake2_128_concat) T::AccountId => MessageId;
+		pub Values get(values): map hasher(blake2_128_concat) T::AccountId => Vec<(MessageId, Message)>;
 	}
 }
 

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -80,7 +80,7 @@ decl_module! {
 		fn migrate_inbox(origin, user_id: T::AccountId, next_index: MessageId, new_messages: Vec<(MessageId, Message)>) -> DispatchResult {
 			Self::ensure_sylo_migrator(origin)?;
 
-			let mut existing_messages = <inbox::Values<T>>::get(&user_id).clone();
+			let mut existing_messages = <inbox::Values<T>>::get(&user_id);
 			let (existing_indexes, _): (Vec<MessageId>, Vec<_>) = existing_messages.clone().into_iter().unzip();
 
 			// For repeatability, we update the existing messages that are assumed to be migrated already.
@@ -90,7 +90,6 @@ decl_module! {
 				}
 			}
 
-			ensure!(existing_messages.len() as u32 <= u32::max_value(), Error::<T>::MaxInboxLimitReached);
 			<inbox::Values<T>>::insert(&user_id, existing_messages);
 			<inbox::NextIndexes<T>>::insert(&user_id, next_index);
 			Ok(())
@@ -100,7 +99,7 @@ decl_module! {
 		fn migrate_vault(origin, user_id: T::AccountId, new_vaults: Vec<(VaultKey, VaultValue)>) -> DispatchResult {
 			Self::ensure_sylo_migrator(origin)?;
 
-			let mut existing_vaults = <vault::Vault<T>>::get(&user_id).clone();
+			let mut existing_vaults = <vault::Vault<T>>::get(&user_id);
 			let (existing_vault_key, _): (Vec<VaultKey>, Vec<_>) = existing_vaults.clone().into_iter().unzip();
 
 			// For repeatability, we update the existing vaults that are assumed to be migrated already.

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -296,7 +296,7 @@ mod tests {
 	}
 
 	#[test]
-	fn migrate_inbox_works_with_existing_messages() {
+	fn migrate_inbox_works_with_existing_data() {
 		ExtBuilder::default().build().execute_with(|| {
 			let user_id = H256::from_low_u64_be(1);
 			let next_index = 7357;
@@ -363,7 +363,7 @@ mod tests {
 	}
 
 	#[test]
-	fn migrate_vault_works_with_existing_messages() {
+	fn migrate_vault_works_with_existing_data() {
 		ExtBuilder::default().build().execute_with(|| {
 			let user_id = H256::from_low_u64_be(1);
 			let existing_vaults = vec![


### PR DESCRIPTION
### Changes
- Add `fn migrate_inbox`
- Add `fn migrate_vault`
- ~~Expose required types & storages~~
- Add unit tests

### Concerns / Notes
- method signatures could be changed later depending on the migration script and API
- `fn migrate_inbox` retrieves any existing messages and append new messages whose index is not present in the existing data
    - this is done to leave the existing messages alone, assuming that these are already (partially) migrated
    - otherwise we could end up with duplicates or two versions of data