### PR TITLE
Feature/260 sylo fees

### DIFF
--- a/crml/sylo/src/lib.rs
+++ b/crml/sylo/src/lib.rs
@@ -19,6 +19,7 @@ pub mod device;
 pub mod e2ee;
 pub mod groups;
 pub mod inbox;
+pub mod payment;
 pub mod response;
 pub mod vault;
 

--- a/crml/sylo/src/payment.rs
+++ b/crml/sylo/src/payment.rs
@@ -1,0 +1,141 @@
+/* Copyright 2020 Centrality Investments Limited
+*
+* Licensed under the LGPL, Version 3.0 (the "License");
+* you may not use this file except in compliance with the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* You may obtain a copy of the License at the root of this project source code,
+* or at:
+*     https://centrality.ai/licenses/gplv3.txt
+*     https://centrality.ai/licenses/lgplv3.txt
+*/
+
+//! Manage the authorized accounts set for the Sylo fee payment
+
+use frame_support::{decl_module, decl_storage, ensure, weights::SimpleDispatchInfo, IterableStorageMap};
+use frame_system::{ensure_root, ensure_signed};
+use sp_runtime::DispatchResult;
+use sp_std::prelude::*;
+
+pub trait Trait: frame_system::Trait {}
+
+const NOT_SYLO_PAYER: &str = "You are not a Sylo payer!";
+
+decl_storage! {
+	trait Store for Module<T: Trait> as SyloModule {
+		/// Accounts which have authority to pay for Sylo fees on behalf of the users
+		AuthorisedPayers: map hasher(twox_64_concat) T::AccountId => bool;
+	}
+}
+
+decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
+
+		/// Add `account_id` as an authorized Sylo fee payer. Only Sudo can set a payment account.
+		#[weight = SimpleDispatchInfo::FixedOperational(0)]
+		pub fn set_payment_account(origin, account_id: T::AccountId) -> DispatchResult {
+			ensure_root(origin)?;
+			AuthorisedPayers::<T>::insert(account_id, true);
+			Ok(())
+		}
+
+		/// If the origin of the call is an authorised payer, revoke its authorisation.
+		/// NOTE: This may halt all Sylo operations if there are no other payers.
+		#[weight = SimpleDispatchInfo::FixedOperational(0)]
+		pub fn revoke_me(origin) -> DispatchResult {
+			let account_id = ensure_signed(origin)?;
+			ensure!(AuthorisedPayers::<T>::get(&account_id), NOT_SYLO_PAYER);
+			AuthorisedPayers::<T>::remove(account_id);
+			Ok(())
+		}
+	}
+}
+
+impl<T: Trait> Module<T> {
+	/// Return the first account that is set for payment, or None when nothing is set.
+	/// In the future, we can make this function smart so it returns the account with enough money in it.
+	pub fn get_payment_account() -> Option<T::AccountId> {
+		AuthorisedPayers::<T>::iter().map(|(x, _)| x).next()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{ExtBuilder, Origin, Test};
+	use frame_support::assert_ok;
+	use frame_system::RawOrigin;
+	use sp_core::H256;
+	use sp_runtime::DispatchError::Other;
+
+	type SyloModule = Module<Test>;
+
+	impl Trait for Test {}
+
+	#[test]
+	fn set_payment_account() {
+		ExtBuilder::default().build().execute_with(|| {
+			let payer_a = H256::from_low_u64_be(2);
+			let payer_b = H256::from_low_u64_be(3);
+
+			assert!(!AuthorisedPayers::<Test>::get(&payer_a));
+			assert!(!AuthorisedPayers::<Test>::get(&payer_b));
+
+			assert_ok!(SyloModule::set_payment_account(Origin::ROOT, payer_a));
+			assert_ok!(SyloModule::set_payment_account(Origin::ROOT, payer_b));
+
+			assert!(AuthorisedPayers::<Test>::get(&payer_a));
+			assert!(AuthorisedPayers::<Test>::get(&payer_b));
+		});
+	}
+
+	#[test]
+	fn get_payment_account() {
+		ExtBuilder::default().build().execute_with(|| {
+			let payer_a = H256::from_low_u64_be(2);
+			let payer_b = H256::from_low_u64_be(3);
+
+			assert_ok!(SyloModule::set_payment_account(Origin::ROOT, payer_a.clone()));
+			assert_ok!(SyloModule::set_payment_account(Origin::ROOT, payer_b));
+
+			assert_eq!(SyloModule::get_payment_account().unwrap(), payer_a);
+		});
+	}
+
+	#[test]
+	fn get_payment_account_when_no_account_is_set() {
+		ExtBuilder::default().build().execute_with(|| {
+			assert_eq!(SyloModule::get_payment_account(), None);
+		});
+	}
+
+	#[test]
+	fn revoke_me_a_payer() {
+		ExtBuilder::default().build().execute_with(|| {
+			let payer_a = H256::from_low_u64_be(2);
+
+			assert_ok!(SyloModule::set_payment_account(Origin::ROOT, payer_a));
+
+			assert_ok!(SyloModule::revoke_me(Origin::from(RawOrigin::Signed(payer_a.clone()))));
+
+			assert!(!AuthorisedPayers::<Test>::get(&payer_a));
+		});
+	}
+
+	#[test]
+	fn revoke_me_a_non_payer() {
+		ExtBuilder::default().build().execute_with(|| {
+			let payer_a = H256::from_low_u64_be(2);
+
+			assert_eq!(
+				SyloModule::revoke_me(Origin::from(RawOrigin::Signed(payer_a.clone()))),
+				Err(Other(NOT_SYLO_PAYER))
+			);
+
+			assert!(!AuthorisedPayers::<Test>::get(&payer_a));
+		});
+	}
+}

--- a/crml/sylo/src/payment.rs
+++ b/crml/sylo/src/payment.rs
@@ -55,7 +55,7 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
-	/// Return the first account that is set for payment, or None when nothing is set.
+	/// Return an account that is set for payment, or `None` when nothing is set.
 	/// In the future, we can make this function smart so it returns the account with enough money in it.
 	pub fn payment_account() -> Option<T::AccountId> {
 		AuthorisedPayers::<T>::iter().map(|(x, _)| x).next()

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -67,9 +67,18 @@ type NegativeImbalanceOf<T> =
 
 pub const GAS_FEE_EXCHANGE_KEY: &[u8] = b"gas-fee-exchange-key";
 
+/// This is an interface that can return the account id of a fee payer for a specific call.
+/// If there is no such an individual for a call, it returns None which means the submitter of
+/// the extrinsic is going to pay the fee.
 pub trait FeePayer {
+	/// The runtime call type
 	type Call;
+
+	/// The user account identifier type for the runtime.
 	type AccountId;
+
+	/// Return the account id of the fee payer for `call`. Return None if the fee payer
+	/// is the same as the submitter of the call
 	fn fee_payer(call: &Self::Call) -> Option<Self::AccountId>;
 }
 

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -67,6 +67,12 @@ type NegativeImbalanceOf<T> =
 
 pub const GAS_FEE_EXCHANGE_KEY: &[u8] = b"gas-fee-exchange-key";
 
+pub trait FeePayer {
+	type Call;
+	type AccountId;
+	fn fee_payer(call: &Self::Call) -> Option<Self::AccountId>;
+}
+
 pub trait Trait: frame_system::Trait {
 	/// The units in which we record balances.
 	type Balance: Parameter + Member + BaseArithmetic + Default + Copy + MaybeSerializeDeserialize + Debug;
@@ -103,6 +109,8 @@ pub trait Trait: frame_system::Trait {
 
 	/// Something which can report whether a call is gas metered
 	type GasMeteredCallResolver: IsGasMeteredCall<Call = <Self as frame_system::Trait>::Call>;
+
+	type FeePayer: FeePayer<Call = Self::Call, AccountId = Self::AccountId>;
 }
 
 decl_storage! {
@@ -261,9 +269,10 @@ where
 
 		// Only mess with balances if the fee is not zero.
 		if !fee.is_zero() {
+			let payer = T::FeePayer::fee_payer(call).unwrap_or(who.clone());
 			if let Some(exchange) = &self.fee_exchange {
 				// Buy the CENNZnet fee currency paying with the user's nominated fee currency
-				exchange_asset_spent = T::BuyFeeAsset::buy_fee_asset(who, fee, &exchange).map_err(|e| {
+				exchange_asset_spent = T::BuyFeeAsset::buy_fee_asset(&payer, fee, &exchange).map_err(|e| {
 					let code = match e {
 						DispatchError::Module { message, .. } => error_code::buy_fee_asset_error_msg_to_code(
 							message.unwrap_or("Unknown buy fee asset error"),
@@ -280,7 +289,7 @@ where
 				WithdrawReason::TransactionPayment | WithdrawReason::Tip
 			};
 			// Pay for the transaction `fee` in the native fee currency
-			let imbalance = match T::Currency::withdraw(who, fee, withdraw_reason, ExistenceRequirement::KeepAlive) {
+			let imbalance = match T::Currency::withdraw(&payer, fee, withdraw_reason, ExistenceRequirement::KeepAlive) {
 				Ok(imbalance) => imbalance,
 				Err(_) => return Err(InvalidTransaction::Custom(error_code::INSUFFICIENT_FEE_ASSET_BALANCE).into()),
 			};
@@ -397,6 +406,14 @@ mod tests {
 		}
 	}
 
+	impl FeePayer for MockCallResolver {
+		type Call = Call;
+		type AccountId = u64;
+		fn fee_payer(_call: &Self::Call) -> Option<Self::AccountId> {
+			None
+		}
+	}
+
 	/// Implement a fake BuyFeeAsset for tests
 	impl BuyFeeAsset for Module<Runtime> {
 		type AccountId = u64;
@@ -502,6 +519,7 @@ mod tests {
 		type FeeMultiplierUpdate = ();
 		type BuyFeeAsset = Module<Self>;
 		type GasMeteredCallResolver = MockCallResolver;
+		type FeePayer = MockCallResolver;
 	}
 
 	type Balances = pallet_balances::Module<Runtime>;

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -110,6 +110,7 @@ pub trait Trait: frame_system::Trait {
 	/// Something which can report whether a call is gas metered
 	type GasMeteredCallResolver: IsGasMeteredCall<Call = <Self as frame_system::Trait>::Call>;
 
+	/// A fee payer, if specified for a call, is an account that can be different from the submitter of an extrinsic.
 	type FeePayer: FeePayer<Call = Self::Call, AccountId = Self::AccountId>;
 }
 

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -316,7 +316,7 @@ impl crml_transaction_payment::FeePayer for FeePayerResolver {
 			_ => false,
 		};
 		if is_sylo {
-			sylo_payment::Module::<Runtime>::get_payment_account()
+			sylo_payment::Module::<Runtime>::payment_account()
 		} else {
 			None
 		}

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -16,7 +16,7 @@
 
 //! Some configurable implementations as associated type for the substrate runtime.
 
-use crate::{Call, MaximumBlockWeight, NegativeImbalance, Runtime, ScaleDownFactor, System};
+use crate::{sylo_payment, Call, MaximumBlockWeight, NegativeImbalance, Runtime, ScaleDownFactor, System};
 use cennznet_primitives::{
 	traits::{BuyFeeAsset, IsGasMeteredCall},
 	types::{Balance, FeeExchange},
@@ -297,6 +297,28 @@ impl IsGasMeteredCall for GasMeteredCallResolver {
 			Call::Contracts(pallet_contracts::Call::instantiate(_, _, _, _)) => true,
 			Call::Contracts(pallet_contracts::Call::put_code(_, _)) => true,
 			_ => false,
+		}
+	}
+}
+
+pub struct FeePayerResolver;
+impl crml_transaction_payment::FeePayer for FeePayerResolver {
+	type Call = Call;
+	type AccountId = <Runtime as frame_system::Trait>::AccountId;
+	fn fee_payer(call: &Self::Call) -> Option<<Runtime as frame_system::Trait>::AccountId> {
+		let is_sylo = match call {
+			Call::SyloGroups(_) => true,
+			Call::SyloE2EE(_) => true,
+			Call::SyloDevice(_) => true,
+			Call::SyloInbox(_) => true,
+			Call::SyloResponse(_) => true,
+			Call::SyloVault(_) => true,
+			_ => false,
+		};
+		if is_sylo {
+			sylo_payment::Module::<Runtime>::get_payment_account()
+		} else {
+			None
 		}
 	}
 }

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -304,6 +304,7 @@ impl IsGasMeteredCall for GasMeteredCallResolver {
 	}
 }
 
+/// The type that implements FeePayer for the cennznet-runtime Call(s)
 pub struct FeePayerResolver;
 impl crml_transaction_payment::FeePayer for FeePayerResolver {
 	type Call = Call;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -71,8 +71,8 @@ pub use crml_sylo::vault as sylo_vault;
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
 use impls::{
-	CENNZnetDispatchVerifier, CurrencyToVoteHandler, GasHandler, GasMeteredCallResolver, ScaleLinearWeightToFee,
-	SplitToAllValidators, TargetedFeeAdjustment,
+	CENNZnetDispatchVerifier, CurrencyToVoteHandler, FeePayerResolver, GasHandler, GasMeteredCallResolver,
+	ScaleLinearWeightToFee, SplitToAllValidators, TargetedFeeAdjustment,
 };
 
 /// Constant values used within the runtime.
@@ -230,6 +230,7 @@ impl crml_transaction_payment::Trait for Runtime {
 	type FeeMultiplierUpdate = TargetedFeeAdjustment<TargetBlockFullness>;
 	type BuyFeeAsset = CennzxSpot;
 	type GasMeteredCallResolver = GasMeteredCallResolver;
+	type FeePayer = FeePayerResolver;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -64,6 +64,7 @@ pub use crml_sylo::device as sylo_device;
 pub use crml_sylo::e2ee as sylo_e2ee;
 pub use crml_sylo::groups as sylo_groups;
 pub use crml_sylo::inbox as sylo_inbox;
+pub use crml_sylo::payment as sylo_payment;
 pub use crml_sylo::response as sylo_response;
 pub use crml_sylo::vault as sylo_vault;
 
@@ -179,6 +180,7 @@ impl crml_sylo::device::Trait for Runtime {}
 impl crml_sylo::response::Trait for Runtime {}
 impl crml_sylo::inbox::Trait for Runtime {}
 impl crml_sylo::vault::Trait for Runtime {}
+impl crml_sylo::payment::Trait for Runtime {}
 
 parameter_types! {
 	pub const EpochDuration: u64 = EPOCH_DURATION_IN_SLOTS;
@@ -574,6 +576,7 @@ construct_runtime!(
 		SyloInbox: sylo_inbox::{Module, Call, Storage},
 		SyloResponse: sylo_response::{Module, Call, Storage},
 		SyloVault: sylo_vault::{Module, Call, Storage},
+		SyloPayment: sylo_payment::{Module, Call, Storage},
 		CennzxSpot: crml_cennzx_spot::{Module, Call, Storage, Config<T>, Event<T>},
 	}
 );

--- a/runtime/tests/tests.rs
+++ b/runtime/tests/tests.rs
@@ -16,9 +16,10 @@
 use cennznet_primitives::types::{AccountId, Balance, BlockNumber, DigestItem, FeeExchange, FeeExchangeV1};
 use cennznet_runtime::{
 	constants::{asset::*, currency::*},
-	Babe, Call, CennzxSpot, CheckedExtrinsic, ContractTransactionBaseFee, EpochDuration, Event, Executive,
-	GenericAsset, Header, ImOnline, Origin, Runtime, Session, SessionsPerEra, Staking, System, Timestamp,
-	TransactionBaseFee, TransactionByteFee, TransactionPayment, UncheckedExtrinsic,
+	sylo_e2ee, sylo_groups, sylo_inbox, sylo_response, sylo_vault, Babe, Call, CennzxSpot, CheckedExtrinsic,
+	ContractTransactionBaseFee, EpochDuration, Event, Executive, GenericAsset, Header, ImOnline, Origin, Runtime,
+	Session, SessionsPerEra, Staking, SyloPayment, System, Timestamp, TransactionBaseFee, TransactionByteFee,
+	TransactionPayment, UncheckedExtrinsic,
 };
 use cennznet_testing::keyring::*;
 use codec::Encode;
@@ -26,6 +27,7 @@ use crml_staking::{EraIndex, RewardDestination, StakingLedger};
 use crml_transaction_payment::constants::error_code::*;
 use frame_support::{
 	additional_traits::MultiCurrencyAccounting as MultiCurrency,
+	assert_ok,
 	storage::StorageValue,
 	traits::{Imbalance, OnInitialize},
 	weights::{DispatchClass, DispatchInfo, GetDispatchInfo},
@@ -674,6 +676,147 @@ fn runtime_mock_setup_works() {
 			assert_eq!(GenericAsset::total_issuance(asset), amount * 9);
 		}
 	});
+}
+
+fn apply_extrinsic(origin: AccountId, call: Call) -> Balance {
+	let xt = sign(CheckedExtrinsic {
+		signed: Some((origin, signed_extra(0, 0, None, None))),
+		function: call.clone(),
+	});
+
+	let fee = transfer_fee(&xt, &call);
+
+	Executive::initialize_block(&header());
+	let r = Executive::apply_extrinsic(xt);
+	assert!(r.is_ok());
+
+	fee
+}
+
+#[test]
+fn non_sylo_call_is_not_paid_by_payment_account() {
+	let call = Call::GenericAsset(pallet_generic_asset::Call::transfer(CENTRAPAY_ASSET_ID, dave(), 100));
+
+	ExtBuilder::default()
+		.initial_balance(100 * TransactionBaseFee::get())
+		.build()
+		.execute_with(|| {
+			assert_ok!(SyloPayment::set_payment_account(Origin::ROOT, bob()));
+
+			let fee_asset_id = Some(GenericAsset::spending_asset_id());
+			let bob_balance = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id.clone());
+
+			let _ = apply_extrinsic(charlie(), call);
+
+			let bob_balance_after_calls = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id);
+			assert_eq!(bob_balance_after_calls, bob_balance);
+		});
+}
+
+#[test]
+fn sylo_e2ee_call_is_paid_by_payment_account() {
+	let call = Call::SyloE2EE(sylo_e2ee::Call::register_device(1, vec![]));
+
+	ExtBuilder::default()
+		.initial_balance(100 * TransactionBaseFee::get())
+		.build()
+		.execute_with(|| {
+			assert_ok!(SyloPayment::set_payment_account(Origin::ROOT, bob()));
+
+			let fee_asset_id = Some(GenericAsset::spending_asset_id());
+			let bob_balance = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id.clone());
+
+			let call_fee = apply_extrinsic(charlie(), call);
+
+			let bob_balance_after_calls = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id);
+			assert_eq!(bob_balance_after_calls, bob_balance - call_fee);
+		});
+}
+
+#[test]
+fn sylo_inbox_call_is_paid_by_payment_account() {
+	let call = Call::SyloInbox(sylo_inbox::Call::add_value(dave(), b"dude!".to_vec()));
+
+	ExtBuilder::default()
+		.initial_balance(100 * TransactionBaseFee::get())
+		.build()
+		.execute_with(|| {
+			assert_ok!(SyloPayment::set_payment_account(Origin::ROOT, bob()));
+
+			let fee_asset_id = Some(GenericAsset::spending_asset_id());
+			let bob_balance = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id.clone());
+
+			let call_fee = apply_extrinsic(charlie(), call);
+
+			let bob_balance_after_calls = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id);
+			assert_eq!(bob_balance_after_calls, bob_balance - call_fee);
+		});
+}
+
+#[test]
+fn sylo_vault_call_is_paid_by_payment_account() {
+	let call = Call::SyloVault(sylo_vault::Call::upsert_value(b"key".to_vec(), b"value".to_vec()));
+
+	ExtBuilder::default()
+		.initial_balance(100 * TransactionBaseFee::get())
+		.build()
+		.execute_with(|| {
+			assert_ok!(SyloPayment::set_payment_account(Origin::ROOT, bob()));
+
+			let fee_asset_id = Some(GenericAsset::spending_asset_id());
+			let bob_balance = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id.clone());
+
+			let call_fee = apply_extrinsic(charlie(), call);
+
+			let bob_balance_after_calls = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id);
+			assert_eq!(bob_balance_after_calls, bob_balance - call_fee);
+		});
+}
+
+#[test]
+fn sylo_response_call_is_paid_by_payment_account() {
+	let call = Call::SyloResponse(sylo_response::Call::remove_response([0u8; 32].into()));
+
+	ExtBuilder::default()
+		.initial_balance(100 * TransactionBaseFee::get())
+		.build()
+		.execute_with(|| {
+			assert_ok!(SyloPayment::set_payment_account(Origin::ROOT, bob()));
+
+			let fee_asset_id = Some(GenericAsset::spending_asset_id());
+			let bob_balance = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id.clone());
+
+			let call_fee = apply_extrinsic(charlie(), call);
+
+			let bob_balance_after_calls = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id);
+			assert_eq!(bob_balance_after_calls, bob_balance - call_fee);
+		});
+}
+
+#[test]
+fn sylo_groups_call_is_paid_by_payment_account() {
+	let meta = vec![(b"key".to_vec(), b"value".to_vec())];
+	let call = Call::SyloGroups(sylo_groups::Call::create_group(
+		[1u8; 32].into(),
+		meta,
+		vec![],
+		(b"group".to_vec(), b"data".to_vec()),
+	));
+
+	ExtBuilder::default()
+		.initial_balance(100 * TransactionBaseFee::get())
+		.build()
+		.execute_with(|| {
+			assert_ok!(SyloPayment::set_payment_account(Origin::ROOT, bob()));
+
+			let fee_asset_id = Some(GenericAsset::spending_asset_id());
+			let bob_balance = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id.clone());
+
+			let call_fee = apply_extrinsic(charlie(), call);
+
+			let bob_balance_after_calls = <GenericAsset as MultiCurrency>::free_balance(&bob(), fee_asset_id);
+			assert_eq!(bob_balance_after_calls, bob_balance - call_fee);
+		});
 }
 
 #[test]


### PR DESCRIPTION
Closes #260 

Here is the list of features:
- Only Sudo will be able to set one or more payment accounts for Sylo calls. 
- Only an authorised payment account can revoke itself from being a payment account anymore.
- When there is more than one payment account, at the moment, we will simply use the first one, which is set earlier. In the future, we can make this smarter to go for the account with the highest balance.
- Having more than one account as payment accounts enables a seamless swap of the accounts. If Sylo wants to use a different account, they can simple first add the new one and then remove the old one, without being worried that it can make any pause in their operations.
- I haven't created an easy direct revoke of all the payment accounts simply because it will definitely halt all Sylo operations until a new one is set. So we'd better need to do such operations with more effort rather than less effort.
- The method used here is secure because users cannot modify which call is being paid by Sylo with runtime operations and only Sudo has the privilege to set a payment account.
- When there are no payment accounts for Sylo, we will see if the caller can pay the fee themselves before rejecting the call.
