### PR TITLE
Prerelease/1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,14 +646,14 @@ dependencies = [
 
 [[package]]
 name = "cennznet"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "cennznet-cli",
 ]
 
 [[package]]
 name = "cennznet-cli"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "cennznet-primitives",
  "cennznet-runtime",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "cennznet-runtime"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "cennznet-cli",
  "cennznet-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "cli/src/main.rs"
 
 [package]
 name = "cennznet"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM debian:stretch-slim
 LABEL maintainer="support@centrality.ai"
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates openssl && \
+    apt-get install -y ca-certificates openssl curl && \
     mkdir -p /root/.local/share/cennznet && \
     ln -s /root/.local/share/cennznet /data
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Now you can proceed to the terminal with the following command:
 # Start a local validator on a development chain
 $ docker run \
     -p 9933:9933 -p 9944:9944 \
-    cennznet/cennznet:1.2.2 \
+    cennznet/cennznet:1.2.3 \
     --dev \
     --unsafe-ws-external \
     --unsafe-rpc-external \

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-cli"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "CENNZnet node implementation in Rust."
 build = "build.rs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   node-0:
-    image: cennznet/cennznet:1.2.2
+    image: cennznet/cennznet:1.2.3
     volumes:
     - ./data/node-0:/mnt/data
     command:
@@ -19,7 +19,7 @@ services:
       - "9944:9944"
       - "30334:30333"
   node-1:
-    image: cennznet/cennznet:1.2.2
+    image: cennznet/cennznet:1.2.3
     volumes:
     - ./data/node-1:/mnt/data
     command:
@@ -33,7 +33,7 @@ services:
     ports:
       - "30335:30333"
   node-2:
-    image: cennznet/cennznet:1.2.2
+    image: cennznet/cennznet:1.2.3
     volumes:
     - ./data/node-2:/mnt/data
     command:
@@ -47,7 +47,7 @@ services:
     ports:
       - "30336:30333"
   node-3:
-    image: cennznet/cennznet:1.2.2
+    image: cennznet/cennznet:1.2.3
     volumes:
     - ./data/node-3:/mnt/data
     command:
@@ -61,7 +61,7 @@ services:
     ports:
       - "30337:30333"
   node-4:
-    image: cennznet/cennznet:1.2.2
+    image: cennznet/cennznet:1.2.3
     volumes:
     - ./data/node-4:/mnt/data
     command:
@@ -75,7 +75,7 @@ services:
     ports:
       - "30338:30333"
   node-5:
-    image: cennznet/cennznet:1.2.2
+    image: cennznet/cennznet:1.2.3
     volumes:
     - ./data/node-5:/mnt/data
     command:

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-runtime"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,8 +111,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set `impl_version` to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave `spec_version` as
 	// is and increment `impl_version`.
-	spec_version: 37,
-	impl_version: 37,
+	spec_version: 38,
+	impl_version: 38,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,
 };


### PR DESCRIPTION
release with new 👴 rpc
bumped runtime to v38 since some staking changes are included also
added curl to dockerfile as requested by @maochuanli 