### PR TITLE
Benchmark accept_invite and set the corresponding weight function

### DIFF
--- a/crml/sylo/src/groups/default_weights.rs
+++ b/crml/sylo/src/groups/default_weights.rs
@@ -54,7 +54,9 @@ impl crate::groups::WeightInfo for () {
 			.saturating_add(DbWeight::get().writes(31 as Weight))
 	}
 	fn accept_invite() -> Weight {
-		0
+		(544_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(6 as Weight))
+			.saturating_add(DbWeight::get().writes(5 as Weight))
 	}
 	fn revoke_invites(_i: usize) -> Weight {
 		(435_834_000 as Weight)

--- a/crml/sylo/src/groups/mod.rs
+++ b/crml/sylo/src/groups/mod.rs
@@ -364,10 +364,9 @@ decl_module! {
 
 			let sig = ed25519::Signature(signature.into());
 			// TODO ensure payload is encoded properly
-			ensure!(
-				sig.verify(payload.encode().as_slice(), &ed25519::Public(invite.invite_key.into())),
-				Error::<T>::InvitationSignatureRejected
-			);
+			let _verify_result = sig.verify(payload.encode().as_slice(), &ed25519::Public(invite.invite_key.into()));
+			#[cfg(any(test, not(feature = "runtime-benchmarks")))]
+			ensure!(_verify_result, Error::<T>::InvitationSignatureRejected);
 
 			let mut roles = vec![MemberRoles::Member];
 			roles.extend(invite.roles);


### PR DESCRIPTION
Because the key generation needs certain rand_core features which are not available during a wasm-run, I had to resort to predefined key and signature taken from the test mode. However invitee_id is different in the test mode and thus using the same key and signature can cause InvitationSignatureRejected in the runtime mode for benchmarking. For this reason, accept_invite is modified not to emit InvitationSignatureRejected during the benchmark.