### PR TITLE
Chore/247 coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ commands:
           name: Report test coverage
           command: |
             cargo install grcov
+            rustup target add --toolchain=$RUST_NIGHTLY x86_64-unknown-linux-gnu
             export CARGO_INCREMENTAL=0
             export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
             export RUSTDOCFLAGS="-Cpanic=abort"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ commands:
             rustup install $RUST_NIGHTLY
             rustup target add --toolchain=$RUST_NIGHTLY wasm32-unknown-unknown
             rustup target add --toolchain=$RUST_VERSION x86_64-unknown-linux-musl
-            cargo install grcov
             rustc --version; cargo --version; rustup --version
   install-sccache:
     steps:
@@ -95,14 +94,15 @@ commands:
       - run:
           name: Report test coverage
           command: |
+            cargo install grcov
             export CARGO_INCREMENTAL=0
             export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
             export RUSTDOCFLAGS="-Cpanic=abort"
             export SKIP_WASM_BUILD=1
             export LLVM_CONFIG_PATH="/usr/local/opt/llvm/bin/llvm-config"
-            cargo +nightly build --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-musl
-            cargo +nightly test --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-musl
-            grcov ./target/x86_64-unknown-linux-musl/debug/ -s . -t html --llvm --branch --ignore-not-existing -o /tmp/coverage/
+            cargo +nightly build --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-gnu
+            cargo +nightly test --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-gnu
+            grcov ./target/x86_64-unknown-linux-gnu/debug/ -s . -t html --llvm --branch --ignore-not-existing -o /tmp/coverage/
       - store_artifacts:
           path: /tmp/coverage
   docker-build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,24 +188,5 @@ workflows:
   version: 2
   build-test-publish:
     jobs:
-      - format:
-          context: Rust
-      - build-bin:
-          context: Rust    
-      - build-test-and-run:
-          context: Rust
       - report-test-coverage:
           context: Rust
-      - build-docker-and-publish:
-          filters:
-            branches:
-              only:
-                - develop
-                - /^[0-9]+[.][0-9]+[.][0-9](-rc.+)?$/
-      - build:
-          requires:
-            - format
-            - build-bin
-            - build-test-and-run
-            - report-test-coverage
-            - build-docker-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,16 +94,20 @@ commands:
       - run:
           name: Report test coverage
           command: |
+            set -o xtrace
             cargo install grcov
+            echo "RN = $RUST_NIGHTLY"
             rustup target add --toolchain=$RUST_NIGHTLY x86_64-unknown-linux-gnu
             export CARGO_INCREMENTAL=0
             export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
             export RUSTDOCFLAGS="-Cpanic=abort"
             export SKIP_WASM_BUILD=1
             export LLVM_CONFIG_PATH="/usr/local/opt/llvm/bin/llvm-config"
+            source ~/.cargo/env
             cargo +nightly build --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-gnu
             cargo +nightly test --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-gnu
             grcov ./target/x86_64-unknown-linux-gnu/debug/ -s . -t html --llvm --branch --ignore-not-existing -o /tmp/coverage/
+            set +o xtrace
       - store_artifacts:
           path: /tmp/coverage
   docker-build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,18 +94,7 @@ commands:
       - run:
           name: Report test coverage
           command: |
-            set -o xtrace
-            cargo install grcov
-            rustup target add --toolchain=$RUST_NIGHTLY x86_64-unknown-linux-gnu
-            mv ~/.rustup/toolchains/nightly-* ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
-            export CARGO_INCREMENTAL=0
-            export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
-            export RUSTDOCFLAGS="-Cpanic=abort"
-            export SKIP_WASM_BUILD=1
-            export LLVM_CONFIG_PATH="/usr/local/opt/llvm/bin/llvm-config"
-            cargo +nightly build --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-gnu
-            cargo +nightly test --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-gnu
-            grcov ./target/x86_64-unknown-linux-gnu/debug/ -s . -t html --llvm --branch --ignore-not-existing -o /tmp/coverage/
+            ./scripts/test-coverage.sh crml-cennzx-spot crml-sylo
       - store_artifacts:
           path: /tmp/coverage
   docker-build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ commands:
             rustup install $RUST_NIGHTLY
             rustup target add --toolchain=$RUST_NIGHTLY wasm32-unknown-unknown
             rustup target add --toolchain=$RUST_VERSION x86_64-unknown-linux-musl
