### PR TITLE
Build docker image on tagged release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then
               IMAGE_TAG="develop-${CIRCLE_SHA1:0:6}"
             else
-	      echo "${CIRCLE_TAG}"
+              echo "${CIRCLE_TAG}"
               IMAGE_TAG="${CIRCLE_TAG}"
             fi
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then
               IMAGE_TAG="develop-${CIRCLE_SHA1:0:6}"
             else
-              IMAGE_TAG="${CIRCLE_BRANCH////-}"
+              IMAGE_TAG="${GIT_TAG}"
             fi
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
             docker build --build-arg RUST_VERSION=$RUST_VERSION --build-arg RUST_NIGHTLY=$RUST_NIGHTLY --pull -t $IMAGE_NAME:$IMAGE_TAG -f ./Dockerfile .
@@ -174,6 +174,8 @@ jobs:
   build-docker-and-publish:
     machine:
       image: ubuntu-1604:201903-01
+    environment:
+      GIT_TAG: pipeline.git.tag
     steps:
       - checkout
       - docker-build-and-publish
@@ -185,7 +187,9 @@ workflows:
       - build-docker-and-publish:
           context: Rust
           filters:
+            tags:
+              only:
+                - /^[0-9]+[.][0-9]+[.][0-9](-rc.+)?$/
             branches:
               only:
                 - develop
-                - /^release\/[0-9]+[.][0-9]+[.][0-9](-rc.+)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,8 @@ commands:
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then
               IMAGE_TAG="develop-${CIRCLE_SHA1:0:6}"
             else
-              IMAGE_TAG="${GIT_TAG}"
+	      echo "${CIRCLE_TAG}"
+              IMAGE_TAG="${CIRCLE_TAG}"
             fi
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
             docker build --build-arg RUST_VERSION=$RUST_VERSION --build-arg RUST_NIGHTLY=$RUST_NIGHTLY --pull -t $IMAGE_NAME:$IMAGE_TAG -f ./Dockerfile .
@@ -174,8 +175,6 @@ jobs:
   build-docker-and-publish:
     machine:
       image: ubuntu-1604:201903-01
-    environment:
-      GIT_TAG: pipeline.git.tag
     steps:
       - checkout
       - docker-build-and-publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,14 +646,14 @@ dependencies = [
 
 [[package]]
 name = "cennznet"
-version = "1.2.0-rc2"
+version = "1.2.0"
 dependencies = [
  "cennznet-cli",
 ]
 
 [[package]]
 name = "cennznet-cli"
-version = "1.2.0-rc2"
+version = "1.2.0"
 dependencies = [
  "cennznet-primitives",
  "cennznet-runtime",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "cennznet-runtime"
-version = "1.2.0-rc2"
+version = "1.2.0"
 dependencies = [
  "cennznet-cli",
  "cennznet-primitives",


### PR DESCRIPTION
release branches are now named: 'release/\<version\>'
release tags are: '\<version\>'

This change ensures a docker image is built and tagged correctly on a matching release tag