### PR TITLE
4dp transaction fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.1"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74f02beb35d47e0706155c9eac554b50c671e0d868fe8296bcdf44a9a4847bf"
+checksum = "34d38aeaffc032ec69faa476b3caaca8d4dd7f3f798137ff30359e5c7869ceb6"
 dependencies = [
  "arrayvec 0.5.1",
  "bitvec",
@@ -4375,9 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
+checksum = "cd20ff7e0399b274a5f5bb37b712fccb5b3a64b9128200d1c3cc40fe709cb073"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/cli/src/chain_spec/azalea.rs
+++ b/cli/src/chain_spec/azalea.rs
@@ -242,7 +242,7 @@ pub fn config_genesis(network_keys: NetworkKeys) -> GenesisConfig {
 				enable_println: false, // this should only be enabled on development chains
 				..Default::default()
 			},
-			gas_price: 1 * MILLICENTS,
+			gas_price: 1 * MICROS,
 		}),
 		pallet_sudo: Some(SudoConfig { key: root_key.clone() }),
 		pallet_babe: Some(BabeConfig { authorities: vec![] }),

--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -187,7 +187,7 @@ pub fn config_genesis(network_keys: NetworkKeys, enable_println: bool) -> Genesi
 				enable_println, // this should only be enabled on development chains
 				..Default::default()
 			},
-			gas_price: 1 * MILLICENTS,
+			gas_price: 1 * MICROS,
 		}),
 		pallet_sudo: Some(SudoConfig { key: root_key.clone() }),
 		pallet_babe: Some(BabeConfig { authorities: vec![] }),

