### PR TITLE
Fix docker to use build time context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ commands:
               IMAGE_TAG="${CIRCLE_BRANCH////-}"
             fi
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-            docker build --pull -t $IMAGE_NAME:$IMAGE_TAG -f ./Dockerfile .
+            docker build --build-arg RUST_VERSION=$RUST_VERSION --build-arg RUST_NIGHTLY=$RUST_NIGHTLY --pull -t $IMAGE_NAME:$IMAGE_TAG -f ./Dockerfile .
             docker push $IMAGE_NAME:$IMAGE_TAG
           no_output_timeout: 60m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,7 @@ workflows:
       - report-test-coverage:
           context: Rust
       - build-docker-and-publish:
+          context: Rust
           filters:
             branches:
               only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,17 @@ FROM  rustlang/rust:nightly AS builder
 WORKDIR /cennznet
 COPY . /cennznet
 
-ENV RUST_VERSION 1.44.1
+ARG RUST_VERSION=1.44.1
+ARG RUST_NIGHTLY=nightly-2020-06-24
 RUN apt-get update && \
     apt-get -y install apt-utils cmake pkg-config libssl-dev git clang libclang-dev && \
+    rustup uninstall nightly && \
     rustup install $RUST_VERSION && \
+    rustup install $RUST_NIGHTLY && \
     rustup default $RUST_VERSION && \
-    rustup target add --toolchain nightly wasm32-unknown-unknown && \
+    rustup target add --toolchain $RUST_NIGHTLY wasm32-unknown-unknown && \
     rustup target add --toolchain $RUST_VERSION x86_64-unknown-linux-musl && \
+    mv /usr/local/rustup/toolchains/nightly* /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
     mkdir -p /cennznet/.cargo
 ENV CARGO_HOME=/cennznet/.cargo
 RUN cargo build --release


### PR DESCRIPTION
Bring the same change as in the release 1.1.1 to "develop"
Closes #277 