### PR TITLE
Bonding is enabled by default but can be blocked by root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
- "substrate-wasm-builder-runner 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-wasm-builder-runner",
  "wabt",
 ]
 
@@ -7238,7 +7238,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
- "substrate-wasm-builder-runner 1.0.6 (git+https://github.com/plugblockchain/plug-blockchain?branch=spike/2.0)",
+ "substrate-wasm-builder-runner",
  "trie-db",
 ]
 
@@ -7287,12 +7287,6 @@ dependencies = [
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
 source = "git+https://github.com/plugblockchain/plug-blockchain?branch=spike/2.0#307a6e04404a52d00c24ee051c577085f29e1d71"
-
-[[package]]
-name = "substrate-wasm-builder-runner"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 
 [[package]]
 name = "subtle"

--- a/crml/staking/Cargo.toml
+++ b/crml/staking/Cargo.toml
@@ -47,4 +47,3 @@ std = [
 	"pallet-authorship/std",
 	"pallet-session/std",
 ]
-no-bond = []

--- a/crml/staking/Cargo.toml
+++ b/crml/staking/Cargo.toml
@@ -47,3 +47,4 @@ std = [
 	"pallet-authorship/std",
 	"pallet-session/std",
 ]
+no-bond = []

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1007,7 +1007,7 @@ decl_module! {
 			payee: RewardDestination<T::AccountId>
 		) {
 			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(no_bond)]
+			#[cfg(feature = "no-bond")]
 			let _ = ensure_root(origin.clone())?;
 
 			let stash = ensure_signed(origin)?;
@@ -1053,7 +1053,7 @@ decl_module! {
 		#[weight = T::WeightInfo::bond_extra()]
 		fn bond_extra(origin, #[compact] max_additional: BalanceOf<T>) {
 			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(no_bond)]
+			#[cfg(feature = "no-bond")]
 			let _ = ensure_root(origin.clone())?;
 
 			let stash = ensure_signed(origin)?;
@@ -1097,7 +1097,7 @@ decl_module! {
 		#[weight = T::WeightInfo::unbond()]
 		fn unbond(origin, #[compact] value: BalanceOf<T>) {
 			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(no_bond)]
+			#[cfg(feature = "no-bond")]
 			let _ = ensure_root(origin.clone())?;
 
 			let controller = ensure_signed(origin)?;
@@ -1140,7 +1140,7 @@ decl_module! {
 		#[weight = T::WeightInfo::rebond()]
 		fn rebond(origin, #[compact] value: BalanceOf<T>) {
 			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(no_bond)]
+			#[cfg(feature = "no-bond")]
 			let _ = ensure_root(origin.clone())?;
 
 			let controller = ensure_signed(origin)?;
@@ -1196,7 +1196,7 @@ decl_module! {
 		#[weight = T::WeightInfo::withdraw_unbonded()]
 		fn withdraw_unbonded(origin) {
 			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(no_bond)]
+			#[cfg(feature = "no-bond")]
 			let _ = ensure_root(origin.clone())?;
 
 			let controller = ensure_signed(origin)?;

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -1006,6 +1006,10 @@ decl_module! {
 			#[compact] value: BalanceOf<T>,
 			payee: RewardDestination<T::AccountId>
 		) {
+			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
+			#[cfg(no_bond)]
+			let _ = ensure_root(origin.clone())?;
+
 			let stash = ensure_signed(origin)?;
 
 			if <Bonded<T>>::contains_key(&stash) {
@@ -1048,6 +1052,10 @@ decl_module! {
 		/// # </weight>
 		#[weight = T::WeightInfo::bond_extra()]
 		fn bond_extra(origin, #[compact] max_additional: BalanceOf<T>) {
+			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
+			#[cfg(no_bond)]
+			let _ = ensure_root(origin.clone())?;
+
 			let stash = ensure_signed(origin)?;
 
 			let controller = Self::bonded(&stash).ok_or(Error::<T>::NotStash)?;
@@ -1088,6 +1096,10 @@ decl_module! {
 		/// </weight>
 		#[weight = T::WeightInfo::unbond()]
 		fn unbond(origin, #[compact] value: BalanceOf<T>) {
+			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
+			#[cfg(no_bond)]
+			let _ = ensure_root(origin.clone())?;
+
 			let controller = ensure_signed(origin)?;
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 			ensure!(
@@ -1127,6 +1139,10 @@ decl_module! {
 		/// # </weight>
 		#[weight = T::WeightInfo::rebond()]
 		fn rebond(origin, #[compact] value: BalanceOf<T>) {
+			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
+			#[cfg(no_bond)]
+			let _ = ensure_root(origin.clone())?;
+
 			let controller = ensure_signed(origin)?;
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 			ensure!(
@@ -1179,6 +1195,10 @@ decl_module! {
 		/// # </weight>
 		#[weight = T::WeightInfo::withdraw_unbonded()]
 		fn withdraw_unbonded(origin) {
+			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
+			#[cfg(no_bond)]
+			let _ = ensure_root(origin.clone())?;
+
 			let controller = ensure_signed(origin)?;
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 			let ledger = ledger.consolidate_unlocked(Self::current_era());

--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -876,6 +876,10 @@ decl_storage! {
 		/// The earliest era for which we have a pending, unapplied slash.
 		EarliestUnappliedSlash: Option<EraIndex>;
 
+		// TODO remove the following variable when https://github.com/cennznet/cennznet/issues/297
+		/// Used to toggle the bonding functionality off/on
+		BlockBonding get(fn block_bonding) config(): bool;
+
 		/// The version of storage for upgrade.
 		StorageVersion: u32;
 	}
@@ -963,6 +967,8 @@ decl_error! {
 		NotSortedAndUnique,
 		/// Cannot nominate the same account multiple times
 		DuplicateNominee,
+		// TODO remove the following error when https://github.com/cennznet/cennznet/issues/297
+		BondingNotEnabled,
 	}
 }
 
@@ -1006,9 +1012,7 @@ decl_module! {
 			#[compact] value: BalanceOf<T>,
 			payee: RewardDestination<T::AccountId>
 		) {
-			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(feature = "no-bond")]
-			let _ = ensure_root(origin.clone())?;
+			ensure!(!Self::block_bonding(), Error::<T>::BondingNotEnabled);
 
 			let stash = ensure_signed(origin)?;
 
@@ -1052,9 +1056,7 @@ decl_module! {
 		/// # </weight>
 		#[weight = T::WeightInfo::bond_extra()]
 		fn bond_extra(origin, #[compact] max_additional: BalanceOf<T>) {
-			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(feature = "no-bond")]
-			let _ = ensure_root(origin.clone())?;
+			ensure!(!Self::block_bonding(), Error::<T>::BondingNotEnabled);
 
 			let stash = ensure_signed(origin)?;
 
@@ -1096,9 +1098,7 @@ decl_module! {
 		/// </weight>
 		#[weight = T::WeightInfo::unbond()]
 		fn unbond(origin, #[compact] value: BalanceOf<T>) {
-			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(feature = "no-bond")]
-			let _ = ensure_root(origin.clone())?;
+			ensure!(!Self::block_bonding(), Error::<T>::BondingNotEnabled);
 
 			let controller = ensure_signed(origin)?;
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
@@ -1139,9 +1139,7 @@ decl_module! {
 		/// # </weight>
 		#[weight = T::WeightInfo::rebond()]
 		fn rebond(origin, #[compact] value: BalanceOf<T>) {
-			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(feature = "no-bond")]
-			let _ = ensure_root(origin.clone())?;
+			ensure!(!Self::block_bonding(), Error::<T>::BondingNotEnabled);
 
 			let controller = ensure_signed(origin)?;
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
@@ -1195,9 +1193,7 @@ decl_module! {
 		/// # </weight>
 		#[weight = T::WeightInfo::withdraw_unbonded()]
 		fn withdraw_unbonded(origin) {
-			// TODO remove the following 2 lines when https://github.com/cennznet/cennznet/issues/297
-			#[cfg(feature = "no-bond")]
-			let _ = ensure_root(origin.clone())?;
+			ensure!(!Self::block_bonding(), Error::<T>::BondingNotEnabled);
 
 			let controller = ensure_signed(origin)?;
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -3381,3 +3381,33 @@ fn payout_to_any_account_works() {
 		assert!(Balances::free_balance(42) > 0);
 	})
 }
+
+#[test]
+fn bonding_can_be_blocked() {
+	ExtBuilder::default().build().execute_with(|| {
+		// Block bonding should be disabled by default
+		assert!(!BlockBonding::get());
+
+		BlockBonding::put(true);
+		assert_noop!(
+			Staking::bond(Origin::signed(11), 10, 43, RewardDestination::Controller),
+			Error::<Test>::BondingNotEnabled
+		);
+		assert_noop!(
+			Staking::bond_extra(Origin::signed(11), 43),
+			Error::<Test>::BondingNotEnabled
+		);
+		assert_noop!(
+			Staking::unbond(Origin::signed(11), 43),
+			Error::<Test>::BondingNotEnabled
+		);
+		assert_noop!(
+			Staking::rebond(Origin::signed(11), 43),
+			Error::<Test>::BondingNotEnabled
+		);
+		assert_noop!(
+			Staking::withdraw_unbonded(Origin::signed(11)),
+			Error::<Test>::BondingNotEnabled
+		);
+	});
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/cennznet/cennznet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
+crml-staking = { path = "../crml/staking", default-features = false}
 cennznet-cli = { path = "../cli", default-features = false }
 sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "spike/2.0" }
 wabt = "0.10.0"
@@ -76,11 +77,11 @@ crml-cennzx = { path = "../crml/cennzx", default-features = false }
 crml-cennzx-rpc-runtime-api = { path = "../crml/cennzx/rpc/runtime-api", default-features = false }
 crml-sylo = { path = "../crml/sylo", default-features = false}
 crml-transaction-payment = { path = "../crml/transaction-payment", default-features = false}
-crml-staking = { path = "../crml/staking", default-features = false}
+crml-staking = { path = "../crml/staking", default-features = false, features = ["no-bond"]}
 crml-staking-reward-curve = { path = "../crml/staking/reward-curve", default-features = false}
 
 [build-dependencies]
-wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/plugblockchain/plug-blockchain", branch = "spike/2.0" }
 
 [features]
 default = ["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/cennznet/cennznet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
-crml-staking = { path = "../crml/staking", default-features = false}
 cennznet-cli = { path = "../cli", default-features = false }
 sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, branch = "spike/2.0" }
 wabt = "0.10.0"
@@ -77,7 +76,7 @@ crml-cennzx = { path = "../crml/cennzx", default-features = false }
 crml-cennzx-rpc-runtime-api = { path = "../crml/cennzx/rpc/runtime-api", default-features = false }
 crml-sylo = { path = "../crml/sylo", default-features = false}
 crml-transaction-payment = { path = "../crml/transaction-payment", default-features = false}
-crml-staking = { path = "../crml/staking", default-features = false, features = ["no-bond"]}
+crml-staking = { path = "../crml/staking", default-features = false}
 crml-staking-reward-curve = { path = "../crml/staking/reward-curve", default-features = false}
 
 [build-dependencies]


### PR DESCRIPTION
Keeping bonding enabled by default is necessary for the tests. However, the storage variable can be used to toggle the blocking.

Note: the PR also contains an incidental fix for the version of the dependency substrate-wasm-builder-runner