### PR TITLE
Update cennznet to use the latest TranscationPaymentApi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1757,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1835,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "node-inspect"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "node-transaction-factory"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3944,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3995,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4044,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4083,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "pallet-generic-asset"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4112,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "pallet-generic-asset-rpc"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "pallet-generic-asset-rpc-runtime-api"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "pallet-generic-asset",
  "parity-scale-codec",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4239,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4270,7 +4270,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4288,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4301,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "prml-attestation"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "prml-doughnut"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5406,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "bytes 0.5.5",
  "derive_more",
@@ -5433,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5455,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5471,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5486,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5497,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -5536,7 +5536,7 @@ dependencies = [
 [[package]]
 name = "sc-client"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5604,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5632,7 +5632,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5674,7 +5674,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5696,7 +5696,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5709,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5730,7 +5730,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "log 0.4.8",
  "sc-client-api",
@@ -5744,7 +5744,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -5787,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5803,7 +5803,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "assert_matches",
  "finality-grandpa",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -5873,7 +5873,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "hex",
@@ -5888,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "bitflags",
  "bytes 0.5.5",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5954,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "bytes 0.5.5",
  "fnv",
@@ -5980,7 +5980,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -5992,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6024,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6047,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6062,7 +6062,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "exit-future",
@@ -6112,7 +6112,7 @@ dependencies = [
 [[package]]
 name = "sc-service-test"
 version = "2.0.0-dev"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "env_logger",
  "fdlimit",
@@ -6133,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -6147,7 +6147,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "bytes 0.5.5",
  "futures 0.3.5",
@@ -6169,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -6184,7 +6184,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc3"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6204,7 +6204,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc3"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6619,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6643,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6656,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6668,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6679,7 +6679,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6691,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -6707,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6729,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6745,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6757,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "environmental",
  "sp-std",
@@ -6817,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6830,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6840,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -6852,7 +6852,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "hash-db",
  "libsecp256k1",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6881,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -6890,7 +6890,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -6899,7 +6899,7 @@ dependencies = [
 [[package]]
 name = "sp-phragmen"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6910,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "serde",
  "sp-core",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "doughnut_rs",
  "hash256-std-hasher",
@@ -6941,7 +6941,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "primitive-types 0.7.2",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6967,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -6980,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6989,7 +6989,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "hash-db",
  "log 0.4.8",
@@ -7029,12 +7029,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "impl-serde 0.2.3",
  "serde",
@@ -7045,7 +7045,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7059,7 +7059,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc3"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "tracing",
 ]
@@ -7067,7 +7067,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc2"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7097,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc3"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7248,12 +7248,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-dev"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7308,12 +7308,12 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0-alpha.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.1#316757e3f29c6aa1629fc1955fc18078fcb32126"
+source = "git+https://github.com/plugblockchain/plug-blockchain?branch=1.0.0-rc4.2#f7839e5cd00b53cc4533c5149508da46b839ba7a"
 
 [[package]]
 name = "substrate-wasmtime"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,45 +25,45 @@ structopt = { version = "0.3.8", optional = true }
 tracing = "0.1.10"
 
 # primitives
-sp-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-grandpa-primitives = { package = "sp-finality-grandpa", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-finality-tracker = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-inherents = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-consensus  = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sp-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+grandpa-primitives = { package = "sp-finality-grandpa", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-finality-tracker = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-inherents = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-consensus  = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 # client dependencies
-sc-client-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-chain-spec = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-network = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-grandpa = { package = "sc-finality-grandpa", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1"  }
-sc-offchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-client-db = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sc-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-basic-authorship = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-service = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sc-tracing = {git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-telemetry = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sc-client-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-chain-spec = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-network = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2"  }
+sc-offchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-client-db = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sc-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-basic-authorship = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-service = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sc-tracing = {git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-telemetry = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 # frame dependencies
-pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 crml-transaction-payment = { path="../crml/transaction-payment", default-features = false } # pallet-transaction-payment specilised for cennznet
-frame-support = { version = "2.0.0-alpha.5", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-pallet-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+frame-support = { version = "2.0.0-alpha.5", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 # cennznet dependencies
 cennznet-runtime = { path = "../runtime" }
@@ -72,15 +72,15 @@ cennznet-primitives = { path = "../primitives" }
 cennznet-executor = { path = "../executor" }
 
 # CLI-specific dependencies
-sc-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", optional = true }
-node-transaction-factory = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", optional = true }
-node-inspect = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", optional = true }
+sc-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", optional = true }
+node-transaction-factory = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", optional = true }
+node-inspect = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", optional = true }
 
 [dev-dependencies]
-sc-keystore = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", features = ["test-helpers"], branch = "1.0.0-rc4.1" }
-sc-consensus-epochs = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-service-test = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sc-keystore = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", features = ["test-helpers"], branch = "1.0.0-rc4.2" }
+sc-consensus-epochs = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-service-test = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 futures = "0.3.1"
 tempfile = "3.1.0"
 assert_cmd = "0.12"
@@ -89,12 +89,12 @@ serde_json = "1.0"
 crml-transaction-payment = { path = "../crml/transaction-payment" }
 
 [build-dependencies]
-build-script-utils = { package = "substrate-build-script-utils", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+build-script-utils = { package = "substrate-build-script-utils", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 structopt = { version = "0.3.8", optional = true }
-node-transaction-factory = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", optional = true }
-node-inspect = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", optional = true }
-frame-benchmarking-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", optional = true }
-sc-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+node-transaction-factory = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", optional = true }
+node-inspect = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", optional = true }
+frame-benchmarking-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", optional = true }
+sc-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 vergen = { version = "3.0.4", optional = true }
 
 [features]

--- a/crml/cennzx-spot/Cargo.toml
+++ b/crml/cennzx-spot/Cargo.toml
@@ -9,13 +9,13 @@ codec = { version = "1.3.0", package = "parity-scale-codec", default-features = 
 primitive-types = { version = "0.6.1", default-features = false }
 serde = { version = "1.0", optional = true }
 cennznet-primitives = { path = "../../primitives", default-features = false }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
 
 [features]
 default = ["std"]

--- a/crml/cennzx-spot/rpc/Cargo.toml
+++ b/crml/cennzx-spot/rpc/Cargo.toml
@@ -13,13 +13,13 @@ jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"
 serde = { version = "1.0.101", features = ["derive"] }
 
-sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
 
 crml-cennzx-spot-rpc-runtime-api = { version = "2.0.0", path = "./runtime-api" }

--- a/crml/cennzx-spot/rpc/runtime-api/Cargo.toml
+++ b/crml/cennzx-spot/rpc/runtime-api/Cargo.toml
@@ -8,10 +8,10 @@ license = "GPL-3.0"
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { version = "1.3.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/crml/scaling/Cargo.toml
+++ b/crml/scaling/Cargo.toml
@@ -9,13 +9,13 @@ description = "CENNZnet temporary pallet to scale down CENNZ and CPAY balances"
 [dependencies]
 codec = { version = "1.3.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-pallet-sudo = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+pallet-sudo = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
 
 [dev-dependencies]
 cennznet-testing = { path = "../../testing"}

--- a/crml/staking/Cargo.toml
+++ b/crml/staking/Cargo.toml
@@ -10,24 +10,24 @@ description = "CENNZnet staking pallet"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-keyring = { optional = true, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-std = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-phragmen = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-io ={ default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-runtime = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-staking = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-frame-support = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-frame-system = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-session = { default-features = false, features = ["historical"], git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-authorship = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sp-keyring = { optional = true, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-std = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-phragmen = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-io ={ default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-runtime = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-staking = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+frame-support = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+frame-system = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-session = { default-features = false, features = ["historical"], git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-authorship = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 crml-staking-reward-curve = { path = "../staking/reward-curve" }
-substrate-test-utils = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+substrate-test-utils = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 hex = "0.4"
 
 [features]

--- a/crml/staking/reward-curve/Cargo.toml
+++ b/crml/staking/reward-curve/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }

--- a/crml/sylo/Cargo.toml
+++ b/crml/sylo/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 [dependencies]
 codec = { version = "1.3.0", package = "parity-scale-codec", default-features = false }
 serde = { version = "1.0.101", default-features = false }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
 
 [features]
 default = ["std"]

--- a/crml/transaction-payment/Cargo.toml
+++ b/crml/transaction-payment/Cargo.toml
@@ -9,17 +9,17 @@ description = "CENNZnet pallet to manage transaction payments"
 [dependencies]
 codec = { version = "1.3.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 cennznet-primitives = { path = "../../primitives", default-features = false }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", default-features = false }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 [features]
 default = ["std"]

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -10,36 +10,36 @@ repository = "https://github.com/cennznet/cennznet"
 # third-party dependencies
 codec = { version = "1.3.0", package = "parity-scale-codec" }
 trie-root = "0.16.0"
-frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 # internal dependencies
 cennznet-primitives = { path = "../primitives" }
 cennznet-runtime = { path = "../runtime" }
 
 # frame dependencies
-sp-state-machine = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-executor = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-trie = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sp-state-machine = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-executor = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-trie = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 [dev-dependencies]
 criterion = "0.3.0"
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 cennznet-testing = { path = "../testing" }
-pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-grandpa = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-session = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
+pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-grandpa = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-session = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
 crml-transaction-payment = { path="../crml/transaction-payment", default-features = false }
-pallet-treasury = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-application-crypto = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-externalities = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-substrate-test-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
 wabt = "0.9.2"
+pallet-treasury = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-application-crypto = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-externalities = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+substrate-test-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 
 [features]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,13 +7,13 @@ repository = "https://github.com/cennznet/cennznet"
 
 [dependencies]
 codec = { version = "1.3.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
-sp-serializer = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sp-serializer = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 
 [features]

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/cennznet/cennznet"
 
 [dependencies]
 cennznet-primitives = { path = "../primitives" }
-sc-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sc-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 env_logger = "0.7.0"
 futures = "0.1.29"
 hyper = "0.12.35"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -15,20 +15,20 @@ cennznet-runtime = { path = "../runtime" }
 crml-cennzx-spot-rpc = { path = "../crml/cennzx-spot/rpc" }
 
 #frame dependencies
-pallet-contracts-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-generic-asset-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-transaction-payment-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-substrate-frame-rpc-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+pallet-contracts-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-generic-asset-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-transaction-payment-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+substrate-frame-rpc-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 #primitives and client dependencies
-sc-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-consensus-babe-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-keystore = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-consensus-epochs = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-consensus = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sc-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-consensus-babe-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-keystore = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-consensus-epochs = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-consensus = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -32,7 +32,6 @@
 use std::{fmt, sync::Arc};
 
 use cennznet_primitives::types::{AccountId, AssetId, Balance, Block, BlockNumber, Index};
-use cennznet_runtime::UncheckedExtrinsic;
 use sc_consensus_babe::{Config, Epoch};
 use sc_consensus_babe_rpc::BabeRPCHandler;
 use sc_consensus_epochs::SharedEpochChanges;
@@ -85,7 +84,7 @@ where
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber>,
-	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance, UncheckedExtrinsic>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: crml_cennzx_spot_rpc::CennzxSpotRuntimeApi<Block, AssetId, Balance, AccountId>,
 	C::Api: pallet_generic_asset_rpc::AssetMetaApi<Block, AssetId>,
 	C::Api: BabeApi<Block>,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,65 +23,65 @@ crml-staking = { path = "../crml/staking", default-features = false }
 crml-staking-reward-curve = { path = "../crml/staking/reward-curve", default-features = false}
 
 # primitives
-sp-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-offchain = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-staking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", optional = true, branch = "1.0.0-rc4.1" }
-sp-session = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-inherents = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-block-builder = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-sp-version = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
+sp-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-consensus-babe = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-offchain = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-staking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", optional = true, branch = "1.0.0-rc4.2" }
+sp-session = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-inherents = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-block-builder = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+sp-version = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
 
 # frame dependencies
-prml-doughnut = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-prml-attestation = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
+prml-doughnut = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+prml-attestation = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
 
-frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-frame-system-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-frame-executive = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
+frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+frame-system-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+frame-executive = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
 
-pallet-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-authorship = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-babe = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-collective = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-contracts-primitives = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-democracy = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-elections-phragmen = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-finality-tracker = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-generic-asset-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-grandpa = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-membership = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-offences = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-randomness-collective-flip = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-session = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, features = ["historical"], branch = "1.0.0-rc4.1" }
-pallet-sudo = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-treasury = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-utility = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.1" }
+pallet-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-authorship = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-babe = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-collective = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-contracts-primitives = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-democracy = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-elections-phragmen = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-finality-tracker = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-generic-asset-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-grandpa = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-membership = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-offences = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-randomness-collective-flip = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-session = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, features = ["historical"], branch = "1.0.0-rc4.2" }
+pallet-sudo = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-treasury = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-utility = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "1.0.0-rc4.2" }
 
 # Imported just for the `no_cc` feature
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.5", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.5", git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 [dev-dependencies]
 cennznet-testing = { path = "../testing"}
 cennznet-cli = { path = "../cli" }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 hex = "0.4.0"
 hex-literal = "0.2.1"
 wabt = "0.9.2"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -757,12 +757,8 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
-		Block,
-		Balance,
-		UncheckedExtrinsic,
-	> for Runtime {
-		fn query_info(uxt: UncheckedExtrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
+		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
 			TransactionPayment::query_info(uxt, len)
 		}
 	}

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -14,28 +14,28 @@ cennznet-runtime = { path = "../runtime" }
 crml-staking = { path = "../crml/staking" }
 crml-transaction-payment = { path="../crml/transaction-payment", default-features = false }
 
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-grandpa = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-pallet-session = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-block-builder = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-client-db = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-client-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-executor = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", features = ["wasmtime"]}
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-consensus = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-finality-tracker = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-block-builder = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-inherents = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-substrate-test-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-contracts = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-grandpa = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+pallet-session = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-block-builder = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-client-db = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-client-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-executor = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", features = ["wasmtime"]}
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-consensus = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-finality-tracker = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-block-builder = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-inherents = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+substrate-test-client = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
 
 wabt = "0.9.2"
 log = "0.4.8"
@@ -44,8 +44,8 @@ fs_extra = "1.1.0"
 
 [dev-dependencies]
 criterion = "0.3.0"
-sc-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1" }
-sc-service = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.1", features = ["rocksdb"] }
+sc-cli = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }
+sc-service = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", features = ["rocksdb"] }
 
 [[bench]]
 name = "import"


### PR DESCRIPTION
The potential fix for #264 has brought in the branch plug 1.0.0-rc4.2 and thus cennznet should be updated to use that branch.
closes #264 