### PR TITLE
Chore/cennz slash

### DIFF
--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -18,7 +18,7 @@
 
 use crate::{
 	constants::fee::{MAX_WEIGHT, MIN_WEIGHT},
-	sylo_payment, Call, MaximumBlockWeight, NegativeImbalance, Runtime, System,
+	sylo_payment, Call, MaximumBlockWeight, NegativeImbalance, Runtime, System, Treasury,
 };
 use cennznet_primitives::{
 	traits::{BuyFeeAsset, IsGasMeteredCall},
@@ -412,6 +412,15 @@ impl additional_traits::DelegatedDispatchVerifier for CENNZnetDispatchVerifier {
 		_contract_addr: &Self::AccountId,
 	) -> Result<(), &'static str> {
 		Ok(()) // Just return OK for now
+	}
+}
+
+// An on unbalanced handler which takes a slash amount in the staked currency
+// and moves it to the system Treasury.
+pub struct SlashFundsToTreasury;
+impl OnUnbalanced<NegativeImbalance> for SlashFundsToTreasury {
+	fn on_nonzero_unbalanced(slash_amount: NegativeImbalance) {
+		StakingAssetCurrency::resolve_creating(&Treasury::account_id(), slash_amount);
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -72,7 +72,7 @@ pub use crml_sylo::vault as sylo_vault;
 pub mod impls;
 use impls::{
 	CENNZnetDispatchVerifier, CurrencyToVoteHandler, FeePayerResolver, GasHandler, GasMeteredCallResolver,
-	ScaledWeightToFee, SplitToAllValidators, TargetedFeeAdjustment,
+	ScaledWeightToFee, SlashFundsToTreasury, SplitToAllValidators, TargetedFeeAdjustment,
 };
 
 /// Constant values used within the runtime.
@@ -306,7 +306,7 @@ impl crml_staking::Trait for Runtime {
 	type CurrencyToVote = CurrencyToVoteHandler;
 	type RewardRemainder = Treasury;
 	type Event = Event;
-	type Slash = Treasury; // send the slashed funds to the treasury.
+	type Slash = SlashFundsToTreasury; // send the slashed funds in CENNZ to the treasury.
 	type Reward = (); // rewards are minted from the void
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;

--- a/runtime/tests/common/mock.rs
+++ b/runtime/tests/common/mock.rs
@@ -15,32 +15,21 @@
 
 //! Mock runtime storage setup
 
-use crate::common::helpers::make_authority_keys;
 use cennznet_cli::chain_spec::{session_keys, AuthorityKeys};
 use cennznet_primitives::types::Balance;
 use cennznet_runtime::{constants::asset::*, GenericAsset, Runtime, StakerStatus};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
 use crml_cennzx::{FeeRate, PerMillion, PerThousand};
-use crml_staking::EraIndex;
 use frame_support::additional_traits::MultiCurrencyAccounting as MultiCurrency;
-use frame_support::traits::Get;
 use pallet_contracts::{Gas, Schedule};
 use sp_runtime::Perbill;
-use std::cell::RefCell;
+
+use crate::common::helpers::make_authority_keys;
 
 /// The default number of validators for mock storage setup
 const DEFAULT_VALIDATOR_COUNT: usize = 3;
-thread_local! {
-   static SLASH_DEFER_DURATION: RefCell<EraIndex> = RefCell::new(0);
-}
 
-pub struct SlashDeferDuration;
-impl Get<EraIndex> for SlashDeferDuration {
-	fn get() -> EraIndex {
-		SLASH_DEFER_DURATION.with(|v| *v.borrow())
-	}
-}
 pub struct ExtBuilder {
 	initial_balance: Balance,
 	gas_price: Balance,
@@ -51,7 +40,6 @@ pub struct ExtBuilder {
 	stash: Balance,
 	// The initial authority set
 	initial_authorities: Vec<AuthorityKeys>,
-	slash_defer_duration: EraIndex,
 }
 
 impl Default for ExtBuilder {
@@ -63,7 +51,6 @@ impl Default for ExtBuilder {
 			gas_regular_op_cost: 0_u64,
 			stash: 0,
 			initial_authorities: Default::default(),
-			slash_defer_duration: EraIndex::default(),
 		}
 	}
 }
@@ -91,10 +78,6 @@ impl ExtBuilder {
 	}
 	pub fn stash(mut self, stash: Balance) -> Self {
 		self.stash = stash;
-		self
-	}
-	pub fn slash_defer_duration(mut self, eras: EraIndex) -> Self {
-		self.slash_defer_duration = eras;
 		self
 	}
 	pub fn build(self) -> sp_io::TestExternalities {

--- a/runtime/tests/common/mock.rs
+++ b/runtime/tests/common/mock.rs
@@ -15,21 +15,32 @@
 
 //! Mock runtime storage setup
 
+use crate::common::helpers::make_authority_keys;
 use cennznet_cli::chain_spec::{session_keys, AuthorityKeys};
 use cennznet_primitives::types::Balance;
 use cennznet_runtime::{constants::asset::*, GenericAsset, Runtime, StakerStatus};
 use cennznet_testing::keyring::*;
 use core::convert::TryFrom;
 use crml_cennzx::{FeeRate, PerMillion, PerThousand};
+use crml_staking::EraIndex;
 use frame_support::additional_traits::MultiCurrencyAccounting as MultiCurrency;
+use frame_support::traits::Get;
 use pallet_contracts::{Gas, Schedule};
 use sp_runtime::Perbill;
-
-use crate::common::helpers::make_authority_keys;
+use std::cell::RefCell;
 
 /// The default number of validators for mock storage setup
 const DEFAULT_VALIDATOR_COUNT: usize = 3;
+thread_local! {
+   static SLASH_DEFER_DURATION: RefCell<EraIndex> = RefCell::new(0);
+}
 
+pub struct SlashDeferDuration;
+impl Get<EraIndex> for SlashDeferDuration {
+	fn get() -> EraIndex {
+		SLASH_DEFER_DURATION.with(|v| *v.borrow())
+	}
+}
 pub struct ExtBuilder {
 	initial_balance: Balance,
 	gas_price: Balance,
@@ -40,6 +51,7 @@ pub struct ExtBuilder {
 	stash: Balance,
 	// The initial authority set
 	initial_authorities: Vec<AuthorityKeys>,
+	slash_defer_duration: EraIndex,
 }
 
 impl Default for ExtBuilder {
@@ -51,6 +63,7 @@ impl Default for ExtBuilder {
 			gas_regular_op_cost: 0_u64,
 			stash: 0,
 			initial_authorities: Default::default(),
+			slash_defer_duration: EraIndex::default(),
 		}
 	}
 }
@@ -78,6 +91,10 @@ impl ExtBuilder {
 	}
 	pub fn stash(mut self, stash: Balance) -> Self {
 		self.stash = stash;
+		self
+	}
+	pub fn slash_defer_duration(mut self, eras: EraIndex) -> Self {
+		self.slash_defer_duration = eras;
 		self
 	}
 	pub fn build(self) -> sp_io::TestExternalities {

--- a/runtime/tests/staking_reward.rs
+++ b/runtime/tests/staking_reward.rs
@@ -31,7 +31,7 @@ use frame_support::{
 use frame_system::RawOrigin;
 use sp_consensus_babe::{digests, AuthorityIndex, BABE_ENGINE_ID};
 use sp_runtime::{traits::Header as HeaderT, Perbill};
-use sp_staking::{offence::OnOffenceHandler, offence::Offence, SessionIndex};
+use sp_staking::{offence::Offence, offence::OnOffenceHandler, SessionIndex};
 
 mod common;
 

--- a/runtime/tests/staking_reward.rs
+++ b/runtime/tests/staking_reward.rs
@@ -568,6 +568,7 @@ fn slashed_cennz_gets_into_treasury() {
 			let cpay_amount = 12_112;
 			let updated_cennz_amount = 4_210_000;
 			let update_rewarded_cpay_amount = 12_449;
+			// Deposit some CENNZ/CPAY in treasury
 			let _ = <GenericAsset as MultiCurrencyAccounting>::deposit_creating(
 				&Treasury::account_id(),
 				Some(STAKING_ASSET_ID),
@@ -578,15 +579,21 @@ fn slashed_cennz_gets_into_treasury() {
 				Some(SPENDING_ASSET_ID),
 				cpay_amount,
 			);
+			// Check Treasury balance before starting new era
+			assert_eq!(
+				GenericAsset::free_balance(&CENNZ_ASSET_ID, &Treasury::account_id()),
+				cennz_amount
+			);
+			assert_eq!(
+				GenericAsset::free_balance(&CENTRAPAY_ASSET_ID, &Treasury::account_id()),
+				cpay_amount
+			);
 			assert_eq!(Staking::current_era(), 0);
 
-			// function `apply_unapplied_slashes` is private
-			// Staking::apply_unapplied_slashes(era_now);
-
-			// slashing::apply_slash(unapplied[0]); // slashing module is private to staking and apply_slash is also private
-			// Default slash_defer_duration is 168, so have to set erra to 169 for slash to be applied.
+			// Default slash_defer_duration is 168, so have to set era to 169 for slash to be applied.
 			start_era(169); // new_era function will internally call apply_unapplied_slashes
 			assert_eq!(Staking::current_era(), 169);
+			// Check Treasury balance after starting new era
 			assert_eq!(
 				GenericAsset::free_balance(&CENNZ_ASSET_ID, &Treasury::account_id()),
 				updated_cennz_amount


### PR DESCRIPTION
This PR is to address the feature, 'The CENNZnet treasury should receive CPAY from reward payouts and CENNZ from slashes'. 
Have tested it with a test case where when slash is applied, call to pay_reporters::<T>(reward_payout, slashed_imbalance, &unapplied_slash.reporters); is made and slash goes to Treasury in CENNZ