### PR TITLE
Include benchmarking host functions

### DIFF
--- a/cli/src/service.rs
+++ b/cli/src/service.rs
@@ -35,18 +35,6 @@ use crate::rpc as node_rpc;
 use cennznet_primitives::types::Block;
 use cennznet_runtime::RuntimeApi;
 
-// CENNZnet native executor instance.
-#[cfg(not(feature = "runtime-benchmarks"))]
-native_executor_instance!(
-	pub Executor,
-	cennznet_runtime::api::dispatch,
-	cennznet_runtime::native_version,
-	(
-		cennznet_runtime::legacy_host_functions::storage::HostFunctions,
-	),
-);
-// CENNZnet native executor instance with benchmarking
-#[cfg(feature = "runtime-benchmarks")]
 native_executor_instance!(
 	pub Executor,
 	cennznet_runtime::api::dispatch,


### PR DESCRIPTION
The cofiguration which doesn't have the benchmarking host function deos not work in 2.0 any more and throws: `Cannot create a runtime: Instantiation("Instantiation: Export ext_benchmarking_commit_db_version_1 not found") ` So I'm removing it.