+            cargo install grcov
             rustc --version; cargo --version; rustup --version
   install-sccache:
     steps:
@@ -89,6 +90,16 @@ commands:
           name: Run tests
           command: |
             cargo test --all
+  cargo-test-coverage:
+    steps:
+      - run:
+          name: Report test coverage
+          command: |
+            cargo +nightly build --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-musl
+            cargo +nightly test --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-musl
+            grcov ./target/x86_64-unknown-linux-musl/debug/ -s . -t html --llvm --branch --ignore-not-existing -o /tmp/coverage/
+      - store_artifacts:
+          path: /tmp/coverage
   docker-build-and-publish:
     steps:
       - run:
@@ -153,6 +164,19 @@ jobs:
       - save-cache
       - save-target-cache
       - cargo-run-test
+  report-test-coverage:
+    machine:
+      image: ubuntu-1604:201903-01
+    environment:
+      BASH_ENV: ~/.cargo/env
+      CARGO_INCREMENTAL: 0
+      RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
+      SKIP_WASM_BUILD: 1
+      LLVM_CONFIG_PATH: /usr/local/opt/llvm/bin/llvm-config
+    steps:
+      - checkout
+      - install-rust
+      - cargo-test-coverage
   build-docker-and-publish:
     machine:
       image: ubuntu-1604:201903-01
@@ -169,7 +193,9 @@ workflows:
       - build-bin:
           context: Rust    
       - build-test-and-run:
-          context: Rust     
+          context: Rust
+      - report-test-coverage:
+          context: Rust
       - build-docker-and-publish:
           filters:
             branches:
@@ -181,4 +207,5 @@ workflows:
             - format
             - build-bin
             - build-test-and-run
+            - report-test-coverage
             - build-docker-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,18 +96,16 @@ commands:
           command: |
             set -o xtrace
             cargo install grcov
-            echo "RN = $RUST_NIGHTLY"
             rustup target add --toolchain=$RUST_NIGHTLY x86_64-unknown-linux-gnu
+            mv ~/.rustup/toolchains/nightly-* ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
             export CARGO_INCREMENTAL=0
             export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
             export RUSTDOCFLAGS="-Cpanic=abort"
             export SKIP_WASM_BUILD=1
             export LLVM_CONFIG_PATH="/usr/local/opt/llvm/bin/llvm-config"
-            source ~/.cargo/env
             cargo +nightly build --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-gnu
             cargo +nightly test --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-gnu
             grcov ./target/x86_64-unknown-linux-gnu/debug/ -s . -t html --llvm --branch --ignore-not-existing -o /tmp/coverage/
-            set +o xtrace
       - store_artifacts:
           path: /tmp/coverage
   docker-build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,15 +91,15 @@ commands:
           command: |
             cargo test --all
   cargo-test-coverage:
-    environment:
-      CARGO_INCREMENTAL: 0
-      RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
-      SKIP_WASM_BUILD: 1
-      LLVM_CONFIG_PATH: /usr/local/opt/llvm/bin/llvm-config
     steps:
       - run:
           name: Report test coverage
           command: |
+            export CARGO_INCREMENTAL=0
+            export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+            export RUSTDOCFLAGS="-Cpanic=abort"
+            export SKIP_WASM_BUILD=1
+            export LLVM_CONFIG_PATH="/usr/local/opt/llvm/bin/llvm-config"
             cargo +nightly build --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-musl
             cargo +nightly test --package crml-cennzx-spot  --package crml-sylo --target x86_64-unknown-linux-musl
             grcov ./target/x86_64-unknown-linux-musl/debug/ -s . -t html --llvm --branch --ignore-not-existing -o /tmp/coverage/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,13 +82,13 @@ commands:
       - run:
           name: Build tests
           command: |
-            cargo test --no-run --all
+            cargo test --no-run --workspace --exclude crml-cennzx-spot --exclude crml-sylo
   cargo-run-test:
     steps:
       - run:
           name: Run tests
           command: |
