### PR TITLE
Move benchmark files to the right destination

### DIFF
--- a/scripts/use-benchmark-results.sh
+++ b/scripts/use-benchmark-results.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo Utilising benchmark results...
+mv *.rs "runtime/src/weights/"


### PR DESCRIPTION
NOTE: This may look too simple to warrant an individual script for the current structure. However with 2.0, every result should go to their own folders while being touched to include the trait definition too. For example later we need to change this script to move "crml_cennzx.rs" to "crml/cennzx/src/weights" while adding the following snippet to the produced file:
`pub trait WeightInfo {
	fn buy_asset() -> Weight;
	fn sell_asset() -> Weight;
	fn add_liquidity() -> Weight;
	fn remove_liquidity() -> Weight;
	fn set_fee_rate() -> Weight;
}`