### PR TITLE
Peg nightly for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ commands:
             source ~/.cargo/env
             rustup install $RUST_VERSION
             rustup default $RUST_VERSION
-            rustup install nightly
-            rustup target add --toolchain=nightly wasm32-unknown-unknown
+            rustup install nightly-2020-04-17
+            rustup target add --toolchain=nightly-2020-04-17 wasm32-unknown-unknown
             rustup target add --toolchain=$RUST_VERSION x86_64-unknown-linux-musl
             rustc --version; cargo --version; rustup --version
   install-sccache:


### PR DESCRIPTION
### Context

Using the latest nightly breaks one of dependencies we have:
```rust
error[E0514]: found crate `autocfg` compiled by an incompatible version of rustc
 --> /home/circleci/.cargo/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.11/build.rs:1:1
  |
1 | extern crate autocfg;
  | ^^^^^^^^^^^^^^^^^^^^^
  |
  = help: please recompile that crate using this compiler (rustc 1.44.0-nightly (ce93331e2 2020-04-17))
```

### Changes

- Add `nightly-2020-04-17` to avoid using the latest nightly version