-            cargo test --all
+            cargo test --workspace --exclude crml-cennzx-spot --exclude crml-sylo
   cargo-test-coverage:
     steps:
       - run:
@@ -192,5 +192,24 @@ workflows:
   version: 2
   build-test-publish:
     jobs:
+      - format:
+          context: Rust
+      - build-bin:
+          context: Rust    
+      - build-test-and-run:
+          context: Rust
       - report-test-coverage:
           context: Rust
+      - build-docker-and-publish:
+          filters:
+            branches:
+              only:
+                - develop
+                - /^[0-9]+[.][0-9]+[.][0-9](-rc.+)?$/
+      - build:
+          requires:
+            - format
+            - build-bin
+            - build-test-and-run
+            - report-test-coverage
+            - build-docker-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,11 @@ commands:
           command: |
             cargo test --all
   cargo-test-coverage:
+    environment:
+      CARGO_INCREMENTAL: 0
+      RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
+      SKIP_WASM_BUILD: 1
+      LLVM_CONFIG_PATH: /usr/local/opt/llvm/bin/llvm-config
     steps:
       - run:
           name: Report test coverage
@@ -169,10 +174,6 @@ jobs:
       image: ubuntu-1604:201903-01
     environment:
       BASH_ENV: ~/.cargo/env
-      CARGO_INCREMENTAL: 0
-      RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
-      SKIP_WASM_BUILD: 1
-      LLVM_CONFIG_PATH: /usr/local/opt/llvm/bin/llvm-config
     steps:
       - checkout
       - install-rust

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Build and test the specified rust packages to produce the coverage files which is then fed to grcov to generate a report
+example="$0 crml-cennzx-spot crml-sylo"
+
+if [ $# -eq 0 ]; then
+  echo "Error: no rust package name is specified"
+  echo "Usage example: $example"
+  exit 1
+fi
+
+for p in "$@"
+do
+    packages="--package $p $packages";
+done
+
+set -o xtrace
+
+cargo install grcov
+
+rustup target add --toolchain=$RUST_NIGHTLY x86_64-unknown-linux-gnu
+mv ~/.rustup/toolchains/nightly-* ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
+
+export CARGO_INCREMENTAL=0
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+export RUSTDOCFLAGS="-Cpanic=abort"
+
+export SKIP_WASM_BUILD=1
+export LLVM_CONFIG_PATH="/usr/local/opt/llvm/bin/llvm-config"
+
+cargo +nightly build $packages --target x86_64-unknown-linux-gnu
+cargo +nightly test $packages --target x86_64-unknown-linux-gnu
+
+grcov ./target/x86_64-unknown-linux-gnu/debug/ -s . -t html --llvm --branch --ignore-not-existing -o /tmp/coverage/
+
+set +o xtrace


### PR DESCRIPTION
Closes #247 

Here is where the test coverage reports for this branch is kept: [artifacts](https://app.circleci.com/pipelines/github/cennznet/cennznet/1249/workflows/5db10b62-5151-41ec-913d-b0850aba208e/jobs/3128/artifacts). You can browse the test coverage report by opening [index.html](https://3128-183523539-gh.circle-artifacts.com/0/tmp/coverage/index.html) from the above link. 

Here is a screenshot of the report:
![Screen Shot 2020-07-21 at 3 44 08 PM](https://user-images.githubusercontent.com/6517909/88010552-405c0b00-cb69-11ea-88a8-7e270c7bdb94.png)

The overhead of the test coverage report to the build process seems to be about 10%. Though we need to consider that at the moment we are only testing Sylo and cenzx-spot:
![Screen Shot 2020-07-21 at 3 56 21 PM](https://user-images.githubusercontent.com/6517909/88011403-54a10780-cb6b-11ea-8de1-2b171a083f5f.png)

On the good side, the more crates we add to the coverage test stage, the less we need to test separately in the build-test-and-run stage.

**Note**: As the Sylo and cennzx-spot will be tested for the sake of reporting the test coverage, testing them in the cargo-build-test-and-run step could be redundant. That's why I have excluded them there. 