### PR TITLE
Count chars instead of bytes

### DIFF
--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -348,7 +348,7 @@ impl additional_traits::DelegatedDispatchVerifier for CENNZnetDispatchVerifier {
 			.find('-')
 			.ok_or("CENNZnut does not grant permission for module")?
 			+ 1;
-		if module_offset <= 1 || module_offset >= module.len() {
+		if module_offset <= 1 || module_offset >= module.chars().count() {
 			return Err("error during module name segmentation");
 		}
 		match cennznut.validate_runtime_call(&module[module_offset..], method, &[]) {

--- a/runtime/tests/doughnut.rs
+++ b/runtime/tests/doughnut.rs
@@ -128,6 +128,15 @@ fn it_works_with_arbitrary_prefix_long() {
 }
 
 #[test]
+fn it_works_with_arbitrary_non_ascii_characters() {
+	let cennznut = make_runtime_cennznut("attestation", "attest");
+	let doughnut = make_doughnut("cennznet", cennznut.encode());
+	assert_ok!(verify_dispatch(&doughnut, "ṫřṁl-attestation", "attest"));
+	assert_eq!("ṫřṁl-attestation".len(), 21);
+	assert_eq!("ṫřṁl-attestation".chars().count(), 16);
+}
+
+#[test]
 fn it_fails_when_not_using_the_cennznet_domain() {
 	let doughnut = make_doughnut("test", Default::default());
 	assert_err!(


### PR DESCRIPTION
Noticed we are counting number of bytes rather than characters themselves (which is okay for ASCII values).