### PR TITLE
Unbond should consume active stake less than minimum bond

### DIFF
--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1556,10 +1556,6 @@ impl<T: Trait> Module<T> {
 		let mut all_validators = Vec::new();
 		for (validator, preference) in <Validators<T>>::iter() {
 			let active_bond = Self::active_balance_of(&validator);
-			// Do not consdier zero bonds for election.
-			if active_bond.is_zero() {
-				continue;
-			}
 			let self_vote = (validator.clone(), active_bond, vec![validator.clone()]);
 			all_nominators.push(self_vote);
 			all_validators_and_prefs.insert(validator.clone(), preference);
@@ -1585,7 +1581,6 @@ impl<T: Trait> Module<T> {
 			let s = Self::active_balance_of(&n);
 			(n, s, ns)
 		}));
-		all_nominators.retain(|(_, active, _)| !active.is_zero());
 
 		let maybe_phragmen_result = sp_phragmen::elect::<_, _, T::CurrencyToVote, Perbill>(
 			Self::validator_count() as usize,

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1004,8 +1004,9 @@ decl_module! {
 			if !value.is_zero() {
 				ledger.active -= value;
 
-				// Avoid there being a dust balance left in the staking system.
-				if ledger.active < T::Currency::minimum_balance() {
+				// If active stake drops below the minimum bond threshold or currency minimum
+				// then the entirety of the stash should be unbonded here.
+				if ledger.active < T::Currency::minimum_balance() || ledger.active < Self::minimum_bond() {
 					value += ledger.active;
 					ledger.active = Zero::zero();
 				}

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -378,20 +378,25 @@ pub struct UnlockChunk<Balance: HasCompact> {
 pub struct StakingLedger<AccountId, Balance: HasCompact> {
 	/// The stash account whose balance is actually locked and at stake.
 	pub stash: AccountId,
-	/// The total amount of the stash's balance that we are currently accounting for.
-	/// It's just `active` plus all the `unlocking` balances.
+	/// The total amount of the stash's balance (`active` plus any `unlocking` balances).
 	#[codec(compact)]
 	pub total: Balance,
-	/// The total amount of the stash's balance that will be at stake in any forthcoming
-	/// rounds.
+	/// The amount of the stash's balance that will be at stake in any forthcoming
+	/// eras. i.e it will affect voting power in the next election.
+	/// It could lessen in the current round after unbonding.
 	#[codec(compact)]
 	pub active: Balance,
-	/// Any balance that is becoming free, which may eventually be transferred out
+	/// Any balance that has been unbonded and becoming free, which may eventually be transferred out
 	/// of the stash (assuming it doesn't get slashed first).
 	pub unlocking: Vec<UnlockChunk<Balance>>,
 }
 
 impl<AccountId, Balance: HasCompact + Copy + Saturating + AtLeast32Bit> StakingLedger<AccountId, Balance> {
+	/// The amount of stash's funds slashable as of right now.
+	/// It should remain slashable until the bonding duration expires and it is withdrawn.
+	fn slashable_balance(&self) -> Balance {
+		self.total
+	}
 	/// Remove entries from `unlocking` that are sufficiently old and reduce the
 	/// total by the sum of their balances.
 	fn consolidate_unlocked(self, current_era: EraIndex) -> Self {
@@ -453,17 +458,17 @@ where
 	/// Slashes from `active` funds first, and then `unlocking`, starting with the
 	/// chunks that are closest to unlocking.
 	fn slash(&mut self, mut value: Balance, minimum_balance: Balance) -> Balance {
-		let pre_total = self.total;
-		let total = &mut self.total;
+		let total_before_slash = self.total;
+		let total_after_slash = &mut self.slashable_balance();
 		let active = &mut self.active;
 
-		value = Self::apply_slash(total, active, value, minimum_balance);
+		value = Self::apply_slash(total_after_slash, active, value, minimum_balance);
 
 		let i = self
 			.unlocking
 			.iter_mut()
 			.map(|chunk| {
-				value = Self::apply_slash(total, &mut chunk.value, value, minimum_balance);
+				value = Self::apply_slash(total_after_slash, &mut chunk.value, value, minimum_balance);
 				chunk.value
 			})
 			.take_while(|value| value.is_zero()) // take all fully-consumed chunks out.
@@ -472,7 +477,9 @@ where
 		// kill all drained chunks.
 		let _ = self.unlocking.drain(..i);
 
-		pre_total.saturating_sub(*total)
+		self.total = *total_after_slash;
+		// return the slashed amount
+		total_before_slash.saturating_sub(*total_after_slash)
 	}
 
 	/// Apply slash to a target set of funds
@@ -860,7 +867,7 @@ decl_error! {
 		/// Slash record index out of bounds.
 		InvalidSlashIndex,
 		/// Can not bond with value less than minimum balance.
-		InsufficientValue,
+		InsufficientBond,
 		/// Can not schedule more unlock chunks.
 		NoMoreChunks,
 		/// Can not rebond without unlocking chunks.
@@ -922,7 +929,7 @@ decl_module! {
 
 			// reject a bond which is considered to be _dust_.
 			if value < Self::minimum_bond() {
-				Err(Error::<T>::InsufficientValue)?
+				Err(Error::<T>::InsufficientBond)?
 			}
 
 			// You're auto-bonded forever, here. We might improve this by only bonding when
@@ -999,22 +1006,28 @@ decl_module! {
 				Error::<T>::NoMoreChunks,
 			);
 
-			let mut value = value.min(ledger.active);
-
-			if !value.is_zero() {
-				ledger.active -= value;
-
-				// If active stake drops below the minimum bond threshold or currency minimum
-				// then the entirety of the stash should be unbonded here.
-				if ledger.active < T::Currency::minimum_balance() || ledger.active < Self::minimum_bond() {
-					value += ledger.active;
-					ledger.active = Zero::zero();
-				}
-
-				let era = Self::current_era() + T::BondingDuration::get();
-				ledger.unlocking.push(UnlockChunk { value, era });
-				Self::update_ledger(&controller, &ledger);
+			if ledger.active.is_zero() || value.is_zero() {
+				return Ok(());
 			}
+
+			// If active stake drops below the minimum bond threshold or currency minimum
+			// then the entirety of the stash should be scheduled to unlock.
+			// Care must be taken to ensure that funds are still at stake until the unlocking period is over.
+			let remaining_active = ledger.active.checked_sub(&value).unwrap_or(Zero::zero());
+			let era = Self::current_era() + T::BondingDuration::get();
+			if remaining_active < T::Currency::minimum_balance() || remaining_active < Self::minimum_bond() {
+				// Must unbond all funds
+				ledger.unlocking.push(UnlockChunk { value: ledger.active, era });
+				ledger.active = Zero::zero();
+				// The account should no longer be considered for election as a validator nor should it have any
+				// voting power via nomination.
+				Self::chill_stash(&ledger.stash);
+			} else {
+				ledger.unlocking.push(UnlockChunk { value, era });
+				ledger.active = remaining_active;
+			}
+
+			Self::update_ledger(&controller, &ledger);
 		}
 
 		/// Rebond a portion of the stash scheduled to be unlocked.
@@ -1090,6 +1103,7 @@ decl_module! {
 
 			let controller = ensure_signed(origin)?;
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
+			ensure!(ledger.active >= Self::minimum_bond(), Error::<T>::InsufficientBond);
 			let stash = &ledger.stash;
 
 			let prefs = ValidatorPrefs {
@@ -1117,6 +1131,7 @@ decl_module! {
 			let controller = ensure_signed(origin)?;
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 			let stash = &ledger.stash;
+			ensure!(ledger.active >= Self::minimum_bond(), Error::<T>::InsufficientBond);
 			ensure!(!targets.is_empty(), Error::<T>::EmptyTargets);
 			let targets = targets.into_iter()
 				.take(MAX_NOMINATIONS)
@@ -1295,11 +1310,21 @@ decl_module! {
 impl<T: Trait> Module<T> {
 	// PUBLIC IMMUTABLES
 
-	/// The total balance that can be slashed from a stash account as of right now.
-	pub fn slashable_balance_of(stash: &T::AccountId) -> BalanceOf<T> {
+	/// The total balance that is at stake as of right now.
+	/// It will remain slashable at least until bonding duration has exceeded.
+	pub fn active_balance_of(stash: &T::AccountId) -> BalanceOf<T> {
 		Self::bonded(stash)
 			.and_then(Self::ledger)
 			.map(|l| l.active)
+			.unwrap_or_default()
+	}
+
+	/// The slashable balance of a stash account as of right now.
+	/// It could lessen in the near future as funds become unlocked and are withdrawn.
+	pub fn slashable_balance_of(stash: &T::AccountId) -> BalanceOf<T> {
+		Self::bonded(stash)
+			.and_then(Self::ledger)
+			.map(|l| l.slashable_balance())
 			.unwrap_or_default()
 	}
 
@@ -1530,11 +1555,12 @@ impl<T: Trait> Module<T> {
 		let mut all_validators_and_prefs = BTreeMap::new();
 		let mut all_validators = Vec::new();
 		for (validator, preference) in <Validators<T>>::iter() {
-			let self_vote = (
-				validator.clone(),
-				Self::slashable_balance_of(&validator),
-				vec![validator.clone()],
-			);
+			let active_bond = Self::active_balance_of(&validator);
+			// Do not consdier zero bonds for election.
+			if active_bond.is_zero() {
+				continue;
+			}
+			let self_vote = (validator.clone(), active_bond, vec![validator.clone()]);
 			all_nominators.push(self_vote);
 			all_validators_and_prefs.insert(validator.clone(), preference);
 			all_validators.push(validator);
@@ -1556,9 +1582,10 @@ impl<T: Trait> Module<T> {
 			(nominator, targets)
 		});
 		all_nominators.extend(nominator_votes.map(|(n, ns)| {
-			let s = Self::slashable_balance_of(&n);
+			let s = Self::active_balance_of(&n);
 			(n, s, ns)
 		}));
+		all_nominators.retain(|(_, active, _)| !active.is_zero());
 
 		let maybe_phragmen_result = sp_phragmen::elect::<_, _, T::CurrencyToVote, Perbill>(
 			Self::validator_count() as usize,
@@ -1581,7 +1608,7 @@ impl<T: Trait> Module<T> {
 			let supports = sp_phragmen::build_support_map::<_, _, _, T::CurrencyToVote, Perbill>(
 				&elected_stashes,
 				&assignments,
-				Self::slashable_balance_of,
+				Self::active_balance_of,
 			);
 
 			// Clear Stakers.

--- a/crml/staking/src/mock.rs
+++ b/crml/staking/src/mock.rs
@@ -319,6 +319,24 @@ impl ExtBuilder {
 		EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
 		SLASH_DEFER_DURATION.with(|v| *v.borrow_mut() = self.slash_defer_duration);
 	}
+	// Simplified version of `build` taking constant parameters only
+	// no acccount, balance, or staking setup is performed.
+	pub fn simple(self) -> sp_io::TestExternalities {
+		let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+		let _ = GenesisConfig::<Test> {
+			current_era: 0,
+			stakers: vec![],
+			validator_count: self.validator_count,
+			minimum_validator_count: self.minimum_validator_count,
+			invulnerables: self.invulnerables,
+			minimum_bond: self.minimum_bond,
+			slash_reward_fraction: Perbill::from_percent(10),
+			..Default::default()
+		}
+		.assimilate_storage(&mut storage);
+
+		sp_io::TestExternalities::from(storage)
+	}
 	pub fn build(self) -> sp_io::TestExternalities {
 		self.set_associated_consts();
 		let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
@@ -379,7 +397,6 @@ impl ExtBuilder {
 		let _ = GenesisConfig::<Test> {
 			current_era: 0,
 			stakers: stakers,
-
 			validator_count: self.validator_count,
 			minimum_validator_count: self.minimum_validator_count,
 			invulnerables: self.invulnerables,

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -1780,7 +1780,7 @@ fn bond_with_no_staked_value() {
 		.minimum_bond(3)
 		.build()
 		.execute_with(|| {
-			// Can't bond with 1
+			// Can't bond with value < minimum bond
 			assert_noop!(
 				Staking::bond(Origin::signed(1), 2, 1, RewardDestination::Controller),
 				Error::<Test>::InsufficientBond,
@@ -3053,7 +3053,7 @@ fn minimum_bond_in_genesis_config_must_be_greater_than_zero() {
 }
 
 #[test]
-fn unbond_requested_value_when_it_leaves_remaining_active_more_than_minimum_bond() {
+fn unbond_works_when_remaining_active_is_more_than_minimum_bond() {
 	ExtBuilder::default().minimum_bond(5).build().execute_with(|| {
 		// `ExtBuilder` auto configures some IDs < 100 with funds
 		// making tests less clear
@@ -3097,7 +3097,7 @@ fn unbond_requested_value_when_it_leaves_remaining_active_more_than_minimum_bond
 }
 
 #[test]
-fn unbond_should_unstake_validator_when_remaining_bond_is_less_than_minimum_bond() {
+fn unbond_should_remove_validator_from_future_era_when_remaining_bond_is_less_than_minimum_bond() {
 	ExtBuilder::default().minimum_bond(5).build().execute_with(|| {
 		// `ExtBuilder` auto configures some IDs < 100 with funds
 		// making tests less clear
@@ -3117,12 +3117,20 @@ fn unbond_should_unstake_validator_when_remaining_bond_is_less_than_minimum_bond
 		assert_ok!(Staking::validate(Origin::signed(controller), ValidatorPrefs::default()));
 		// Unbond just enough to put the active stash below the minimum bond amount
 		assert_ok!(Staking::unbond(Origin::signed(controller), 51));
+
+		// Stash will not be onsidered as a validator next era
 		assert!(!<Staking as crate::Store>::Validators::contains_key(stash));
+
+		// Stash cannnot validate again with inactive bond
+		assert_noop!(
+			Staking::validate(Origin::signed(controller), ValidatorPrefs::default()),
+			Error::<Test>::InsufficientBond,
+		);
 	});
 }
 
 #[test]
-fn unbond_should_unstake_nominator_when_remaining_bond_is_less_than_minimum_bond() {
+fn unbond_should_remove_nominator_from_future_era_when_remaining_bond_is_less_than_minimum_bond() {
 	ExtBuilder::default().minimum_bond(5).build().execute_with(|| {
 		// `ExtBuilder` auto configures some IDs < 100 with funds
 		// making tests less clear
@@ -3142,15 +3150,156 @@ fn unbond_should_unstake_nominator_when_remaining_bond_is_less_than_minimum_bond
 		assert_ok!(Staking::nominate(Origin::signed(controller), vec![stash]));
 		// Unbond just enough to put the active stash below the minimum bond amount
 		assert_ok!(Staking::unbond(Origin::signed(controller), 51));
+
+		// Stash will not be onsidered as a nominator next era
 		assert!(!<Staking as crate::Store>::Nominators::contains_key(stash));
+
+		// Stash cannnot nominate again with inactive bond
+		assert_noop!(
+			Staking::nominate(Origin::signed(controller), vec![1, 2, 3, 4, 5]),
+			Error::<Test>::InsufficientBond,
+		);
 	});
 }
 
 #[test]
-fn nominate_should_fail_when_stash_does_not_have_minimum_bond() {}
+fn validators_with_insufficent_active_bond_are_not_elected() {
+	ExtBuilder::default()
+		.minimum_bond(1_000)
+		.validator_count(5)
+		.minimum_validator_count(3)
+		.simple()
+		.execute_with(|| {
+			// Check some initial parameters are set
+			assert_eq!(<Staking as crate::Store>::ValidatorCount::get(), 5);
+			assert_eq!(<Staking as crate::Store>::MinimumValidatorCount::get(), 3);
+
+			// Setup
+			// 1) Fund and bond stashes
+			// 2) Sign up to validate
+			let stashes = vec![1, 2, 3, 4, 5];
+			let controllers = vec![11, 22, 33, 44, 55];
+			let initial_bond = Staking::minimum_bond() + 50;
+
+			for (stash, controller) in stashes.iter().zip(controllers.iter()) {
+				let _ = Balances::deposit_creating(&stash, initial_bond + controller);
+				// Bond with slightly more than the minimum bond
+				assert_ok!(Staking::bond(
+					Origin::signed(*stash),
+					controller.clone(),
+					initial_bond,
+					RewardDestination::Controller
+				));
+
+				assert_ok!(Staking::validate(
+					Origin::signed(*controller),
+					ValidatorPrefs::default()
+				));
+			}
+
+			// Run an initial election, every stash should be elected
+			let mut initial_elected = Staking::select_validators().1.expect("some were elected");
+			initial_elected.sort();
+			assert_eq!(initial_elected, stashes);
+
+			// Unbond 2 validators and run another election, they should not be elected as their active stash
+			// is now `0` and additionaly should have been removed from the validator candidacy storage.
+			assert_ok!(Staking::unbond(Origin::signed(controllers[0]), 51));
+			assert_ok!(Staking::unbond(Origin::signed(controllers[1]), 51));
+
+			// The unbonded validators are not elected
+			let mut next_elected = Staking::select_validators().1.expect("some were elected");
+			next_elected.sort();
+			assert_eq!(next_elected[..], stashes[2..]);
+		});
+}
 
 #[test]
-fn validate_should_fail_when_stash_does_not_have_minimum_bond() {}
+fn nominations_with_insufficent_active_bond_are_ignored_during_election() {
+	ExtBuilder::default()
+		.minimum_bond(1_000)
+		.validator_count(3)
+		.minimum_validator_count(3)
+		.simple()
+		.execute_with(|| {
+			// Scenario:
+			// - 5 validators are bonded equally ids: [1,2,3,4,5]
+			// - The validator count is set to 3 (only 3/5 will be selected in the next election)
+			//-  2 nominators bond and nominate validator ids: [1, 2]
+			// - The nominators backing should ensure [1, 2] are elected
+			// - The nominators unbond
+			// - The nominators backing is no longer considered
 
-#[test]
-fn validators_with_insufficent_active_bond_are_not_elected() {}
+			// Check some initial parameters are set
+			assert_eq!(<Staking as crate::Store>::ValidatorCount::get(), 3);
+			assert_eq!(<Staking as crate::Store>::MinimumValidatorCount::get(), 3);
+
+			// Setup
+			// 1) Fund and bond stashes
+			// 2) Sign up to validate
+			let stashes = vec![1, 2, 3, 4, 5];
+			let controllers = vec![11, 22, 33, 44, 55];
+			let initial_bond = Staking::minimum_bond() + 50;
+
+			for (stash, controller) in stashes.iter().zip(controllers.iter()) {
+				let _ = Balances::deposit_creating(&stash, initial_bond + controller);
+				// Bond with slightly more than the minimum bond
+				assert_ok!(Staking::bond(
+					Origin::signed(*stash),
+					controller.clone(),
+					// bond less as stash ID increases
+					// This ensures a deterministic candidate order at election time
+					// i.e at election time prefernce is: 1 > 2 > 3 > 4 > 5
+					initial_bond - stash,
+					RewardDestination::Controller
+				));
+
+				assert_ok!(Staking::validate(
+					Origin::signed(*controller),
+					ValidatorPrefs::default()
+				));
+			}
+
+			// 1) Fund and bond stashes
+			// 2) Sign up to nominate
+			let nominator_stashes = vec![100, 200];
+			let nominator_controllers = vec![101, 202];
+			for (stash, controller) in nominator_stashes.iter().zip(nominator_controllers.iter()) {
+				let _ = Balances::deposit_creating(&stash, initial_bond + controller);
+				// Bond with slightly more than the minimum bond
+				assert_ok!(Staking::bond(
+					Origin::signed(*stash),
+					controller.clone(),
+					initial_bond * 2, // Give the nominators a big sway at election time
+					RewardDestination::Controller
+				));
+
+				assert_ok!(Staking::nominate(
+					Origin::signed(*controller),
+					vec![stashes[3], stashes[4]]
+				));
+			}
+
+			// Run an initial election, stashes[3], stashes[4] should be elected with the largest total backing
+			// via nomination.
+			let initial_elected = Staking::select_validators().1.expect("some were elected");
+			assert!(initial_elected.contains(&stashes[3]));
+			assert!(initial_elected.contains(&stashes[4]));
+
+			// Unbond the nominators
+			assert_ok!(Staking::unbond(
+				Origin::signed(nominator_controllers[0]),
+				initial_bond * 2
+			));
+			assert_ok!(Staking::unbond(
+				Origin::signed(nominator_controllers[1]),
+				initial_bond * 2
+			));
+
+			// The unbonded nominations are not considered in subsequent elections
+			// stashes with highest bond from validators should be elected instead.
+			let mut next_elected = Staking::select_validators().1.expect("some were elected");
+			next_elected.sort();
+			assert_eq!(next_elected[..], stashes[..3]);
+		});
+}


### PR DESCRIPTION
Addresses a few bugs stemming from `unbond` leaving accounts active in the staking system.

Changes:
- Require that `minimum bond` is available to validate and/or nominate
- Unbond consumes all stake if remainder is less than minimum bond
- Unbond 'chills' the stash if remainder is less than minimum bond
- Clarify confusion between active bond usable for voting and slashable bond
- Clarify doc comments and intent in some places
- Ignore dust currency check
