### PR TITLE
Rename cennzx-spot -> cennzx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,20 +82,20 @@ commands:
       - run:
           name: Build tests
           command: |
-            cargo test --no-run --workspace --exclude crml-cennzx-spot --exclude crml-sylo
+            cargo test --no-run --workspace --exclude crml-cennzx --exclude crml-sylo
           no_output_timeout: 30m
   cargo-run-test:
     steps:
       - run:
           name: Run tests
           command: |
-            cargo test --workspace --exclude crml-cennzx-spot --exclude crml-sylo
+            cargo test --workspace --exclude crml-cennzx --exclude crml-sylo
   cargo-test-coverage:
     steps:
       - run:
           name: Report test coverage
           command: |
-            ./scripts/test-coverage.sh crml-cennzx-spot crml-sylo
+            ./scripts/test-coverage.sh crml-cennzx crml-sylo
       - store_artifacts:
           path: /tmp/coverage
   docker-build-and-publish:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ version = "1.0.0"
 dependencies = [
  "cennznet-primitives",
  "cennznet-runtime",
- "crml-cennzx-spot-rpc",
+ "crml-cennzx-rpc",
  "jsonrpc-core",
  "pallet-contracts-rpc",
  "pallet-generic-asset-rpc",
@@ -714,8 +714,8 @@ dependencies = [
  "cennznet-testing",
  "cennznut",
  "clear_on_drop",
- "crml-cennzx-spot",
- "crml-cennzx-spot-rpc-runtime-api",
+ "crml-cennzx",
+ "crml-cennzx-rpc-runtime-api",
  "crml-staking",
  "crml-staking-reward-curve",
  "crml-sylo",
@@ -1101,7 +1101,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "crml-cennzx-spot"
+name = "crml-cennzx"
 version = "1.0.0"
 dependencies = [
  "cennznet-primitives",
@@ -1118,10 +1118,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crml-cennzx-spot-rpc"
+name = "crml-cennzx-rpc"
 version = "2.0.0"
 dependencies = [
- "crml-cennzx-spot-rpc-runtime-api",
+ "crml-cennzx-rpc-runtime-api",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -1138,7 +1138,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "crml-cennzx-spot-rpc-runtime-api"
+name = "crml-cennzx-rpc-runtime-api"
 version = "2.0.0"
 dependencies = [
  "parity-scale-codec",

--- a/cli/src/chain_spec/azalea.rs
+++ b/cli/src/chain_spec/azalea.rs
@@ -19,7 +19,7 @@ use super::{session_keys, ChainSpec, NetworkKeys};
 use cennznet_primitives::types::{AccountId, AssetId, Balance};
 use cennznet_runtime::constants::currency::*;
 use cennznet_runtime::{
-	AssetInfo, AuthorityDiscoveryConfig, BabeConfig, CennzxSpotConfig, ContractsConfig, CouncilConfig, FeeRate,
+	AssetInfo, AuthorityDiscoveryConfig, BabeConfig, CennzxConfig, ContractsConfig, CouncilConfig, FeeRate,
 	GenericAssetConfig, GenesisConfig, GrandpaConfig, ImOnlineConfig, PerMillion, PerThousand, SessionConfig,
 	StakerStatus, StakingConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig, WASM_BINARY,
 };
@@ -278,7 +278,7 @@ pub fn config_genesis(network_keys: NetworkKeys) -> GenesisConfig {
 			slash_reward_fraction: Perbill::from_percent(10),
 			..Default::default()
 		}),
-		crml_cennzx_spot: Some(CennzxSpotConfig {
+		crml_cennzx: Some(CennzxConfig {
 			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}),

--- a/cli/src/chain_spec/mod.rs
+++ b/cli/src/chain_spec/mod.rs
@@ -18,9 +18,9 @@
 
 use cennznet_runtime::constants::{asset::*, currency::*};
 use cennznet_runtime::{
-	AssetInfo, AuthorityDiscoveryConfig, BabeConfig, CennzxSpotConfig, ContractsConfig, CouncilConfig,
-	GenericAssetConfig, GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus, StakingConfig,
-	SudoConfig, SystemConfig, TechnicalCommitteeConfig, WASM_BINARY,
+	AssetInfo, AuthorityDiscoveryConfig, BabeConfig, CennzxConfig, ContractsConfig, CouncilConfig, GenericAssetConfig,
+	GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
+	TechnicalCommitteeConfig, WASM_BINARY,
 };
 use cennznet_runtime::{Block, FeeRate, PerMillion, PerThousand};
 use core::convert::TryFrom;
@@ -210,7 +210,7 @@ pub fn config_genesis(network_keys: NetworkKeys, enable_println: bool) -> Genesi
 				(CENTRAPAY_ASSET_ID, AssetInfo::new(b"CPAY".to_vec(), 2)),
 			],
 		}),
-		crml_cennzx_spot: Some(CennzxSpotConfig {
+		crml_cennzx: Some(CennzxConfig {
 			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}),

--- a/crml/cennzx-spot/Cargo.toml
+++ b/crml/cennzx-spot/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "crml-cennzx-spot"
+name = "crml-cennzx"
 version = "1.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"

--- a/crml/cennzx-spot/rpc/Cargo.toml
+++ b/crml/cennzx-spot/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 
 [package]
-name = "crml-cennzx-spot-rpc"
+name = "crml-cennzx-rpc"
 version = "2.0.0"
 authors = ["Centrality Developers <developers@centrality.ai>"]
 edition = "2018"
@@ -22,4 +22,4 @@ sp-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "
 sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
 sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2", default-features = false }
 
-crml-cennzx-spot-rpc-runtime-api = { version = "2.0.0", path = "./runtime-api" }
+crml-cennzx-rpc-runtime-api = { version = "2.0.0", path = "./runtime-api" }

--- a/crml/cennzx-spot/rpc/runtime-api/Cargo.toml
+++ b/crml/cennzx-spot/rpc/runtime-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "crml-cennzx-spot-rpc-runtime-api"
+name = "crml-cennzx-rpc-runtime-api"
 version = "2.0.0"
 authors = ["Centrality Developers <developers@centrality.ai>"]
 edition = "2018"

--- a/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
+++ b/crml/cennzx-spot/rpc/runtime-api/src/lib.rs
@@ -24,7 +24,7 @@ use sp_runtime::RuntimeDebug;
 
 /// A result of querying the exchange
 #[derive(Eq, PartialEq, Encode, Decode, RuntimeDebug)]
-pub enum CennzxSpotResult<Balance> {
+pub enum CennzxResult<Balance> {
 	/// The exchange returned successfully.
 	Success(Balance),
 	/// There was an issue querying the exchange
@@ -33,7 +33,7 @@ pub enum CennzxSpotResult<Balance> {
 
 sp_api::decl_runtime_apis! {
 	/// The RPC API to interact with CENNZX Spot Exchange
-	pub trait CennzxSpotApi<AssetId, Balance, AccountId> where
+	pub trait CennzxApi<AssetId, Balance, AccountId> where
 		AssetId: Codec,
 		Balance: Codec + BaseArithmetic,
 		AccountId: Codec,
@@ -43,13 +43,13 @@ sp_api::decl_runtime_apis! {
 			asset_to_buy: AssetId,
 			amount: Balance,
 			asset_to_sell: AssetId,
-		) -> CennzxSpotResult<Balance>;
+		) -> CennzxResult<Balance>;
 		/// Query how much `asset_to_sell` is required to buy `amount` of `asset_to_buy`
 		fn sell_price(
 			asset_to_sell: AssetId,
 			amount: Balance,
 			asset_to_buy: AssetId,
-		) -> CennzxSpotResult<Balance>;
+		) -> CennzxResult<Balance>;
 		/// Query the value of liquidity in the exchange for `asset_id` for `account`
 		/// Returns (liquidity_volume, core_value, asset_value)
 		fn liquidity_value(

--- a/crml/cennzx-spot/src/impls.rs
+++ b/crml/cennzx-spot/src/impls.rs
@@ -85,7 +85,7 @@ pub(crate) mod impl_tests {
 	use super::*;
 	use crate::{
 		mock::{self, FEE_ASSET_ID, TRADE_ASSET_A_ID},
-		mock::{CennzXSpot, ExtBuilder, Test},
+		mock::{Cennzx, ExtBuilder, Test},
 		Error,
 	};
 	use frame_support::traits::Currency;
@@ -109,7 +109,7 @@ pub(crate) mod impl_tests {
 			let fee_rate_factor = scale_factor + fee_rate; // 1_000_000 + 3_000
 
 			assert_ok!(
-				<CennzXSpot as BuyFeeAsset>::buy_fee_asset(
+				<Cennzx as BuyFeeAsset>::buy_fee_asset(
 					&user,
 					target_fee,
 					&TestFeeExchange::new_v1(TRADE_ASSET_A_ID, 2_000_000)
@@ -173,7 +173,7 @@ pub(crate) mod impl_tests {
 			let user = with_account!(CoreAssetCurrency => 0, TradeAssetCurrencyA => 10);
 
 			assert_err!(
-				<CennzXSpot as BuyFeeAsset>::buy_fee_asset(
+				<Cennzx as BuyFeeAsset>::buy_fee_asset(
 					&user,
 					51,
 					&TestFeeExchange::new_v1(TRADE_ASSET_A_ID, 2_000_000),
@@ -192,7 +192,7 @@ pub(crate) mod impl_tests {
 			let user = with_account!(CoreAssetCurrency => 0, TradeAssetCurrencyA => 10);
 
 			assert_err!(
-				<CennzXSpot as BuyFeeAsset>::buy_fee_asset(
+				<Cennzx as BuyFeeAsset>::buy_fee_asset(
 					&user,
 					51,
 					&TestFeeExchange::new_v1(TRADE_ASSET_A_ID, 2_000_000),

--- a/crml/cennzx-spot/src/lib.rs
+++ b/crml/cennzx-spot/src/lib.rs
@@ -14,7 +14,7 @@
 */
 
 //!
-//! CENNZX-Spot exchange
+//! CENNZX spot exchange
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -297,7 +297,7 @@ decl_event!(
 );
 
 decl_storage! {
-	trait Store for Module<T: Trait> as CennzxSpot {
+	trait Store for Module<T: Trait> as Cennzx {
 		/// AssetId of Core Asset
 		pub CoreAssetId get(core_asset_id) config(): T::AssetId;
 		/// Default Trading fee rate

--- a/crml/cennzx-spot/src/mock.rs
+++ b/crml/cennzx-spot/src/mock.rs
@@ -102,7 +102,7 @@ impl Trait for Test {
 	type UnsignedIntToBalance = UnsignedIntToBalance;
 }
 
-pub type CennzXSpot = Module<Test>;
+pub type Cennzx = Module<Test>;
 
 pub const CORE_ASSET_ID: u32 = 0;
 pub const TRADE_ASSET_A_ID: u32 = 1;

--- a/crml/transaction-payment/src/constants.rs
+++ b/crml/transaction-payment/src/constants.rs
@@ -30,7 +30,7 @@ pub mod error_code {
 	pub const MAXIMUM_SELL_REQUIREMENT_NOT_MET: u8 = 206;
 	pub const INSUFFICIENT_BALANCE: u8 = 195;
 
-	// Matches and converts crml-cennzx-spot module errors, such that
+	// Matches and converts crml-cennzx module errors, such that
 	// they are propagated in crml-transaction-payment module
 	pub fn buy_fee_asset_error_msg_to_code(message: &'static str) -> u8 {
 		match message {

--- a/genesis/azalea.json
+++ b/genesis/azalea.json
@@ -371,7 +371,7 @@
       "palletAuthorityDiscovery": {
         "keys": []
       },
-      "crmlCennzxSpot": {
+      "crmlCennzx": {
         "coreAssetId": 2,
         "feeRate": [
           3000,

--- a/genesis/nikau.json
+++ b/genesis/nikau.json
@@ -217,7 +217,7 @@
       "palletAuthorityDiscovery": {
         "keys": []
       },
-      "crmlCennzxSpot": {
+      "crmlCennzx": {
         "coreAssetId": 16001,
         "feeRate": [
           3000,

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,7 +12,7 @@ jsonrpc-core = "14.0.3"
 #cennznet dependencies
 cennznet-primitives = { path = "../primitives" }
 cennznet-runtime = { path = "../runtime" }
-crml-cennzx-spot-rpc = { path = "../crml/cennzx-spot/rpc" }
+crml-cennzx-rpc = { path = "../crml/cennzx-spot/rpc" }
 
 #frame dependencies
 pallet-contracts-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", branch = "1.0.0-rc4.2" }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -85,7 +85,7 @@ where
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-	C::Api: crml_cennzx_spot_rpc::CennzxSpotRuntimeApi<Block, AssetId, Balance, AccountId>,
+	C::Api: crml_cennzx_rpc::CennzxRuntimeApi<Block, AssetId, Balance, AccountId>,
 	C::Api: pallet_generic_asset_rpc::AssetMetaApi<Block, AssetId>,
 	C::Api: BabeApi<Block>,
 	<C::Api as sp_api::ApiErrorExt>::Error: fmt::Debug,
@@ -93,7 +93,7 @@ where
 	M: jsonrpc_core::Metadata + Default,
 	SC: SelectChain<Block> + 'static,
 {
-	use crml_cennzx_spot_rpc::{CennzxSpot, CennzxSpotApi};
+	use crml_cennzx_rpc::{Cennzx, CennzxApi};
 	use pallet_contracts_rpc::{Contracts, ContractsApi};
 	use pallet_generic_asset_rpc::{GenericAsset, GenericAssetApi};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
@@ -127,7 +127,7 @@ where
 		babe_config,
 		select_chain,
 	)));
-	io.extend_with(CennzxSpotApi::to_delegate(CennzxSpot::new(client.clone())));
+	io.extend_with(CennzxApi::to_delegate(Cennzx::new(client.clone())));
 	io.extend_with(GenericAssetApi::to_delegate(GenericAsset::new(client)));
 
 	io

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -15,8 +15,8 @@ serde = { version = "1.0.102", optional = true }
 
 # internal dependencies
 crml-sylo = { path = "../crml/sylo", default-features = false }
-crml-cennzx-spot = { path = "../crml/cennzx-spot", default-features = false }
-crml-cennzx-spot-rpc-runtime-api = { path =  "../crml/cennzx-spot/rpc/runtime-api", default-features = false }
+crml-cennzx = { path = "../crml/cennzx-spot", default-features = false }
+crml-cennzx-rpc-runtime-api = { path =  "../crml/cennzx-spot/rpc/runtime-api", default-features = false }
 cennznet-primitives = { path = "../primitives", default-features = false }
 crml-transaction-payment = { path = "../crml/transaction-payment", default-features = false }
 crml-staking = { path = "../crml/staking", default-features = false }
@@ -138,7 +138,7 @@ std = [
 	"prml-attestation/std",
 	"prml-doughnut/std",
 	"cennznut/std",
-	"crml-cennzx-spot/std",
-	"crml-cennzx-spot-rpc-runtime-api/std",
+	"crml-cennzx/std",
+	"crml-cennzx-rpc-runtime-api/std",
 	"crml-transaction-payment/std",
 ]

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -42,7 +42,7 @@ use sp_runtime::{
 };
 use sp_std::{any::Any, prelude::Vec};
 
-type CennzxSpot<T> = crml_cennzx_spot::Module<T>;
+type Cennzx<T> = crml_cennzx::Module<T>;
 type Contracts<T> = pallet_contracts::Module<T>;
 type GenericAsset<T> = pallet_generic_asset::Module<T>;
 
@@ -170,7 +170,7 @@ pub struct GasHandler;
 
 impl<T> pallet_contracts::GasHandler<T> for GasHandler
 where
-	T: pallet_contracts::Trait + pallet_generic_asset::Trait + crml_cennzx_spot::Trait,
+	T: pallet_contracts::Trait + pallet_generic_asset::Trait + crml_cennzx::Trait,
 {
 	/// Fill the gas meter
 	///
@@ -215,7 +215,7 @@ where
 		let payment_asset = exchange_op.asset_id();
 
 		// Calculate the `fill_meter_cost` in terms of the user's nominated payment asset
-		let converted_fill_meter_cost = CennzxSpot::<T>::get_asset_to_core_buy_price(
+		let converted_fill_meter_cost = Cennzx::<T>::get_asset_to_core_buy_price(
 			&payment_asset,
 			T::Balance::unique_saturated_from(fill_meter_cost.saturated_into()),
 		)?;
@@ -264,7 +264,7 @@ where
 			// Pay for `gas_spent` in a user nominated currency using the CENNZX spot exchange
 			// Payment can never fail as liquidity is verified before filling the meter
 			if let Some(used_gas_cost) = gas_price.checked_mul(&gas_spent.saturated_into()) {
-				let _ = CennzxSpot::<T>::buy_fee_asset(
+				let _ = Cennzx::<T>::buy_fee_asset(
 					transactor,
 					T::Balance::unique_saturated_from(used_gas_cost.saturated_into()),
 					&exchange_op,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -22,8 +22,8 @@
 #![allow(array_into_iter)]
 
 use cennznet_primitives::types::{AccountId, AssetId, Balance, BlockNumber, Hash, Index, Moment, Signature};
-pub use crml_cennzx_spot::{ExchangeAddressGenerator, FeeRate, PerMillion, PerThousand};
-use crml_cennzx_spot_rpc_runtime_api::CennzxSpotResult;
+pub use crml_cennzx::{ExchangeAddressGenerator, FeeRate, PerMillion, PerThousand};
+use crml_cennzx_rpc_runtime_api::CennzxResult;
 use frame_support::{
 	additional_traits::MultiCurrencyAccounting,
 	construct_runtime, debug, parameter_types,
@@ -162,7 +162,7 @@ impl pallet_utility::Trait for Runtime {
 	type MaxSignatories = MaxSignatories;
 }
 
-impl crml_cennzx_spot::Trait for Runtime {
+impl crml_cennzx::Trait for Runtime {
 	type Call = Call;
 	type Event = Event;
 	type ExchangeAddressGenerator = ExchangeAddressGenerator<Self>;
@@ -228,7 +228,7 @@ impl crml_transaction_payment::Trait for Runtime {
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = ScaledWeightToFee<TransactionMinWeightFee, TransactionMaxWeightFee>;
 	type FeeMultiplierUpdate = TargetedFeeAdjustment<TargetBlockFullness>;
-	type BuyFeeAsset = CennzxSpot;
+	type BuyFeeAsset = Cennzx;
 	type GasMeteredCallResolver = GasMeteredCallResolver;
 	type FeePayer = FeePayerResolver;
 }
@@ -578,7 +578,7 @@ construct_runtime!(
 		SyloResponse: sylo_response::{Module, Call, Storage},
 		SyloVault: sylo_vault::{Module, Call, Storage},
 		SyloPayment: sylo_payment::{Module, Call, Storage},
-		CennzxSpot: crml_cennzx_spot::{Module, Call, Storage, Config<T>, Event<T>},
+		Cennzx: crml_cennzx::{Module, Call, Storage, Config<T>, Event<T>},
 	}
 );
 
@@ -763,7 +763,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl crml_cennzx_spot_rpc_runtime_api::CennzxSpotApi<
+	impl crml_cennzx_rpc_runtime_api::CennzxApi<
 		Block,
 		AssetId,
 		Balance,
@@ -773,11 +773,11 @@ impl_runtime_apis! {
 			buy_asset: AssetId,
 			buy_amount: Balance,
 			sell_asset: AssetId,
-		) -> CennzxSpotResult<Balance> {
-			let result = CennzxSpot::get_buy_price(buy_asset, buy_amount, sell_asset);
+		) -> CennzxResult<Balance> {
+			let result = Cennzx::get_buy_price(buy_asset, buy_amount, sell_asset);
 			match result {
-				Ok(value) => CennzxSpotResult::Success(value),
-				Err(_) => CennzxSpotResult::Error,
+				Ok(value) => CennzxResult::Success(value),
+				Err(_) => CennzxResult::Error,
 			}
 		}
 
@@ -785,11 +785,11 @@ impl_runtime_apis! {
 			sell_asset: AssetId,
 			sell_amount: Balance,
 			buy_asset: AssetId,
-		) -> CennzxSpotResult<Balance> {
-			let result = CennzxSpot::get_sell_price(sell_asset, sell_amount, buy_asset);
+		) -> CennzxResult<Balance> {
+			let result = Cennzx::get_sell_price(sell_asset, sell_amount, buy_asset);
 			match result {
-				Ok(value) => CennzxSpotResult::Success(value),
-				Err(_) => CennzxSpotResult::Error,
+				Ok(value) => CennzxResult::Success(value),
+				Err(_) => CennzxResult::Error,
 			}
 		}
 
@@ -797,7 +797,7 @@ impl_runtime_apis! {
 			account: AccountId,
 			asset_id: AssetId,
 		) -> (Balance, Balance, Balance) {
-			let value = CennzxSpot::account_liquidity_value(&account, asset_id);
+			let value = Cennzx::account_liquidity_value(&account, asset_id);
 			(value.liquidity, value.core, value.asset)
 		}
 
@@ -805,7 +805,7 @@ impl_runtime_apis! {
 			asset_id: AssetId,
 			liquidity_to_buy: Balance
 		) -> (Balance, Balance) {
-			let value = CennzxSpot::liquidity_price(asset_id, liquidity_to_buy);
+			let value = Cennzx::liquidity_price(asset_id, liquidity_to_buy);
 			(value.core, value.asset)
 		}
 	}

--- a/runtime/tests/common/mock.rs
+++ b/runtime/tests/common/mock.rs
@@ -20,7 +20,7 @@ use cennznet_primitives::types::Balance;
 use cennznet_runtime::{constants::asset::*, GenericAsset, Runtime, StakerStatus};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
-use crml_cennzx_spot::{FeeRate, PerMillion, PerThousand};
+use crml_cennzx::{FeeRate, PerMillion, PerThousand};
 use frame_support::additional_traits::MultiCurrencyAccounting as MultiCurrency;
 use pallet_contracts::{Gas, Schedule};
 use sp_runtime::Perbill;
@@ -93,7 +93,7 @@ impl ExtBuilder {
 		let mut t = frame_system::GenesisConfig::default()
 			.build_storage::<Runtime>()
 			.unwrap();
-		crml_cennzx_spot::GenesisConfig::<Runtime> {
+		crml_cennzx::GenesisConfig::<Runtime> {
 			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}

--- a/runtime/tests/extrinsic_extension.rs
+++ b/runtime/tests/extrinsic_extension.rs
@@ -324,7 +324,7 @@ fn contract_dispatches_runtime_call_funds_are_safu() {
 				// Pays for transaction fees
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(2),
-					event: Event::crml_cennzx_spot(crml_cennzx_spot::RawEvent::AssetPurchase(
+					event: Event::crml_cennzx(crml_cennzx::RawEvent::AssetPurchase(
 						CENNZ_ASSET_ID,
 						CENTRAPAY_ASSET_ID,
 						bob(),
@@ -338,7 +338,7 @@ fn contract_dispatches_runtime_call_funds_are_safu() {
 				// Pays for gas fees
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(2),
-					event: Event::crml_cennzx_spot(crml_cennzx_spot::RawEvent::AssetPurchase(
+					event: Event::crml_cennzx(crml_cennzx::RawEvent::AssetPurchase(
 						CENNZ_ASSET_ID,
 						CENTRAPAY_ASSET_ID,
 						bob(),

--- a/runtime/tests/extrinsic_extension.rs
+++ b/runtime/tests/extrinsic_extension.rs
@@ -18,7 +18,7 @@
 use cennznet_primitives::types::{AccountId, FeeExchange, FeeExchangeV1};
 use cennznet_runtime::{
 	constants::{asset::*, currency::*},
-	Call, CennzxSpot, CheckedExtrinsic, ContractTransactionBaseFee, Event, Executive, GenericAsset, Origin, Runtime,
+	Call, Cennzx, CheckedExtrinsic, ContractTransactionBaseFee, Event, Executive, GenericAsset, Origin, Runtime,
 };
 use cennznet_testing::keyring::{alice, bob, charlie, dave, ferdie, signed_extra};
 use codec::Encode;
@@ -150,7 +150,7 @@ fn generic_asset_transfer_works_with_fee_exchange() {
 		.build()
 		.execute_with(|| {
 			// Alice sets up CENNZ <> CPAY liquidity
-			assert!(CennzxSpot::add_liquidity(
+			assert!(Cennzx::add_liquidity(
 				Origin::signed(alice()),
 				CENNZ_ASSET_ID,
 				0,                 // min liquidity
@@ -172,7 +172,7 @@ fn generic_asset_transfer_works_with_fee_exchange() {
 
 			// Calculate how much CENNZ should be sold to make the above extrinsic
 			let cennz_sold_amount =
-				CennzxSpot::get_asset_to_core_buy_price(&CENNZ_ASSET_ID, extrinsic_fee_for(&xt)).unwrap();
+				Cennzx::get_asset_to_core_buy_price(&CENNZ_ASSET_ID, extrinsic_fee_for(&xt)).unwrap();
 			assert_eq!(cennz_sold_amount, 11_807 * MICROS); // 1.1807 CPAY
 
 			// Initialise block and apply the extrinsic
@@ -234,7 +234,7 @@ fn contract_dispatches_runtime_call_funds_are_safu() {
 		.build()
 		.execute_with(|| {
 			// Setup CENNZ <> CPAY liquidity
-			assert!(CennzxSpot::add_liquidity(
+			assert!(Cennzx::add_liquidity(
 				Origin::signed(dave()),
 				CENNZ_ASSET_ID,
 				0,
@@ -413,7 +413,7 @@ fn contract_call_fails_with_insufficient_gas_with_fee_exchange() {
 		.build()
 		.execute_with(|| {
 			// Setup CENNZ <> CPAY liquidity
-			assert!(CennzxSpot::add_liquidity(
+			assert!(Cennzx::add_liquidity(
 				Origin::signed(charlie()),
 				CENNZ_ASSET_ID,
 				0,               // min. liquidity
@@ -515,7 +515,7 @@ fn contract_call_works_with_fee_exchange() {
 		.build()
 		.execute_with(|| {
 			let initial_liquidity = 1_000 * DOLLARS;
-			assert!(CennzxSpot::add_liquidity(
+			assert!(Cennzx::add_liquidity(
 				Origin::signed(charlie()),
 				CENNZ_ASSET_ID,
 				0,
@@ -537,10 +537,10 @@ fn contract_call_works_with_fee_exchange() {
 			// Calculate the expected gas cost of contract execution at the current CENNZ-X spot rate.
 			let gas_cost = (Schedule::default().call_base_cost + Schedule::default().transfer_cost) as u128;
 			// Check CENNZ price to buy gas (gas is 1:1 with CPAY)
-			let cennz_for_gas_fees = CennzxSpot::get_asset_to_core_buy_price(&CENNZ_ASSET_ID, gas_cost).unwrap();
+			let cennz_for_gas_fees = Cennzx::get_asset_to_core_buy_price(&CENNZ_ASSET_ID, gas_cost).unwrap();
 			// Check CENNZ price to buy tx fees in CPAY
 			let cennz_for_tx_fees =
-				CennzxSpot::get_asset_to_core_buy_price(&CENNZ_ASSET_ID, extrinsic_fee_for(&xt)).unwrap();
+				Cennzx::get_asset_to_core_buy_price(&CENNZ_ASSET_ID, extrinsic_fee_for(&xt)).unwrap();
 
 			Executive::initialize_block(&header());
 			let r = Executive::apply_extrinsic(xt);
@@ -575,7 +575,7 @@ fn contract_call_fails_when_fee_exchange_is_not_enough_for_gas() {
 		.gas_price(1)
 		.build()
 		.execute_with(|| {
-			assert!(CennzxSpot::add_liquidity(
+			assert!(Cennzx::add_liquidity(
 				Origin::signed(charlie()),
 				CENNZ_ASSET_ID,
 				0,           // min. liquidity
@@ -615,7 +615,7 @@ fn contract_call_fails_when_exchange_liquidity_is_low() {
 		.gas_price(1)
 		.build()
 		.execute_with(|| {
-			assert!(CennzxSpot::add_liquidity(
+			assert!(Cennzx::add_liquidity(
 				Origin::signed(charlie()),
 				CENNZ_ASSET_ID,
 				0,            // min. liquidity
@@ -811,7 +811,7 @@ fn generic_asset_transfer_works_with_doughnut_and_fee_exchange_combo() {
 		.build()
 		.execute_with(|| {
 			// setup CENNZ <> CPAY liquidity
-			assert!(CennzxSpot::add_liquidity(
+			assert!(Cennzx::add_liquidity(
 				Origin::signed(ferdie()),
 				CENNZ_ASSET_ID,
 				0,                 // min. liquidity
@@ -832,7 +832,7 @@ fn generic_asset_transfer_works_with_doughnut_and_fee_exchange_combo() {
 
 			// Check CENNZ fee price
 			let cennz_sold_amount =
-				CennzxSpot::get_asset_to_core_buy_price(&CENNZ_ASSET_ID, extrinsic_fee_for(&xt)).unwrap();
+				Cennzx::get_asset_to_core_buy_price(&CENNZ_ASSET_ID, extrinsic_fee_for(&xt)).unwrap();
 			assert_eq!(cennz_sold_amount, 14_161 * MICROS); // 1.4161 CPAY
 
 			// Initialise block and apply the extrinsic

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Build and test the specified rust packages to produce the coverage files which is then fed to grcov to generate a report
-example="$0 crml-cennzx-spot crml-sylo"
+example="$0 crml-cennzx crml-sylo"
 
 if [ $# -eq 0 ]; then
   echo "Error: no rust package name is specified"

--- a/testing/src/genesis.rs
+++ b/testing/src/genesis.rs
@@ -23,7 +23,7 @@ use cennznet_runtime::{
 	FeeRate, PerMillion, PerThousand,
 };
 use cennznet_runtime::{
-	CennzxSpotConfig, ContractsConfig, GenericAssetConfig, GenesisConfig, GrandpaConfig, SessionConfig, StakingConfig,
+	CennzxConfig, ContractsConfig, GenericAssetConfig, GenesisConfig, GrandpaConfig, SessionConfig, StakingConfig,
 	SystemConfig, WASM_BINARY,
 };
 use core::convert::TryFrom;
@@ -130,7 +130,7 @@ pub fn config_endowed(support_changes_trie: bool, code: Option<&[u8]>, extra_end
 		pallet_membership_Instance1: Some(Default::default()),
 		pallet_sudo: Some(Default::default()),
 		pallet_treasury: Some(Default::default()),
-		crml_cennzx_spot: Some(CennzxSpotConfig {
+		crml_cennzx: Some(CennzxConfig {
 			fee_rate: FeeRate::<PerMillion>::try_from(FeeRate::<PerThousand>::from(3u128)).unwrap(),
 			core_asset_id: CENTRAPAY_ASSET_ID,
 		}),


### PR DESCRIPTION
Find/replaces the following:
```
CennzxSpot -> Cennzx
CennzxSpotConfig -> CennzxConfig
crml_cennzx_spot -> crml_cennzx
crml-cennzx-spot -> crml-cennzx
```

The motivation for this change is better consistency in the cennznet/api
```js
# before
api.query.cennzxSpot.<method>
api.rpc.cennzx.<method>
# after
api.query.cennzx.<method>
api.rpc.cennzx.<method>
```