--- a/cli/src/service.rs
+++ b/cli/src/service.rs
@@ -362,7 +362,7 @@ mod tests {
 	use crate::service::{new_full, new_light};
 	use cennznet_primitives::types::{Block, DigestItem, Signature};
 	use cennznet_runtime::{
-		constants::{asset::SPENDING_ASSET_ID, currency::CENTS, time::SLOT_DURATION},
+		constants::{asset::SPENDING_ASSET_ID, currency::MICROS, time::SLOT_DURATION},
 		Address, Call, GenericAssetCall, UncheckedExtrinsic,
 	};
 	use codec::{Decode, Encode};
@@ -516,7 +516,7 @@ mod tests {
 					.expect("error importing test block");
 			},
 			|service, _| {
-				let amount = 5 * CENTS;
+				let amount = 5 * MICROS;
 				let to: Address = AccountPublic::from(bob.public()).into_account().into();
 				let from: Address = AccountPublic::from(charlie.public()).into_account().into();
 				let genesis_hash = service.client().block_hash(0).unwrap().unwrap();

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -161,26 +161,36 @@ impl<T: Trait> Module<T> {
 	}
 }
 
-#[derive(Debug)]
-pub struct FeeParts {
+#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq)]
+/// The variable parts of a transaction's fees
+/// It does not store the `base_fee` as it is a runtime constant
+/// The `tip` is also excluded as it is known by the transactor/caller.
+pub struct FeeParts<Balance: Saturating> {
 	/// The length fee
-	length_fee: u128,
-	/// The weight fee after conversion
-	weight_fee: u128,
-	/// The len + fee after adjustment factor is applied
-	adjusted_fee: u128,
-	/// The final fee
-	final_fee: u128,
+	/// It changes based on the size of the transaction.
+	length_fee: Balance,
+	/// The weight fee
+	/// It changes based on the computational resources required by the transaction.
+	weight_fee: Balance,
+	/// The peak adjustment fee.
+	/// It changes based on recent network transaction load (or more formally "block fullness").
+	peak_adjustment_fee: Balance,
 }
 
-impl FeeParts {
-	fn new(length_fee: u128, weight_fee: u128, adjusted_fee: u128, final_fee: u128) -> Self {
+impl<Balance: Copy + Saturating> FeeParts<Balance> {
+	pub fn new(length_fee: Balance, weight_fee: Balance, peak_adjustment_fee: Balance) -> Self {
 		FeeParts {
 			length_fee,
 			weight_fee,
-			adjusted_fee,
-			final_fee,
+			peak_adjustment_fee,
 		}
+	}
+	/// Calculate the total fee from it's parts
+	pub fn total(&self) -> Balance {
+		// total = length_fee + weight_fee + peak_adjustment_fee
+		self.length_fee
+			.saturating_add(self.weight_fee)
+			.saturating_add(self.peak_adjustment_fee)
 	}
 }
 
@@ -203,52 +213,37 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 	///
 	/// The final fee is composed of:
 	///   - _base_fee_: This is the minimum amount a user pays for a transaction.
-	///   - _len_fee_: This is the amount paid merely to pay for size of the transaction.
+	///   - _length_fee_: This is the amount paid merely to pay for size of the transaction.
 	///   - _weight_fee_: This amount is computed based on the weight of the transaction. Unlike
-	///      size-fee, this is not input dependent and reflects the _complexity_ of the execution
+	///      length_fee, this is not input dependent and reflects the _complexity_ of the execution
 	///      and the time it consumes.
-	///   - _targeted_fee_adjustment_: This is a multiplier that can tune the final fee based on
+	///   - _peak_adjustment_fee_: This is a multiplier that can tune the final fee based on
 	///     the congestion of the network.
 	///   - (optional) _tip_: if included in the transaction, it will be added on top. Only signed
 	///      transactions can have a tip.
 	///
-	/// final_fee = base_fee + targeted_fee_adjustment(len_fee + weight_fee) + tip;
-	pub fn compute_fee(len: u32, info: <Self as SignedExtension>::DispatchInfo, tip: BalanceOf<T>) -> BalanceOf<T>
+	/// final_fee = base_fee + peak_adjustment_fee + len_fee + weight_fee + tip;
+	pub fn compute_fee(length: u32, info: <Self as SignedExtension>::DispatchInfo, tip: BalanceOf<T>) -> BalanceOf<T>
 	where
 		BalanceOf<T>: Sync + Send,
 	{
 		if info.pays_fee {
-			let len = <BalanceOf<T>>::from(len);
-			let per_byte = T::TransactionByteFee::get();
-			let len_fee = per_byte.saturating_mul(len);
-
-			let weight_fee = {
-				// cap the weight to the maximum defined in runtime, otherwise it will be the `Bounded`
-				// `Bounded` maximum of its data type, which is not desired.
-				let capped_weight = info.weight.min(<T as frame_system::Trait>::MaximumBlockWeight::get());
-				T::WeightToFee::convert(capped_weight)
-			};
-
-			// the adjustable part of the fee
-			let adjustable_fee = len_fee.saturating_add(weight_fee);
-			let targeted_fee_adjustment = NextFeeMultiplier::get();
-			// adjusted_fee = adjustable_fee + (adjustable_fee * targeted_fee_adjustment)
-			let adjusted_fee = targeted_fee_adjustment.saturated_multiply_accumulate(adjustable_fee);
-
+			let fee_parts = Self::compute_fee_parts(length, info);
 			let base_fee = T::TransactionBaseFee::get();
-			base_fee.saturating_add(adjusted_fee).saturating_add(tip)
+			base_fee.saturating_add(fee_parts.total()).saturating_add(tip)
 		} else {
 			tip
 		}
 	}
 
-	// Return fee parts (length, weight, adjusted, final)
-	pub fn compute_fee_parts(length: u32, info: <Self as SignedExtension>::DispatchInfo) -> FeeParts
+	/// Compute a transaction's fee constituents (length, weight, peak adjustment)
+	pub fn compute_fee_parts(length: u32, info: <Self as SignedExtension>::DispatchInfo) -> FeeParts<BalanceOf<T>>
 	where
 		BalanceOf<T>: Sync + Send,
 	{
-		let per_byte_fee = T::TransactionByteFee::get();
-		let length_fee = per_byte_fee.saturating_mul(length.saturated_into());
+		let length = <BalanceOf<T>>::from(length);
+		let per_byte = T::TransactionByteFee::get();
+		let length_fee = per_byte.saturating_mul(length);
 
 		let weight_fee = {
 			// cap the weight to the maximum defined in runtime, otherwise it will be the `Bounded`
@@ -257,20 +252,19 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 			T::WeightToFee::convert(capped_weight)
 		};
 
-		// the adjustable part of the fee
 		let adjustable_fee = length_fee.saturating_add(weight_fee);
-		let targeted_fee_adjustment = NextFeeMultiplier::get();
-		// adjusted_fee = adjustable_fee + (adjustable_fee * targeted_fee_adjustment)
-		let adjusted_fee = targeted_fee_adjustment.saturated_multiply_accumulate(adjustable_fee);
+		let target_adjustment_rate = NextFeeMultiplier::get();
 
-		let base_fee = T::TransactionBaseFee::get();
-		let final_fee = base_fee.saturating_add(adjusted_fee);
+		// note 1: `saturated_multiply_accumulate` also converts `target_adjustment_rate` a `Fixed64` into a `Balance`
+		// there are no other conversion functions available so this sneakily doubles as a type conversion.
+		// note 2: this is equivalent to: `adjustable_fee + (adjustable_fee * target_adjustment_rate)`
+		let peak_adjustment_fee = target_adjustment_rate.saturated_multiply_accumulate(adjustable_fee);
 
 		return FeeParts::new(
-			length_fee.saturated_into(),
-			weight_fee.saturated_into(),
-			adjusted_fee.saturated_into(),
-			final_fee.saturated_into(),
+			length_fee,
+			weight_fee,
+			// we only want the value of: `adjustable_fee * target_adjustment_rate`, a bit wasteful :(
+			peak_adjustment_fee.saturating_sub(adjustable_fee),
 		);
 	}
 }
@@ -998,7 +992,7 @@ mod tests {
 			});
 	}
 
-	// For the () implmentation of NegativeImbalance, we reduce the total issuance by the fee
+	// For the () implementation of NegativeImbalance, we reduce the total issuance by the fee
 	#[test]
 	fn imbalanced_is_executed_for_fee_payment() {
 		let base_fee = 5;

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -16,7 +16,7 @@ frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain"
 cennznet-primitives = { path = "../primitives" }
 cennznet-runtime = { path = "../runtime" }
 
-#frame dependencies
+# frame dependencies
 sp-state-machine = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
 sc-executor = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
 sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }

--- a/executor/tests/fees.rs
+++ b/executor/tests/fees.rs
@@ -37,7 +37,6 @@ pub mod common;
 use self::common::{sign, *};
 
 #[test]
-#[ignore]
 fn fee_multiplier_increases_and_decreases_on_big_weight() {
 	let mut t = new_test_ext(COMPACT_CODE, false);
 
@@ -195,7 +194,7 @@ fn transaction_fee_is_correct_ultimate() {
 		// It should serve as a useful warning if:
 		// 1) it changes by several orders of magnitude.
 		// 2) it changes accidentally.
-		assert_eq!(weight_fee as Balance, 9909);
+		assert_eq!(weight_fee as Balance, 1 * DOLLARS);
 
 		balance_alice -= weight_fee;
 		balance_alice -= tip;

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -35,13 +35,12 @@ pub mod asset {
 /// Money matters.
 pub mod currency {
 	use cennznet_primitives::types::Balance;
-
-	pub const PICOCENTS: Balance = 1;
-	pub const NANOCENTS: Balance = 1_000 * PICOCENTS;
-	pub const MICROCENTS: Balance = 1_000 * NANOCENTS;
-	pub const MILLICENTS: Balance = 1_000 * MICROCENTS;
-	pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
-	pub const DOLLARS: Balance = 100 * CENTS;
+	/// The smallest denomination of any currency
+	pub const WEI: Balance = 1;
+	/// The smallest denomination of a 4dp currency
+	pub const MICROS: Balance = WEI;
+	/// The dollar denomination of a 4dp currency
+	pub const DOLLARS: Balance = 10_000;
 }
 
 /// Time.
@@ -100,4 +99,12 @@ pub mod fee {
 
 	/// The block saturation level. Fees will be updates based on this value.
 	pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
+
+	// note: only a few exceptional extrinsics have a weight > 1_000_000.
+	// note: weights are not limited to this range, this range is what has been.
+	// observed in Plug and crml code.
+	/// The maximum weight of a transaction in practice.
+	pub const MAX_WEIGHT: u128 = 10_000_000;
+	/// The minimum weight of a transaction in practice.
+	pub const MIN_WEIGHT: u128 = 10_000;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -139,9 +139,9 @@ impl frame_system::Trait for Runtime {
 
 parameter_types! {
 	// One storage item; value is size 4+4+16+32 bytes = 56 bytes.
-	pub const MultisigDepositBase: Balance = 30 * CENTS;
+	pub const MultisigDepositBase: Balance = 30 * MICROS;
 	// Additional storage item size of 32 bytes.
-	pub const MultisigDepositFactor: Balance = 5 * CENTS;
+	pub const MultisigDepositFactor: Balance = 5 * MICROS;
 	pub const MaxSignatories: u16 = 100;
 }
 
@@ -197,8 +197,10 @@ impl pallet_generic_asset::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const TransactionBaseFee: Balance = 1;
-	pub const TransactionByteFee: Balance = 1;
+	pub const TransactionBaseFee: Balance = 1 * MICROS;
+	pub const TransactionByteFee: Balance = 10 * MICROS;
+	pub const TransactionMinWeightFee: Balance = 100 * MICROS;
+	pub const TransactionMaxWeightFee: Balance = 10 * DOLLARS;
 	// for a sane configuration, this should always be less than `AvailableBlockRatio`.
 	pub const TargetBlockFullness: Perbill = Perbill::from_percent(25);
 }
@@ -222,7 +224,7 @@ impl crml_transaction_payment::Trait for Runtime {
 	type OnTransactionPayment = DealWithFees;
 	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = ScaledWeightToFee;
+	type WeightToFee = ScaledWeightToFee<TransactionMinWeightFee, TransactionMaxWeightFee>;
 	type FeeMultiplierUpdate = TargetedFeeAdjustment<TargetBlockFullness>;
 	type BuyFeeAsset = CennzxSpot;
 	type GasMeteredCallResolver = GasMeteredCallResolver;
@@ -319,7 +321,7 @@ parameter_types! {
 	pub const EnactmentPeriod: BlockNumber = 30 * 24 * 60 * MINUTES;
 	pub const CooloffPeriod: BlockNumber = 28 * 24 * 60 * MINUTES;
 	// One cent: $10,000 / MB
-	pub const PreimageByteDeposit: Balance = 1 * CENTS;
+	pub const PreimageByteDeposit: Balance = 10 * DOLLARS;
 }
 
 parameter_types! {
@@ -389,7 +391,7 @@ parameter_types! {
 	pub const TipCountdown: BlockNumber = 1 * DAYS;
 	pub const TipFindersFee: Percent = Percent::from_percent(20);
 	pub const TipReportDepositBase: Balance = 1 * DOLLARS;
-	pub const TipReportDepositPerByte: Balance = 1 * CENTS;
+	pub const TipReportDepositPerByte: Balance = 10 * MICROS;
 }
 
 impl pallet_treasury::Trait for Runtime {
@@ -410,15 +412,15 @@ impl pallet_treasury::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const ContractTransferFee: Balance = 1 * NANOCENTS;
-	pub const ContractCreationFee: Balance = 1 * MICROCENTS;
-	pub const ContractTransactionBaseFee: Balance = 1 * NANOCENTS;
-	pub const ContractTransactionByteFee: Balance = 10 * MICROCENTS;
-	pub const ContractFee: Balance = 1 * CENTS;
-	pub const TombstoneDeposit: Balance = 1 * DOLLARS;
-	pub const RentByteFee: Balance = 1 * DOLLARS;
-	pub const RentDepositOffset: Balance = 1000 * DOLLARS;
-	pub const SurchargeReward: Balance = 150 * DOLLARS;
+	pub const ContractTransferFee: Balance = 1 * MICROS;
+	pub const ContractCreationFee: Balance = 1 * DOLLARS;
+	pub const ContractTransactionBaseFee: Balance = 1 * MICROS;
+	pub const ContractTransactionByteFee: Balance = 10 * MICROS;
+	pub const ContractFee: Balance = 100 * MICROS;
+	pub const TombstoneDeposit: Balance = 1_600 * MICROS;
+	pub const RentByteFee: Balance = 400 * MICROS;
+	pub const RentDepositOffset: Balance = 1 * DOLLARS;
+	pub const SurchargeReward: Balance = 1 * DOLLARS;
 	pub const BlockGasLimit: u64 = 100 * DOLLARS as u64;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -70,7 +70,7 @@ pub use crml_sylo::vault as sylo_vault;
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
 use impls::{
-	CENNZnetDispatchVerifier, CurrencyToVoteHandler, GasHandler, GasMeteredCallResolver, ScaleLinearWeightToFee,
+	CENNZnetDispatchVerifier, CurrencyToVoteHandler, GasHandler, GasMeteredCallResolver, ScaledWeightToFee,
 	SplitToAllValidators, TargetedFeeAdjustment,
 };
 
@@ -197,10 +197,8 @@ impl pallet_generic_asset::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const TransactionBaseFee: Balance = 1 * CENTS;
-	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
-	// setting this to zero will disable the weight fee.
-	pub const WeightFeeCoefficient: Balance = 1_000;
+	pub const TransactionBaseFee: Balance = 1;
+	pub const TransactionByteFee: Balance = 1;
 	// for a sane configuration, this should always be less than `AvailableBlockRatio`.
 	pub const TargetBlockFullness: Perbill = Perbill::from_percent(25);
 }
@@ -224,7 +222,7 @@ impl crml_transaction_payment::Trait for Runtime {
 	type OnTransactionPayment = DealWithFees;
 	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = ScaleLinearWeightToFee<WeightFeeCoefficient>;
+	type WeightToFee = ScaledWeightToFee;
 	type FeeMultiplierUpdate = TargetedFeeAdjustment<TargetBlockFullness>;
 	type BuyFeeAsset = CennzxSpot;
 	type GasMeteredCallResolver = GasMeteredCallResolver;

--- a/runtime/tests/doughnut.rs
+++ b/runtime/tests/doughnut.rs
@@ -13,7 +13,7 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-//! Doughnut integration tests
+//! Doughnut/CENNZnut runtime validation tests
 
 use cennznet_primitives::types::AccountId;
 use cennznet_runtime::{impls::CENNZnetDispatchVerifier, CennznetDoughnut};

--- a/runtime/tests/fee.rs
+++ b/runtime/tests/fee.rs
@@ -14,13 +14,14 @@
 */
 
 use cennznet_runtime::{
-	constants::{asset::*, currency::*},
-	Call, CheckedExtrinsic, Runtime, UncheckedExtrinsic,
+	constants::{asset::*, currency::*, fee::MAX_WEIGHT},
+	Call, CheckedExtrinsic, Runtime, TransactionBaseFee, TransactionMaxWeightFee, TransactionMinWeightFee,
+	UncheckedExtrinsic,
 };
 use cennznet_testing::keyring::{alice, bob, sign, signed_extra};
 use codec::Encode;
 use crml_transaction_payment::ChargeTransactionPayment;
-use frame_support::weights::GetDispatchInfo;
+use frame_support::weights::{DispatchClass, DispatchInfo, GetDispatchInfo};
 mod mock;
 use mock::ExtBuilder;
 
@@ -37,47 +38,168 @@ fn signed_tx(call: Call) -> UncheckedExtrinsic {
 }
 
 #[test]
+fn fee_scaling_max_weight() {
+	ExtBuilder::default().build().execute_with(|| {
+		let dispatch_info = DispatchInfo {
+			weight: MAX_WEIGHT as u32,
+			class: DispatchClass::Operational,
+			pays_fee: true,
+		};
+		// Scales to maximum weight fee + transaction base fee
+		assert_eq!(
+			TransactionMaxWeightFee::get() + TransactionBaseFee::get(),
+			ChargeTransactionPayment::<Runtime>::compute_fee(0, dispatch_info, 0)
+		);
+	});
+}
+
+#[test]
+fn fee_scaling_min_weight() {
+	ExtBuilder::default().build().execute_with(|| {
+		let dispatch_info = DispatchInfo {
+			weight: 1,
+			class: DispatchClass::Operational,
+			pays_fee: true,
+		};
+		// Scales to minimum weight fee + transaction base fee
+		assert_eq!(
+			TransactionMinWeightFee::get() + TransactionBaseFee::get(),
+			ChargeTransactionPayment::<Runtime>::compute_fee(0, dispatch_info, 0)
+		);
+	});
+}
+
+// These following tests may be used to inspect transaction fee values.
+// They are not required to assert correctness.
+#[test]
+#[ignore]
 fn fee_components_ga() {
 	ExtBuilder::default().build().execute_with(|| {
+		for amount in &[
+			1,
+			1 * DOLLARS,
+			100 * DOLLARS,
+			1000 * DOLLARS,
+			10_000 * DOLLARS,
+			100_000 * DOLLARS,
+		] {
+			let call = Call::GenericAsset(pallet_generic_asset::Call::transfer(CENTRAPAY_ASSET_ID, bob(), *amount));
+			let tx = signed_tx(call);
 
-        for amount in &[1, 1 * DOLLARS, 100 * DOLLARS, 1000 * DOLLARS, 10_000 * DOLLARS, 100_000 * DOLLARS] {
-	        let call = Call::GenericAsset(
-                pallet_generic_asset::Call::transfer(CENTRAPAY_ASSET_ID, bob(), *amount)
-            );
-		    let tx = signed_tx(call);
-
-		    let tx_fee = ChargeTransactionPayment::<Runtime>::compute_fee_parts(
-			    Encode::encode(&tx).len() as u32,
-			    tx.get_dispatch_info(),
-		    );
-            println!("{:?}", tx_fee);
-        }
+			let tx_fee = ChargeTransactionPayment::<Runtime>::compute_fee_parts(
+				Encode::encode(&tx).len() as u32,
+				tx.get_dispatch_info(),
+			);
+			println!("{:?}", tx_fee);
+		}
 
 		assert!(false);
 	});
 }
 
 #[test]
-fn fee_components_sylo() {
+#[ignore]
+fn fee_components_sylo_e2ee_call() {
 	ExtBuilder::default().build().execute_with(|| {
-		let sylo_call = Call::SyloE2EE(
-			crml_sylo::e2ee::Call::register_device(
-				100_000,
-				// 12 pkbs (SHA-256 hash)
-				vec![
-					b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
-				],
-			)
-		);
+		let sylo_call = Call::SyloE2EE(crml_sylo::e2ee::Call::register_device(
+			100_000,
+			// 8 pkbs (SHA-256 hash)
+			vec![
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+			],
+		));
 		let tx = signed_tx(sylo_call);
 
 		let tx_fee = ChargeTransactionPayment::<Runtime>::compute_fee_parts(
 			Encode::encode(&tx).len() as u32,
 			tx.get_dispatch_info(),
 		);
-		println!("{:?}", tx_fee);
-		println!("{:?}", <Runtime as crml_transaction_payment::Trait>::TransactionBaseFee::get());
-		println!("{:?}", <Runtime as crml_transaction_payment::Trait>::TransactionByteFee::get());
+		println!("{:?}", tx_fee.total());
+
+		assert!(false);
+	});
+}
+
+#[test]
+#[ignore]
+fn fee_components_sylo_group_update_member() {
+	ExtBuilder::default().build().execute_with(|| {
+		let sylo_call = Call::SyloGroups(crml_sylo::groups::Call::update_member(
+			Default::default(),
+			vec![(
+				b"some metadata".to_vec(),
+				b"some very long meta data which is similar in size to what would be sent from the normal sylo app"
+					.to_vec(),
+			)],
+		));
+		let tx = signed_tx(sylo_call);
+
+		let tx_fee = ChargeTransactionPayment::<Runtime>::compute_fee_parts(
+			Encode::encode(&tx).len() as u32,
+			tx.get_dispatch_info(),
+		);
+		println!("{:?}", tx_fee.total());
+
+		assert!(false);
+	});
+}
+
+#[test]
+#[ignore]
+fn fee_components_sylo_vault_replenish_pkbs() {
+	ExtBuilder::default().build().execute_with(|| {
+		let sylo_call = Call::SyloE2EE(crml_sylo::e2ee::Call::replenish_pkbs(
+			1_000_000_u32,
+			vec![
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+			],
+		));
+		let tx = signed_tx(sylo_call);
+
+		let tx_fee = ChargeTransactionPayment::<Runtime>::compute_fee_parts(
+			Encode::encode(&tx).len() as u32,
+			tx.get_dispatch_info(),
+		);
+		println!("{:?}", tx_fee.total());
+
+		assert!(false);
+	});
+}
+
+#[test]
+#[ignore]
+fn fee_components_sylo_vault_upsert_value() {
+	ExtBuilder::default().build().execute_with(|| {
+		let sylo_call = Call::SyloVault(crml_sylo::vault::Call::upsert_value(
+			[1_u8; 64].to_vec(),
+			[2_u8; 64].to_vec(),
+		));
+		let tx = signed_tx(sylo_call);
+
+		let tx_fee = ChargeTransactionPayment::<Runtime>::compute_fee_parts(
+			Encode::encode(&tx).len() as u32,
+			tx.get_dispatch_info(),
+		);
+		println!("{:?}", tx_fee.total());
 
 		assert!(false);
 	});

--- a/runtime/tests/fee.rs
+++ b/runtime/tests/fee.rs
@@ -1,0 +1,84 @@
+/* Copyright 2019-2020 Centrality Investments Limited
+*
+* Licensed under the LGPL, Version 3.0 (the "License");
+* you may not use this file except in compliance with the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* You may obtain a copy of the License at the root of this project source code,
+* or at:
+*     https://centrality.ai/licenses/gplv3.txt
+*     https://centrality.ai/licenses/lgplv3.txt
+*/
+
+use cennznet_runtime::{
+	constants::{asset::*, currency::*},
+	Call, CheckedExtrinsic, Runtime, UncheckedExtrinsic,
+};
+use cennznet_testing::keyring::{alice, bob, sign, signed_extra};
+use codec::Encode;
+use crml_transaction_payment::ChargeTransactionPayment;
+use frame_support::weights::GetDispatchInfo;
+mod mock;
+use mock::ExtBuilder;
+
+// Make signed transaction given a `Call`
+fn signed_tx(call: Call) -> UncheckedExtrinsic {
+	sign(
+		CheckedExtrinsic {
+			signed: Some((alice(), signed_extra(0, 0, None, None))),
+			function: call,
+		},
+		4,                  // tx version
+		Default::default(), // genesis hash
+	)
+}
+
+#[test]
+fn fee_components_ga() {
+	ExtBuilder::default().build().execute_with(|| {
+
+        for amount in &[1, 1 * DOLLARS, 100 * DOLLARS, 1000 * DOLLARS, 10_000 * DOLLARS, 100_000 * DOLLARS] {
+	        let call = Call::GenericAsset(
+                pallet_generic_asset::Call::transfer(CENTRAPAY_ASSET_ID, bob(), *amount)
+            );
+		    let tx = signed_tx(call);
+
+		    let tx_fee = ChargeTransactionPayment::<Runtime>::compute_fee_parts(
+			    Encode::encode(&tx).len() as u32,
+			    tx.get_dispatch_info(),
+		    );
+            println!("{:?}", tx_fee);
+        }
+
+		assert!(false);
+	});
+}
+
+#[test]
+fn fee_components_sylo() {
+	ExtBuilder::default().build().execute_with(|| {
+		let sylo_call = Call::SyloE2EE(
+			crml_sylo::e2ee::Call::register_device(
+				100_000,
+				// 12 pkbs (SHA-256 hash)
+				vec![
+					b"0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9".to_vec(),
+				],
+			)
+		);
+		let tx = signed_tx(sylo_call);
+
+		let tx_fee = ChargeTransactionPayment::<Runtime>::compute_fee_parts(
+			Encode::encode(&tx).len() as u32,
+			tx.get_dispatch_info(),
+		);
+		println!("{:?}", tx_fee);
+		println!("{:?}", <Runtime as crml_transaction_payment::Trait>::TransactionBaseFee::get());
+		println!("{:?}", <Runtime as crml_transaction_payment::Trait>::TransactionByteFee::get());
+
+		assert!(false);
+	});
+}

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -220,11 +220,10 @@ pub mod contracts {
 		(func (export "call")
 			(call $ext_dispatch_call
 				(i32.const 8) ;; Pointer to the start of encoded call buffer
-				(i32.const 42) ;; Length of the buffer
+				(i32.const 40) ;; Length of the buffer
 			)
 		)
 		(func (export "deploy"))
-		// TODO UPDATE THIS!
-		(data (i32.const 8) "\06\01\01\FA\90\B5\AB\20\5C\69\74\C9\EA\84\1B\E6\88\86\46\33\DC\9C\A8\A3\57\84\3E\EA\CF\23\14\64\99\65\FE\22\07\00\10\A5\D4\E8")
+		(data (i32.const 8) "\05\01\01\FA\90\B5\AB\20\5C\69\74\C9\EA\84\1B\E6\88\86\46\33\DC\9C\A8\A3\57\84\3E\EA\CF\23\14\64\99\65\FE\22\82\3F\5C\02")
 	)"#;
 }

--- a/runtime/tests/mock.rs
+++ b/runtime/tests/mock.rs
@@ -224,6 +224,7 @@ pub mod contracts {
 			)
 		)
 		(func (export "deploy"))
+		// TODO UPDATE THIS!
 		(data (i32.const 8) "\06\01\01\FA\90\B5\AB\20\5C\69\74\C9\EA\84\1B\E6\88\86\46\33\DC\9C\A8\A3\57\84\3E\EA\CF\23\14\64\99\65\FE\22\07\00\10\A5\D4\E8")
 	)"#;
 }

--- a/testing/src/genesis.rs
+++ b/testing/src/genesis.rs
@@ -119,7 +119,7 @@ pub fn config_endowed(support_changes_trie: bool, code: Option<&[u8]>, extra_end
 		}),
 		pallet_contracts: Some(ContractsConfig {
 			current_schedule: Default::default(),
-			gas_price: 1 * MILLICENTS,
+			gas_price: 1 * MICROS,
 		}),
 		pallet_babe: Some(Default::default()),
 		pallet_grandpa: Some(GrandpaConfig { authorities: vec![] }),


### PR DESCRIPTION
Normalise transaction fees to the right magnitude for a 4dp currency `~(0.0001 - 10.0000)`

**Adds**:
- Add `compute_fee_parts` which returns the breakdown of a transaction fees parts + some example tests (this part could be removed and done in another PR)

**Changes**:
- Weight to fee calculation linearly maps `[min_weight, max_weight]` into `[min_weight_fee, max_weight_fee]`
- `TransactionMinWeightFee` and `TransactionMaxWeightFee` can be configured in the runtime
- Replace currency denominations in runtime, genesis config, and tests with (`DOLLARS/1.0000` and `MICROS/0.0001`)
- refactored `compute_fee` to use `compute_fee_parts` internally

**Fixes**:
- Replace 90% magic number fee constants in tests with calculated values

**Concerns**:
- Contract fees still need some investigation and are a bit opaque around gas pricing
- Future Work: Intending to expose `compute_fee_parts` via RPC to give better transparency on tx fee values