### PR TITLE
Build on rust 1.46.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
       image: ubuntu-1604:201903-01
     environment:
       BASH_ENV: ~/.cargo/env
+      RUST_VERSION: 1.46.0
     steps:
       - checkout
       - install-rust
@@ -135,6 +136,7 @@ jobs:
       BASH_ENV: ~/.cargo/env
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
+      RUST_VERSION: 1.46.0
     steps:
       - checkout
       - install-rust
@@ -151,6 +153,7 @@ jobs:
       BASH_ENV: ~/.cargo/env
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
+      RUST_VERSION: 1.46.0
     steps:
       - checkout
       - install-rust

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,6 @@ jobs:
       image: ubuntu-1604:201903-01
     environment:
       BASH_ENV: ~/.cargo/env
-      RUST_VERSION: 1.46.0
     steps:
       - checkout
       - install-rust
@@ -136,7 +135,6 @@ jobs:
       BASH_ENV: ~/.cargo/env
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
-      RUST_VERSION: 1.46.0
     steps:
       - checkout
       - install-rust
@@ -153,7 +151,6 @@ jobs:
       BASH_ENV: ~/.cargo/env
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
-      RUST_VERSION: 1.46.0
     steps:
       - checkout
       - install-rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d38aeaffc032ec69faa476b3caaca8d4dd7f3f798137ff30359e5c7869ceb6"
+checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
 dependencies = [
  "arrayvec 0.5.1",
  "bitvec",
@@ -4375,9 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd20ff7e0399b274a5f5bb37b712fccb5b3a64b9128200d1c3cc40fe709cb073"
+checksum = "198db82bb1c18fc00176004462dd809b2a6d851669550aa17af6dacd21ae0c14"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -19,7 +19,8 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_git("https://github.com/plugblockchain/plug-blockchain", "1.0.0-rc4.1")
+		// commit hash for: `1.0.0-rc4.1`
+		.with_wasm_builder_from_git("https://github.com/plugblockchain/plug-blockchain", "316757e3f29c6aa1629fc1955fc18078fcb32126")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -19,7 +19,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_git("https://github.com/plugblockchain/plug-blockchain", "1.0.0-rc3.1")
+		.with_wasm_builder_from_git("https://github.com/plugblockchain/plug-blockchain", "1.0.0-rc4.1")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -20,7 +20,10 @@ fn main() {
 	WasmBuilder::new()
 		.with_current_project()
 		// commit hash for: `1.0.0-rc4.1`
-		.with_wasm_builder_from_git("https://github.com/plugblockchain/plug-blockchain", "316757e3f29c6aa1629fc1955fc18078fcb32126")
+		.with_wasm_builder_from_git(
+			"https://github.com/plugblockchain/plug-blockchain",
+			"316757e3f29c6aa1629fc1955fc18078fcb32126",
+		)
 		.export_heap_base()
 		.import_memory()
 		.build()


### PR DESCRIPTION
Fixes #265 

`WasmBuilder` was referencing an older version of plug.

- ~Update to rust 1.46.0~ done via circleci app
- Bump parity-scale-codec version