### PR TITLE
Fix/flaky membership check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "cennznet"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cennznet-cli",
  "ctrlc",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "cennznet-runtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cennznet-cli",
  "cennznet-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/main.rs"
 
 [package]
 name = "cennznet"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 build = "build.rs"
 edition = "2018"

--- a/crml/sylo/src/device.rs
+++ b/crml/sylo/src/device.rs
@@ -93,9 +93,10 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{ExtBuilder, Test};
+	use crate::mock::{ExtBuilder, Origin, Test};
 	use frame_support::{assert_noop, assert_ok};
 	use sp_core::H256;
+	use sp_runtime::DispatchError::Other;
 
 	type Device = Module<Test>;
 
@@ -180,9 +181,6 @@ mod tests {
 		});
 	}
 
-	use crate::mock::Origin;
-	use sp_runtime::DispatchError::BadOrigin;
-
 	type Migration = migration::Module<Test>;
 
 	impl Trait for Test {}
@@ -239,7 +237,7 @@ mod tests {
 
 			assert_eq!(
 				Device::migrate_devices(Origin::signed(invalid_account), user_id.clone(), devices.clone()),
-				Err(BadOrigin)
+				Err(Other("NotASyloMigrator"))
 			);
 
 			assert_eq!(Device::devices(user_id), []);

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -17,7 +17,7 @@
 
 use frame_support::{decl_module, decl_storage, ensure, weights::SimpleDispatchInfo, IterableStorageMap};
 use frame_system::{ensure_root, ensure_signed};
-use sp_runtime::{DispatchError::BadOrigin, DispatchResult};
+use sp_runtime::DispatchResult;
 use sp_std::prelude::*;
 
 pub trait Trait: frame_system::Trait {}
@@ -25,7 +25,7 @@ pub trait Trait: frame_system::Trait {}
 decl_storage! {
 	trait Store for Module<T: Trait> as SyloMigration {
 		/// Accounts which have authority to make Sylo data migration calls
-		AuthorisedMigrators: map hasher(twox_64_concat) T::AccountId => ();
+		AuthorisedMigrators: map hasher(twox_64_concat) T::AccountId => bool;
 	}
 }
 
@@ -36,7 +36,7 @@ decl_module! {
 		#[weight = SimpleDispatchInfo::FixedOperational(0)]
 		pub fn set_migrator_account(origin, account_id: T::AccountId) -> DispatchResult {
 			ensure_root(origin)?;
-			AuthorisedMigrators::<T>::insert(account_id, ());
+			AuthorisedMigrators::<T>::insert(account_id, true);
 			Ok(())
 		}
 
@@ -45,7 +45,7 @@ decl_module! {
 		#[weight = SimpleDispatchInfo::FixedOperational(0)]
 		pub fn revoke_migrators(origin) -> DispatchResult {
 			Self::ensure_sylo_migrator(origin)?;
-			let _ = AuthorisedMigrators::<T>::drain().collect::<Vec<(T::AccountId, ())>>();
+			let _ = AuthorisedMigrators::<T>::drain().collect::<Vec<(T::AccountId, bool)>>();
 			Ok(())
 		}
 	}
@@ -55,7 +55,7 @@ impl<T: Trait> Module<T> {
 	// Ensure `origin` is an authorized Sylo data migrator
 	pub fn ensure_sylo_migrator(origin: T::Origin) -> DispatchResult {
 		let account_id = ensure_signed(origin)?;
-		ensure!(AuthorisedMigrators::<T>::contains_key(account_id), BadOrigin);
+		ensure!(AuthorisedMigrators::<T>::get(account_id), "NotASyloMigrator");
 		Ok(())
 	}
 }
@@ -66,7 +66,7 @@ mod tests {
 	use crate::mock::{ExtBuilder, Origin, Test};
 	use frame_support::assert_ok;
 	use sp_core::H256;
-	use sp_runtime::DispatchError::BadOrigin;
+	use sp_runtime::DispatchError::Other;
 
 	type Migration = Module<Test>;
 
@@ -96,7 +96,7 @@ mod tests {
 
 			assert_eq!(
 				Migration::ensure_sylo_migrator(Origin::signed(invalid_account)),
-				Err(BadOrigin)
+				Err(Other("NotASyloMigrator"))
 			);
 		});
 	}
@@ -108,7 +108,7 @@ mod tests {
 
 			assert_eq!(
 				Migration::ensure_sylo_migrator(Origin::signed(migration_account)),
-				Err(BadOrigin)
+				Err(Other("NotASyloMigrator"))
 			);
 		});
 	}
@@ -126,15 +126,15 @@ mod tests {
 
 			assert_eq!(
 				Migration::ensure_sylo_migrator(Origin::signed(migrator_a)),
-				Err(BadOrigin)
+				Err(Other("NotASyloMigrator"))
 			);
 			assert_eq!(
 				Migration::ensure_sylo_migrator(Origin::signed(migrator_b)),
-				Err(BadOrigin)
+				Err(Other("NotASyloMigrator"))
 			);
 
 			// Migrator storage has emptied
-			assert!(AuthorisedMigrators::<Test>::iter().collect::<Vec<(_, ())>>().is_empty());
+			assert!(AuthorisedMigrators::<Test>::iter().collect::<Vec<(_, bool)>>().is_empty());
 		});
 	}
 
@@ -148,7 +148,7 @@ mod tests {
 
 			assert_eq!(
 				Migration::revoke_migrators(Origin::signed(invalid_account)),
-				Err(BadOrigin)
+				Err(Other("NotASyloMigrator"))
 			);
 
 			assert_ok!(Migration::ensure_sylo_migrator(Origin::signed(migration_account)));

--- a/crml/sylo/src/migration.rs
+++ b/crml/sylo/src/migration.rs
@@ -134,7 +134,9 @@ mod tests {
 			);
 
 			// Migrator storage has emptied
-			assert!(AuthorisedMigrators::<Test>::iter().collect::<Vec<(_, bool)>>().is_empty());
+			assert!(AuthorisedMigrators::<Test>::iter()
+				.collect::<Vec<(_, bool)>>()
+				.is_empty());
 		});
 	}
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-runtime"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -91,8 +91,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set `impl_version` to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave `spec_version` as
 	// is and increment `impl_version`.
-	spec_version: 31,
-	impl_version: 31,
+	spec_version: 32,
+	impl_version: 32,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
ZSTs like `()` are not properly supported by trie storage. This was causing non-deterministic behaviour.

This PR makes the value a boolean which solves the issue.
Also:
- made the error different to `BadOrigin` to make debugging easier.
- Bump cargo versions to 1.0.1 so running node shows the correct version

see: https://github.com/paritytech/subport/issues/7