### PR TITLE
Benchmark Sylo::e2ee register_device

### DIFF
--- a/crml/sylo/src/e2ee/benchmarking.rs
+++ b/crml/sylo/src/e2ee/benchmarking.rs
@@ -33,6 +33,7 @@ benchmarks! {
 	_{ }
 
 	register_device {
+		let p in 0 .. MAX_PKBS as u32;
 		let sender: T::AccountId = whitelisted_caller();
 		let device_id: DeviceId = 11;
 
@@ -70,10 +71,12 @@ benchmarks! {
 		);
 		<SyloGroups<T>>::insert(&sender, &group_id_1, group_1);
 
-		let pre_key_bundle0 = PreKeyBundle::from(*b"prekeybundle0");
-		let pre_key_bundle1 = PreKeyBundle::from(*b"prekeybundle1");
-		let pre_key_bundles = Vec::<PreKeyBundle>::from([pre_key_bundle0, pre_key_bundle1]);
-
+		let mut pre_key_bundles = Vec::<PreKeyBundle>::new();
+		for i in 0..p {
+			let mut pre_key_bundle = PreKeyBundle::from(*b"prekeybundle");
+			pre_key_bundle.extend_from_slice(&i.to_be_bytes());
+			pre_key_bundles.push(pre_key_bundle);
+		}
 	}: _(RawOrigin::Signed(sender.clone()), device_id, pre_key_bundles)
 	verify {
 		assert!(<SyloDevice<T>>::devices(sender).contains(&device_id));

--- a/crml/sylo/src/e2ee/benchmarking.rs
+++ b/crml/sylo/src/e2ee/benchmarking.rs
@@ -1,0 +1,95 @@
+// Copyright 2019-2020 Centrality Investments Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sylo e2ee benchmarking.
+
+#![cfg(feature = "runtime-benchmarks")]
+
+use super::*;
+
+use frame_benchmarking::{account, benchmarks, whitelisted_caller};
+use frame_system::RawOrigin;
+use sp_runtime::traits::Hash;
+use sp_std::boxed::Box;
+use sp_std::{vec, vec::Vec};
+
+use crate::device::Module as SyloDevice;
+use crate::groups::{Group, Member, MemberRoles, Meta, Module as SyloGroups, Text};
+
+const SEED: u32 = 0;
+
+benchmarks! {
+	_{ }
+
+	register_device {
+		let sender: T::AccountId = whitelisted_caller();
+		let device_id: DeviceId = 11;
+
+		let text_tuple0 = (Text::from(*b"t0m0"), Text::from(*b"t0m1"));
+		let text_tuple1 = (Text::from(*b"t1m0"), Text::from(*b"t1m1"));
+		let meta = Meta::from([text_tuple0, text_tuple1]);
+
+		let admin = Member::<T::AccountId>::new(
+			sender.clone(),
+			Vec::<MemberRoles>::from([MemberRoles::Admin, MemberRoles::Member]),
+			Meta::new()
+		);
+
+		let member = Member::<T::AccountId>::new(
+			account("member", 0, SEED),
+			Vec::<MemberRoles>::from([MemberRoles::Member]),
+			Meta::new()
+		);
+
+		let group_id_0 = T::Hashing::hash(b"group0");
+		let group_0 = Group::<T::AccountId, T::Hash>::new(
+			group_id_0,
+			Vec::<Member<T::AccountId>>::from([admin.clone(), member.clone()]),
+			Vec::new(),
+			meta.clone(),
+		);
+		<SyloGroups<T>>::insert(&sender, &group_id_0, group_0);
+
+		let group_id_1 = T::Hashing::hash(b"group1");
+		let group_1 = Group::<T::AccountId, T::Hash>::new(
+			group_id_1,
+			Vec::<Member<T::AccountId>>::from([admin, member]),
+			Vec::new(),
+			meta,
+		);
+		<SyloGroups<T>>::insert(&sender, &group_id_1, group_1);
+
+		let pre_key_bundle0 = PreKeyBundle::from(*b"prekeybundle0");
+		let pre_key_bundle1 = PreKeyBundle::from(*b"prekeybundle1");
+		let pre_key_bundles = Vec::<PreKeyBundle>::from([pre_key_bundle0, pre_key_bundle1]);
+
+	}: _(RawOrigin::Signed(sender.clone()), device_id, pre_key_bundles)
+	verify {
+		assert!(<SyloDevice<T>>::devices(sender).contains(&device_id));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{ExtBuilder, Test};
+	use frame_support::assert_ok;
+
+	#[test]
+	fn register_device() {
+		ExtBuilder::default().build().execute_with(|| {
+			assert_ok!(test_benchmark_register_device::<Test>());
+		});
+	}
+}

--- a/crml/sylo/src/e2ee/default_weights.rs
+++ b/crml/sylo/src/e2ee/default_weights.rs
@@ -21,8 +21,9 @@
 use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::e2ee::WeightInfo for () {
-	fn register_device() -> Weight {
-		(79_000_000 as Weight)
+	fn register_device(p: u32) -> Weight {
+		(76_895_000 as Weight)
+			.saturating_add((255_000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(5 as Weight))
 			.saturating_add(DbWeight::get().writes(4 as Weight))
 	}

--- a/crml/sylo/src/e2ee/default_weights.rs
+++ b/crml/sylo/src/e2ee/default_weights.rs
@@ -22,7 +22,9 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 impl crate::e2ee::WeightInfo for () {
 	fn register_device() -> Weight {
-		0
+		(79_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
 	}
 	fn replenish_pkbs() -> Weight {
 		0

--- a/crml/sylo/src/e2ee/mod.rs
+++ b/crml/sylo/src/e2ee/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 use frame_support::{decl_error, decl_module, decl_storage, dispatch::Vec, ensure, weights::Weight};
 use frame_system::ensure_signed;
 
+mod benchmarking;
 mod default_weights;
 
 const MAX_PKBS: usize = 50;

--- a/crml/sylo/src/e2ee/mod.rs
+++ b/crml/sylo/src/e2ee/mod.rs
@@ -26,7 +26,7 @@ mod default_weights;
 const MAX_PKBS: usize = 50;
 
 pub trait WeightInfo {
-	fn register_device() -> Weight;
+	fn register_device(p: u32) -> Weight;
 	fn replenish_pkbs() -> Weight;
 	fn withdraw_pkbs() -> Weight;
 }
@@ -53,7 +53,7 @@ decl_module! {
 		/// weight:
 		/// O(g) where g is the number of groups the user is in
 		/// Multiple reads and writes depending on the user states.
-		#[weight = <T as Trait>::WeightInfo::register_device()]
+		#[weight = <T as Trait>::WeightInfo::register_device(pkbs.len() as u32)]
 		fn register_device(origin, device_id: DeviceId, pkbs: Vec<PreKeyBundle>) {
 			let sender = ensure_signed(origin)?;
 

--- a/crml/sylo/src/groups/mod.rs
+++ b/crml/sylo/src/groups/mod.rs
@@ -96,6 +96,10 @@ impl<A: Encode + Decode> Member<A> {
 		}
 		false
 	}
+	#[cfg(feature = "runtime-benchmarks")]
+	pub fn new(user_id: A, roles: Vec<MemberRoles>, meta: Meta) -> Self {
+		Self { user_id, roles, meta }
+	}
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Default, Debug)]
@@ -108,6 +112,18 @@ where
 	members: Vec<Member<AccountId>>,
 	invites: Vec<PendingInvite<H256>>,
 	meta: Meta,
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl<A: Encode + Decode, H: Encode + Decode> Group<A, H> {
+	pub fn new(group_id: H, members: Vec<Member<A>>, invites: Vec<PendingInvite<H256>>, meta: Meta) -> Self {
+		Self {
+			group_id,
+			members,
+			invites,
+			meta,
+		}
+	}
 }
 
 decl_error! {
@@ -484,5 +500,11 @@ impl<T: Trait> Module<T> {
 			devices.push((account_id, device_id));
 			<MemberDevices<T>>::insert(group_id, devices);
 		}
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	pub fn insert(sender: &T::AccountId, group_id: &T::Hash, group: Group<T::AccountId, T::Hash>) {
+		<Groups<T>>::insert(group_id, group);
+		Self::store_membership(sender, group_id.clone());
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -897,6 +897,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, sylo_response, SyloResponse);
 			add_benchmark!(params, batches, sylo_inbox, SyloInbox);
 			add_benchmark!(params, batches, sylo_vault, SyloVault);
+			add_benchmark!(params, batches, sylo_e2ee, SyloE2EE);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)


### PR DESCRIPTION
This is 1/3 of Sylo E2ee benchmark. To create the worst-case scenario for register_device, the sender should be a member of several groups for which the new device should be declared. However, when benchmarking e2ee there is no access to the private structures and functions of the groups. The access is necessary for creating some groups when setting up the benchmark. This is why I needed to add some pub functions guarded by the feature runtime-benchmarks to that module. 