### PR TITLE
Prerelease/1.2.0 hotifx 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,8 @@ commands:
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then
               IMAGE_TAG="develop-${CIRCLE_SHA1:0:6}"
             else
-              IMAGE_TAG="${GIT_TAG}"
+              echo "${CIRCLE_TAG}"
+              IMAGE_TAG="${CIRCLE_TAG}"
             fi
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
             docker build --build-arg RUST_VERSION=$RUST_VERSION --build-arg RUST_NIGHTLY=$RUST_NIGHTLY --pull -t $IMAGE_NAME:$IMAGE_TAG -f ./Dockerfile .
@@ -174,8 +175,6 @@ jobs:
   build-docker-and-publish:
     machine:
       image: ubuntu-1604:201903-01
-    environment:
-      GIT_TAG: pipeline.git.tag
     steps:
       - checkout
       - docker-build-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then
               IMAGE_TAG="develop-${CIRCLE_SHA1:0:6}"
             else
-              IMAGE_TAG="${CIRCLE_BRANCH////-}"
+              IMAGE_TAG="${GIT_TAG}"
             fi
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
             docker build --build-arg RUST_VERSION=$RUST_VERSION --build-arg RUST_NIGHTLY=$RUST_NIGHTLY --pull -t $IMAGE_NAME:$IMAGE_TAG -f ./Dockerfile .
@@ -174,6 +174,8 @@ jobs:
   build-docker-and-publish:
     machine:
       image: ubuntu-1604:201903-01
+    environment:
+      GIT_TAG: pipeline.git.tag
     steps:
       - checkout
       - docker-build-and-publish
@@ -185,7 +187,9 @@ workflows:
       - build-docker-and-publish:
           context: Rust
           filters:
+            tags:
+              only:
+                - /^[0-9]+[.][0-9]+[.][0-9](-rc.+)?$/
             branches:
               only:
                 - develop
-                - /^[0-9]+[.][0-9]+[.][0-9](-rc.+)?$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - develop
+    - "release/*"
   push:
     branches:
     - develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2020-09-27
+        toolchain: nightly-2020-11-18
         components: rustfmt
         target: wasm32-unknown-unknown
         default: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - "prerelease/*"
   pull_request:
     branches:
       - develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         MERGE_LABELS: automerge
         MERGE_METHOD: squash
   release-to-github:
+    if: ${{ startsWith(github.head_ref, 'prerelease/') }} && ${{ github.event.label.name == 'automerge' }}
     needs:
     - merge-release-branch
     runs-on: [self-hosted, linux]
@@ -38,7 +39,7 @@ jobs:
     - name: Check out develop
       uses: actions/checkout@v2
       with:
-        ref: develop
+        ref: release/1.2.0
     - name: Find release version
       id: find_version
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - "release/*"
     types:
       - labeled
   # only trigger merge when branch protections (configured in github settings) are met:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - "prerelease/*"
   pull_request:
     branches:
       - develop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,14 +646,14 @@ dependencies = [
 
 [[package]]
 name = "cennznet"
-version = "1.2.0-rc2"
+version = "1.2.0"
 dependencies = [
  "cennznet-cli",
 ]
 
 [[package]]
 name = "cennznet-cli"
-version = "1.2.0-rc2"
+version = "1.2.0"
 dependencies = [
  "cennznet-primitives",
  "cennznet-runtime",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "cennznet-runtime"
-version = "1.2.0-rc2"
+version = "1.2.0"
 dependencies = [
  "cennznet-cli",
  "cennznet-primitives",
@@ -1623,7 +1623,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1742,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1782,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2567,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "15.0.0"
+version = "14.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f7b1cdf66312002e15682a24430728bd13036c641163c016bc53fb686a7c2d"
+checksum = "2773fa94a2a1fd51efb89a8f45b8861023dbb415d18d3c9235ae9388d780f9ec"
 dependencies = [
  "failure",
  "futures 0.1.29",
@@ -2583,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "15.0.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b12567a31d48588a65b6cf870081e6ba1d7b2ae353977cb9820d512e69c70"
+checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
  "futures 0.1.29",
  "log",
@@ -2596,18 +2596,18 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "15.0.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175ca0cf77439b5495612bf216c650807d252d665b4b70ab2eebd895a88fac1"
+checksum = "34221123bc79b66279a3fde2d3363553835b43092d629b34f2e760c44dc94713"
 dependencies = [
  "jsonrpc-client-transports",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "15.1.0"
+version = "14.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a847f9ec7bb52149b2786a17c9cb260d6effc6b8eeb8c16b343a487a7563a3"
+checksum = "d0e77e8812f02155b85a677a96e1d16b60181950c0636199bc4528524fba98dc"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2617,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "15.0.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9996b26c0c7a59626d0ed6c5ec8bf06218e62ce1474bd2849f9b9fd38a0158c0"
+checksum = "0da906d682799df05754480dac1b9e70ec92e12c19ebafd2662a5ea1c9fd6522"
 dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
@@ -2632,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ipc-server"
-version = "15.0.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e8f2278fb2b277175b6e21b23e7ecf30e78daff5ee301d0a2a411d9a821a0a"
+checksum = "dedccd693325d833963b549e959137f30a7a0ea650cde92feda81dc0c1393cb5"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2646,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "15.0.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f389c5cd1f3db258a99296892c21047e21ae73ff4c0e2d39650ea86fe994b4c7"
+checksum = "2d44f5602a11d657946aac09357956d2841299ed422035edf140c552cb057986"
 dependencies = [
  "jsonrpc-core",
  "log",
@@ -2659,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "15.0.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c623e1895d0d9110cb0ea7736cfff13191ff52335ad33b21bd5c775ea98b27af"
+checksum = "56cbfb462e7f902e21121d9f0d1c2b77b2c5b642e1a4e8f4ebfa2e15b94402bb"
 dependencies = [
  "bytes 0.4.12",
  "globset",
@@ -2675,16 +2675,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "15.0.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436a92034d0137ab3e3c64a7a6350b428f31cb4d7d1a89f284bcdbcd98a7bc56"
+checksum = "903d3109fe7c4acb932b567e1e607e0f524ed04741b09fb0e61841bc40a022fc"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
- "parity-ws",
  "parking_lot 0.10.2",
  "slab",
+ "ws",
 ]
 
 [[package]]
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3848,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3921,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3979,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4044,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4233,24 +4233,6 @@ name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
-
-[[package]]
-name = "parity-ws"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e02a625dd75084c2a7024f07c575b61b782f729d18702dabb3cdbf31911dc61"
-dependencies = [
- "byteorder 1.3.4",
- "bytes 0.4.12",
- "httparse",
- "log",
- "mio",
- "mio-extras",
- "rand 0.7.3",
- "sha-1 0.8.2",
- "slab",
- "url 2.1.1",
-]
 
 [[package]]
 name = "parking"
@@ -4518,7 +4500,7 @@ dependencies = [
 [[package]]
 name = "prml-attestation"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4533,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "prml-generic-asset"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4548,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "prml-generic-asset-rpc"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4567,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "prml-generic-asset-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "prml-generic-asset",
@@ -4578,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "prml-support"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5247,7 +5229,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "bytes 0.5.6",
  "derive_more",
@@ -5275,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5299,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5316,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5333,7 +5315,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5344,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5393,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5429,7 +5411,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5459,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5470,7 +5452,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5514,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5538,7 +5520,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5551,7 +5533,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5574,7 +5556,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5588,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5616,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "log",
@@ -5633,7 +5615,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5648,7 +5630,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5666,7 +5648,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -5703,7 +5685,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -5727,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -5745,7 +5727,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "hex",
@@ -5761,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5780,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5834,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5849,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5876,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -5889,7 +5871,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5898,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5930,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5954,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.1.29",
  "jsonrpc-core",
@@ -5972,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "directories",
@@ -6034,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "sc-service-test"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "fdlimit",
  "futures 0.1.29",
@@ -6071,7 +6053,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6085,7 +6067,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6106,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "erased-serde",
  "log",
@@ -6125,7 +6107,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6146,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6550,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "log",
@@ -6562,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6577,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6589,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6601,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6614,7 +6596,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6626,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6637,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6649,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "log",
@@ -6666,7 +6648,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "serde",
  "serde_json",
@@ -6675,7 +6657,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6701,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6715,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6734,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6743,7 +6725,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6755,7 +6737,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6799,7 +6781,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6808,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6818,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6829,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6845,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6855,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -6867,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6890,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6901,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6913,7 +6895,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6924,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6934,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "backtrace",
  "log",
@@ -6943,7 +6925,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "serde",
  "sp-core",
@@ -6952,7 +6934,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6974,7 +6956,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6990,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7002,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "serde",
  "serde_json",
@@ -7011,7 +6993,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7024,7 +7006,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7034,7 +7016,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "hash-db",
  "log",
@@ -7055,12 +7037,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7073,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7087,7 +7069,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7100,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7115,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7129,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7141,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7153,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7282,7 +7264,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "platforms",
 ]
@@ -7290,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -7313,7 +7295,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7327,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -7353,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "cfg-if 0.1.10",
  "frame-executive",
@@ -7395,7 +7377,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -7416,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "futures 0.3.5",
  "substrate-test-utils-derive",
@@ -7426,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.0"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 dependencies = [
  "proc-macro-crate",
  "quote",
@@ -7436,7 +7418,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/plugblockchain/plug-blockchain?rev=2.0.2#421779fe8d4ce04e87a646f4a6313c834d39b398"
+source = "git+https://github.com/plugblockchain/plug-blockchain?rev=hotfix-2.0.2-1#5b2e165708ac6c03ebe42504723b067bdd11928a"
 
 [[package]]
 name = "subtle"
@@ -8628,6 +8610,24 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
+dependencies = [
+ "byteorder 1.3.4",
+ "bytes 0.4.12",
+ "httparse",
+ "log",
+ "mio",
+ "mio-extras",
+ "rand 0.7.3",
+ "sha-1 0.8.2",
+ "slab",
+ "url 2.1.1",
+]
 
 [[package]]
 name = "ws2_32-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "cli/src/main.rs"
 
 [package]
 name = "cennznet"
-version = "1.2.0"
+version = "1.2.0-hotfix.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,67 +15,67 @@ futures = { version = "0.3.1", features = ["compat"] }
 serde = { version = "1.0.102", features = ["derive"] }
 structopt = "0.3.8"
 
-sc-authority-discovery = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-chain-spec = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-cli = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain", features = ["wasmtime"] }
-sp-core = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-executor = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain", features = ["wasmtime"] }
-sc-keystore = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-service = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain", features = ["wasmtime"] }
-sp-inherents = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-transaction-pool = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-transaction-pool = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-authority-discovery = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-consensus-babe = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain", features = ["test-helpers"] }
-sp-consensus-babe = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-consensus = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-consensus-epochs = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-consensus = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-network = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-finality-grandpa = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-finality-grandpa = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-client-api = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-runtime = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-authority-discovery = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-chain-spec = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-cli = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain", features = ["wasmtime"] }
+sp-core = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-executor = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain", features = ["wasmtime"] }
+sc-keystore = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-service = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain", features = ["wasmtime"] }
+sp-inherents = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-transaction-pool = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-transaction-pool = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-authority-discovery = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-consensus-babe = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain", features = ["test-helpers"] }
+sp-consensus-babe = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-consensus = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-consensus-epochs = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-consensus = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-network = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-finality-grandpa = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-finality-grandpa = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-client-api = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-runtime = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
 
 # These dependencies are used for the node RPCs
-jsonrpc-core = "15.0.0"
-pallet-transaction-payment-rpc = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-rpc = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-api = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-rpc-api = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-blockchain = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-block-builder = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-basic-authorship = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-substrate-frame-rpc-system = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-consensus-babe-rpc = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-finality-grandpa-rpc = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
+jsonrpc-core = "14.0.3"
+pallet-transaction-payment-rpc = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-rpc = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-api = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-rpc-api = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-blockchain = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-block-builder = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-basic-authorship = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+substrate-frame-rpc-system = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-consensus-babe-rpc = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-finality-grandpa-rpc = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
 
 # These dependencies are used for runtime benchmarking
-frame-benchmarking = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-frame-benchmarking-cli = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
+frame-benchmarking = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+frame-benchmarking-cli = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
 
 # cennznet dependencies
 cennznet-primitives = { path = "../primitives" }
 cennznet-runtime = { path = "../runtime" }
 # cennznet custom RPCs
 crml-cennzx-rpc = { path = "../crml/cennzx/rpc" }
-prml-generic-asset-rpc = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-prml-generic-asset = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
+prml-generic-asset-rpc = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+prml-generic-asset = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
 
-pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
+pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.5", features = ["derive"] }
-sp-finality-tracker = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-keyring = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sp-timestamp = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-sc-service-test = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
-frame-system = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-finality-tracker = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-keyring = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sp-timestamp = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+sc-service-test = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
+frame-system = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
 crml-transaction-payment = { path = "../crml/transaction-payment" }
 tempfile = "3.1.0"
 
 [build-dependencies]
-substrate-build-script-utils = { rev = "2.0.2", git = "https://github.com/plugblockchain/plug-blockchain" }
+substrate-build-script-utils = { rev = "hotfix-2.0.2-1", git = "https://github.com/plugblockchain/plug-blockchain" }
 
 [features]
 default = []

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-cli"
-version = "1.2.0"
+version = "1.2.0-hotfix.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "CENNZnet node implementation in Rust."
 build = "build.rs"

--- a/crml/cennzx/Cargo.toml
+++ b/crml/cennzx/Cargo.toml
@@ -9,19 +9,19 @@ codec = { version = "1.3.5", package = "parity-scale-codec", default-features = 
 primitive-types = { version = "0.7.2", default-features = false }
 serde = { version = "1.0.101", optional = true }
 cennznet-primitives = { path = "../../primitives", default-features = false }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false, optional = true }
-prml-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-prml-support = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false, optional = true }
+prml-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+prml-support = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
 
 [dev-dependencies]
 cennznet-runtime = { path = "../../runtime" }
-sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
+sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
 
 [features]
 default = ["std"]

--- a/crml/cennzx/rpc/Cargo.toml
+++ b/crml/cennzx/rpc/Cargo.toml
@@ -8,18 +8,18 @@ license = "GPL-3.0"
 
 [dependencies]
 codec = { version = "1.3.5", package = "parity-scale-codec", default-features = false }
-jsonrpc-core = "15.0.0"
-jsonrpc-core-client = "15.0.0"
-jsonrpc-derive = "15.0.0"
+jsonrpc-core = "14.0.3"
+jsonrpc-core-client = "14.0.3"
+jsonrpc-derive = "14.0.3"
 serde = { version = "1.0.102", features = ["derive"] }
 
-sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-blockchain = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-rpc = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
 
 crml-cennzx-rpc-runtime-api = { version = "2.0.0", path = "./runtime-api" }

--- a/crml/cennzx/rpc/runtime-api/Cargo.toml
+++ b/crml/cennzx/rpc/runtime-api/Cargo.toml
@@ -8,10 +8,10 @@ license = "GPL-3.0"
 [dependencies]
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 codec = { version = "1.3.5", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/crml/staking/Cargo.toml
+++ b/crml/staking/Cargo.toml
@@ -9,26 +9,26 @@ description = "CENNZnet staking pallet"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.5", default-features = false, features = ["derive"] }
-sp-io ={ default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-sp-keyring = { optional = true, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-sp-npos-elections = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-sp-runtime = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-sp-staking = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-sp-std = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-frame-support = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-frame-system = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-pallet-authorship = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-pallet-session = { default-features = false, features = ["historical"], git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-pallet-staking = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
+sp-io ={ default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+sp-keyring = { optional = true, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+sp-npos-elections = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+sp-runtime = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+sp-staking = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+sp-std = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+frame-support = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+frame-system = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+pallet-authorship = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+pallet-session = { default-features = false, features = ["historical"], git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+pallet-staking = { default-features = false, git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
 
 [dev-dependencies]
 hex = "0.4"
-pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-pallet-staking-reward-curve = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-prml-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-substrate-test-utils = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
+pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+pallet-staking-reward-curve = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+prml-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+substrate-test-utils = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
 
 [features]
 migrate = []

--- a/crml/sylo/Cargo.toml
+++ b/crml/sylo/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 [dependencies]
 codec = { version = "1.3.5", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", default-features = false }
-frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false, optional = true }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
+frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false, optional = true }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
 
 [features]
 default = ["std"]

--- a/crml/transaction-payment/Cargo.toml
+++ b/crml/transaction-payment/Cargo.toml
@@ -10,20 +10,20 @@ description = "CENNZnet pallet to manage transaction payments"
 codec = { version = "1.3.5", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
 cennznet-primitives = { path = "../../primitives", default-features = false }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
 smallvec = "1.4.1"
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1", default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
-sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
+pallet-balances = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
+sp-io = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
 
 [features]
 default = ["std"]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,10 +7,10 @@ repository = "https://github.com/cennznet/cennznet"
 
 [dependencies]
 codec = { version = "1.3.5", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
 
 [features]
 default = ["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 cennznet-cli = { path = "../cli", default-features = false }
-sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
+sp-keyring = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
 wabt = "0.9.1"
 
 [dependencies]
@@ -19,57 +19,57 @@ codec = { package = "parity-scale-codec", version = "1.3.5", default-features = 
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 smallvec = "1.4.1"
 
-pallet-authorship = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-babe = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-finality-tracker = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-grandpa = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-identity = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-multisig = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-offences = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-randomness-collective-flip = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-treasury = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-scheduler = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-session = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2", features = ["historical"] }
-pallet-sudo = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-utility = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
+pallet-authorship = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-authority-discovery = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-babe = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-finality-tracker = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-grandpa = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-identity = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-im-online = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-multisig = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-offences = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-randomness-collective-flip = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-treasury = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-scheduler = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-session = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1", features = ["historical"] }
+pallet-sudo = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-timestamp = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-utility = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
 
-frame-executive = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
+frame-executive = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+frame-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+frame-system = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
 
-sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-authority-discovery = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2"}
-sp-block-builder = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2"}
-sp-consensus-babe = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-inherents = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-io = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-offchain = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-runtime-interface = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-session = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-version = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-sp-staking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
+sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-authority-discovery = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1"}
+sp-block-builder = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1"}
+sp-consensus-babe = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-inherents = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-io = {  git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-offchain = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-runtime-interface = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-session = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-transaction-pool = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-version = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+sp-staking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
 
-prml-attestation = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-prml-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-prml-generic-asset-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-prml-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
+prml-attestation = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+prml-generic-asset = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+prml-generic-asset-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+prml-support = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
 
 futures = { version = "0.3.1", features = ["compat"] }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2" }
+frame-system-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1" }
 
 # Used for runtime benchmarking
-frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2", optional = true }
-frame-system-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "2.0.2", optional = true }
+frame-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1", optional = true }
+frame-system-benchmarking = { git = "https://github.com/plugblockchain/plug-blockchain", default-features = false, rev = "hotfix-2.0.2-1", optional = true }
 hex-literal = { version = "0.3.1", optional = true }
 
 cennznet-primitives = { path = "../primitives", default-features = false }
@@ -80,7 +80,7 @@ crml-sylo = { path = "../crml/sylo", default-features = false}
 crml-transaction-payment = { path = "../crml/transaction-payment", default-features = false}
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/plugblockchain/plug-blockchain", rev = "hotfix-2.0.2-1" }
 
 [features]
 default = ["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-runtime"
-version = "1.2.0"
+version = "1.2.0-hotfix.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
Fix JSON-RPC for `@polkadot/rpc-provider@1.2.1`
Intended as a hotfix for 1.2.0 until the upgrade to v37 runtime.

--
Ignore GH actions changes, they're to fix the release behaviour when target branch is a `release/*` branch