### PR TITLE
NFT updates

### DIFF
--- a/crml/nft/src/benchmarking.rs
+++ b/crml/nft/src/benchmarking.rs
@@ -148,7 +148,7 @@ benchmarks! {
 		assert!(<Nft<T>>::token_attributes(&collection_id, token_id).is_empty());
 	}
 
-	direct_sale {
+	sell {
 		let owner: T::AccountId = account("owner", 0, 0);
 		let collection_id = setup_token::<T>(owner.clone());
 		let token_id = T::TokenId::from(0_u32);
@@ -160,7 +160,7 @@ benchmarks! {
 		assert!(<Nft<T>>::listings(&collection_id, token_id).is_some());
 	}
 
-	direct_purchase {
+	buy {
 		let owner: T::AccountId = account("owner", 0, 0);
 		let buyer: T::AccountId = account("buyer", 0, 0);
 		let collection_id = setup_token::<T>(owner.clone());
@@ -168,7 +168,7 @@ benchmarks! {
 		let payment_asset = 16_000;
 		let price = 1_000_000 * 10_000; // 1 million 4dp asset
 		let _ = T::MultiCurrency::deposit_creating(&buyer, Some(payment_asset), price);
-		let _ = <Nft<T>>::direct_sale(RawOrigin::Signed(owner.clone()).into(), collection_id.clone(), token_id, Some(buyer.clone()), payment_asset, price, None).expect("listed ok");
+		let _ = <Nft<T>>::sell(RawOrigin::Signed(owner.clone()).into(), collection_id.clone(), token_id, Some(buyer.clone()), payment_asset, price, None).expect("listed ok");
 
 		// Add some tokens to stress test the ownership transfer process
 		for fake_token_id in 1..1000_u32 {
@@ -285,16 +285,16 @@ mod tests {
 	}
 
 	#[test]
-	fn direct_sale() {
+	fn sell() {
 		ExtBuilder::default().build().execute_with(|| {
-			assert_ok!(test_benchmark_direct_sale::<Test>());
+			assert_ok!(test_benchmark_sell::<Test>());
 		});
 	}
 
 	#[test]
-	fn direct_purchase() {
+	fn buy() {
 		ExtBuilder::default().build().execute_with(|| {
-			assert_ok!(test_benchmark_direct_purchase::<Test>());
+			assert_ok!(test_benchmark_buy::<Test>());
 		});
 	}
 

--- a/crml/nft/src/default_weights.rs
+++ b/crml/nft/src/default_weights.rs
@@ -34,12 +34,12 @@ impl crate::WeightInfo for () {
 			.saturating_add(DbWeight::get().reads(6 as Weight))
 			.saturating_add(DbWeight::get().writes(4 as Weight))
 	}
-	fn direct_sale() -> Weight {
+	fn sell() -> Weight {
 		(69_000_000 as Weight)
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
-	fn direct_purchase() -> Weight {
+	fn buy() -> Weight {
 		(329_000_000 as Weight)
 			.saturating_add(DbWeight::get().reads(12 as Weight))
 			.saturating_add(DbWeight::get().writes(10 as Weight))

--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -226,10 +226,17 @@ decl_module! {
 		/// Create a new NFT collection
 		/// The caller will be come the collection' owner
 		/// `collection_id`- 32 byte utf-8 string
-		/// `schema` - for the collection
+		/// `schema` - onchain attributes for tokens in this collection
+		/// `metdata_uri` - offchain metadata uri for tokens in this collection
 		/// `royalties_schedule` - defacto royalties plan for secondary sales, this will apply to all tokens in the collection by default.
 		#[weight = T::WeightInfo::create_collection()]
-		fn create_collection(origin, collection_id: CollectionId, schema: NFTSchema, metadata_uri: Option<MetadataURI>, royalties_schedule: Option<RoyaltiesSchedule<T::AccountId>>) -> DispatchResult {
+		fn create_collection(
+			origin,
+			collection_id: CollectionId,
+			schema: NFTSchema,
+			metadata_uri: Option<MetadataURI>,
+			royalties_schedule: Option<RoyaltiesSchedule<T::AccountId>>,
+		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
 
 			ensure!(!collection_id.is_empty() && collection_id.len() <= MAX_COLLECTION_ID_LENGTH as usize, Error::<T>::CollectionIdInvalid);

--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -122,8 +122,6 @@ decl_error! {
 		SchemaMismatch,
 		/// Provided attribute is not in the collection schema
 		UnknownAttribute,
-		/// The provided attributes or schema cannot be empty
-		SchemaEmpty,
 		/// The schema contains an invalid type
 		SchemaInvalid,
 		/// The schema contains a duplicate attribute name
@@ -238,7 +236,6 @@ decl_module! {
 			ensure!(core::str::from_utf8(&collection_id).is_ok(), Error::<T>::CollectionIdInvalid);
 			ensure!(!<CollectionOwner<T>>::contains_key(&collection_id), Error::<T>::CollectionIdExists);
 
-			ensure!(!schema.is_empty(), Error::<T>::SchemaEmpty);
 			ensure!(schema.len() <= MAX_SCHEMA_FIELDS as usize, Error::<T>::SchemaMaxAttributes);
 
 			let mut set = BTreeSet::new();
@@ -281,7 +278,6 @@ decl_module! {
 			ensure!(collection_owner.unwrap() == origin, Error::<T>::NoPermission);
 
 			// Quick `attributes` sanity checks
-			ensure!(!attributes.is_empty(), Error::<T>::SchemaEmpty);
 			ensure!(attributes.len() as u32 <= MAX_SCHEMA_FIELDS, Error::<T>::SchemaMaxAttributes);
 
 			// Check we can issue a new token

--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -69,8 +69,8 @@ pub trait WeightInfo {
 	fn create_token() -> Weight;
 	fn transfer() -> Weight;
 	fn burn() -> Weight;
-	fn direct_sale() -> Weight;
-	fn direct_purchase() -> Weight;
+	fn sell() -> Weight;
+	fn buy() -> Weight;
 	fn auction() -> Weight;
 	fn bid() -> Weight;
 	fn cancel_sale() -> Weight;
@@ -88,12 +88,12 @@ decl_event!(
 		Update(CollectionId, TokenId),
 		/// An NFT was burned
 		Burn(CollectionId, TokenId),
-		/// A direct sale has been listed (collection, token, authorised buyer, payment asset, fixed price)
-		DirectSaleListed(CollectionId, TokenId, Option<AccountId>, AssetId, Balance),
-		/// A direct sale has completed (collection, token, new owner, payment asset, fixed price)
-		DirectSaleComplete(CollectionId, TokenId, AccountId, AssetId, Balance),
-		/// A direct sale has closed without selling
-		DirectSaleClosed(CollectionId, TokenId),
+		/// A fixed price sale has been listed (collection, token, authorised buyer, payment asset, fixed price)
+		FixedPriceSaleListed(CollectionId, TokenId, Option<AccountId>, AssetId, Balance),
+		/// A fixed price sale has completed (collection, token, new owner, payment asset, fixed price)
+		FixedPriceSaleComplete(CollectionId, TokenId, AccountId, AssetId, Balance),
+		/// A fixed price sale has closed without selling
+		FixedPriceSaleClosed(CollectionId, TokenId),
 		/// An auction has opened (collection, token, payment asset, reserve price)
 		AuctionOpen(CollectionId, TokenId, AssetId, Balance),
 		/// An auction has sold (collection, token, payment asset, bid, new owner)
@@ -135,7 +135,7 @@ decl_error! {
 		/// The NFT does not exist
 		NoToken,
 		/// The NFT is not listed for a direct sale
-		NotForDirectSale,
+		NotForFixedPriceSale,
 		/// The NFT is not listed for auction sale
 		NotForAuction,
 		/// Cannot operate on a listed NFT
@@ -205,8 +205,8 @@ decl_module! {
 		/// Check and close all expired listings
 		fn on_initialize(now: T::BlockNumber) -> Weight {
 			let removed_count = Self::close_listings_at(now);
-			// 'direct_purchase' weight is comparable to succesful closure of an auction
-			T::WeightInfo::direct_purchase() * removed_count as Weight
+			// 'buy' weight is comparable to succesful closure of an auction
+			T::WeightInfo::buy() * removed_count as Weight
 		}
 
 		/// Set the owner of a collection
@@ -361,14 +361,14 @@ decl_module! {
 			Self::deposit_event(RawEvent::Burn(collection_id, token_id));
 		}
 
-		/// Sell an NFT to specific account at a fixed price
+		/// Sell an NFT at a fixed price
 		/// `buyer` optionally, the account to receive the NFT. If unspecified, then any account may purchase
 		/// `asset_id` fungible asset Id to receive as payment for the NFT
 		/// `fixed_price` ask price
 		/// `duration` listing duration time in blocks
 		/// Caller must be the token owner
-		#[weight = T::WeightInfo::direct_sale()]
-		fn direct_sale(origin, collection_id: CollectionId, token_id: T::TokenId, buyer: Option<T::AccountId>, payment_asset: AssetId, fixed_price: Balance, duration: Option<T::BlockNumber>) {
+		#[weight = T::WeightInfo::sell()]
+		fn sell(origin, collection_id: CollectionId, token_id: T::TokenId, buyer: Option<T::AccountId>, payment_asset: AssetId, fixed_price: Balance, duration: Option<T::BlockNumber>) {
 			let origin = ensure_signed(origin)?;
 			let current_owner = Self::token_owner(&collection_id, token_id);
 			ensure!(current_owner == origin, Error::<T>::NoPermission);
@@ -377,8 +377,8 @@ decl_module! {
 
 			let listing_end_block = <frame_system::Module<T>>::block_number().saturating_add(duration.unwrap_or_else(T::DefaultListingDuration::get));
 			ListingEndSchedule::<T>::insert(listing_end_block, &(collection_id.clone(), token_id), ());
-			let listing = Listing::<T>::DirectSale(
-				DirectSaleListing::<T> {
+			let listing = Listing::<T>::FixedPriceSale(
+				FixedPriceSaleListing::<T> {
 					payment_asset,
 					fixed_price,
 					close: listing_end_block,
@@ -386,17 +386,17 @@ decl_module! {
 				}
 			);
 			Listings::insert(&collection_id, token_id, listing);
-			Self::deposit_event(RawEvent::DirectSaleListed(collection_id, token_id, buyer, payment_asset, fixed_price));
+			Self::deposit_event(RawEvent::FixedPriceSaleListed(collection_id, token_id, buyer, payment_asset, fixed_price));
 		}
 
 		/// Buy an NFT for its listed price, must be listed for sale
-		#[weight = T::WeightInfo::direct_purchase()]
+		#[weight = T::WeightInfo::buy()]
 		#[transactional]
-		fn direct_purchase(origin, collection_id: CollectionId, token_id: T::TokenId) {
+		fn buy(origin, collection_id: CollectionId, token_id: T::TokenId) {
 			let origin = ensure_signed(origin)?;
-			ensure!(<Listings<T>>::contains_key(&collection_id, token_id), Error::<T>::NotForDirectSale);
+			ensure!(<Listings<T>>::contains_key(&collection_id, token_id), Error::<T>::NotForFixedPriceSale);
 
-			if let Some(Listing::DirectSale(listing)) = Self::listings(&collection_id, token_id) {
+			if let Some(Listing::FixedPriceSale(listing)) = Self::listings(&collection_id, token_id) {
 
 				// if buyer is specified in the listing, then `origin` must be buyer
 				if let Some(buyer) = listing.buyer {
@@ -430,10 +430,10 @@ decl_module! {
 
 				// must not fail now that payment has been made
 				<TokenOwner<T>>::insert(&collection_id, token_id, &origin);
-				Self::remove_direct_listing(&collection_id, token_id);
-				Self::deposit_event(RawEvent::DirectSaleComplete(collection_id, token_id, origin, listing.payment_asset, listing.fixed_price));
+				Self::remove_fixed_price_listing(&collection_id, token_id);
+				Self::deposit_event(RawEvent::FixedPriceSaleComplete(collection_id, token_id, origin, listing.payment_asset, listing.fixed_price));
 			} else {
-				return Err(Error::<T>::NotForDirectSale.into());
+				return Err(Error::<T>::NotForFixedPriceSale.into());
 			}
 		}
 
@@ -516,10 +516,10 @@ decl_module! {
 			ensure!(current_owner == origin, Error::<T>::NoPermission);
 
 			match Self::listings(&collection_id, token_id) {
-				Some(Listing::<T>::DirectSale(sale)) => {
+				Some(Listing::<T>::FixedPriceSale(sale)) => {
 					Listings::<T>::remove(&collection_id, token_id);
 					ListingEndSchedule::<T>::remove(sale.close, &(collection_id.clone(), token_id));
-					Self::deposit_event(RawEvent::DirectSaleClosed(collection_id, token_id));
+					Self::deposit_event(RawEvent::FixedPriceSaleClosed(collection_id, token_id));
 				},
 				Some(Listing::<T>::Auction(auction)) => {
 					ensure!(Self::listing_winning_bid(&collection_id, token_id).is_none(), Error::<T>::TokenListingProtection);
@@ -550,11 +550,11 @@ impl<T: Trait> Module<T> {
 			)
 			.collect()
 	}
-	/// Remove a single direct listing and all it's metadata
-	fn remove_direct_listing(collection_id: &[u8], token_id: T::TokenId) {
+	/// Remove a single fixed price listing and all it's metadata
+	fn remove_fixed_price_listing(collection_id: &[u8], token_id: T::TokenId) {
 		let listing_type = Listings::<T>::take(collection_id, token_id);
 		ListingWinningBid::<T>::remove(collection_id, token_id);
-		if let Some(Listing::<T>::DirectSale(listing)) = listing_type {
+		if let Some(Listing::<T>::FixedPriceSale(listing)) = listing_type {
 			ListingEndSchedule::<T>::remove(listing.close, &(collection_id.to_vec(), token_id));
 		}
 	}
@@ -565,8 +565,8 @@ impl<T: Trait> Module<T> {
 		let mut removed = 0_u32;
 		for ((collection_id, token_id), _) in ListingEndSchedule::<T>::drain_prefix(now).into_iter() {
 			match Listings::<T>::take(&collection_id, token_id) {
-				Some(Listing::DirectSale(_)) => {
-					Self::deposit_event(RawEvent::DirectSaleClosed(collection_id.clone(), token_id));
+				Some(Listing::FixedPriceSale(_)) => {
+					Self::deposit_event(RawEvent::FixedPriceSaleClosed(collection_id.clone(), token_id));
 				}
 				Some(Listing::Auction(listing)) => {
 					if let Some((winner, hammer_price)) = ListingWinningBid::<T>::take(&collection_id, token_id) {

--- a/crml/nft/src/tests.rs
+++ b/crml/nft/src/tests.rs
@@ -828,7 +828,10 @@ fn cancel_sell() {
 			collection_id.clone(),
 			token_id,
 		));
-		assert!(has_event(RawEvent::FixedPriceSaleClosed(collection_id.clone(), token_id)));
+		assert!(has_event(RawEvent::FixedPriceSaleClosed(
+			collection_id.clone(),
+			token_id
+		)));
 
 		// storage cleared up
 		assert!(Nft::listings(&collection_id, token_id).is_none());

--- a/crml/nft/src/tests.rs
+++ b/crml/nft/src/tests.rs
@@ -613,7 +613,7 @@ fn transfer_fails_prechecks() {
 			Error::<Test>::NoPermission,
 		);
 
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -697,7 +697,7 @@ fn burn_fails_prechecks() {
 			Error::<Test>::NoPermission,
 		);
 
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -715,10 +715,10 @@ fn burn_fails_prechecks() {
 }
 
 #[test]
-fn direct_sale() {
+fn sell() {
 	ExtBuilder::default().build().execute_with(|| {
 		let (collection_id, token_id, token_owner) = setup_token();
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -728,7 +728,7 @@ fn direct_sale() {
 			None,
 		));
 
-		let expected = Listing::<Test>::DirectSale(DirectSaleListing::<Test> {
+		let expected = Listing::<Test>::FixedPrice(FixedPriceListing::<Test> {
 			payment_asset: 16_000,
 			fixed_price: 1_000,
 			close: System::block_number() + <Test as Trait>::DefaultListingDuration::get(),
@@ -745,7 +745,7 @@ fn direct_sale() {
 		)
 		.is_some());
 
-		assert!(has_event(RawEvent::DirectSaleListed(
+		assert!(has_event(RawEvent::FixedPriceListed(
 			collection_id,
 			token_id,
 			Some(5),
@@ -756,12 +756,12 @@ fn direct_sale() {
 }
 
 #[test]
-fn direct_sale_prechecks() {
+fn sell_prechecks() {
 	ExtBuilder::default().build().execute_with(|| {
 		let (collection_id, token_id, token_owner) = setup_token();
 		// no permission
 		assert_noop!(
-			Nft::direct_sale(
+			Nft::sell(
 				Some(token_owner + 1).into(),
 				collection_id.clone(),
 				token_id,
@@ -773,7 +773,7 @@ fn direct_sale_prechecks() {
 			Error::<Test>::NoPermission
 		);
 		// token listed already
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -783,7 +783,7 @@ fn direct_sale_prechecks() {
 			None,
 		));
 		assert_noop!(
-			Nft::direct_sale(
+			Nft::sell(
 				Some(token_owner).into(),
 				collection_id.clone(),
 				token_id,
@@ -795,7 +795,7 @@ fn direct_sale_prechecks() {
 			Error::<Test>::TokenListingProtection
 		);
 
-		// can't auction, listed for direct sale
+		// can't auction, listed for fixed price sale
 		assert_noop!(
 			Nft::auction(
 				Some(token_owner).into(),
@@ -811,10 +811,10 @@ fn direct_sale_prechecks() {
 }
 
 #[test]
-fn cancel_direct_sale() {
+fn cancel_sell() {
 	ExtBuilder::default().build().execute_with(|| {
 		let (collection_id, token_id, token_owner) = setup_token();
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -828,7 +828,7 @@ fn cancel_direct_sale() {
 			collection_id.clone(),
 			token_id,
 		));
-		assert!(has_event(RawEvent::DirectSaleClosed(collection_id.clone(), token_id)));
+		assert!(has_event(RawEvent::FixedPriceClosed(collection_id.clone(), token_id)));
 
 		// storage cleared up
 		assert!(Nft::listings(&collection_id, token_id).is_none());
@@ -849,11 +849,11 @@ fn cancel_direct_sale() {
 }
 
 #[test]
-fn direct_sale_closes_on_schedule() {
+fn sell_closes_on_schedule() {
 	ExtBuilder::default().build().execute_with(|| {
 		let (collection_id, token_id, token_owner) = setup_token();
 		let listing_duration = 100;
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -886,14 +886,14 @@ fn direct_sale_closes_on_schedule() {
 }
 
 #[test]
-fn direct_purchase() {
+fn buy() {
 	ExtBuilder::default().build().execute_with(|| {
 		let (collection_id, token_id, token_owner) = setup_token();
 		let buyer = 5;
 		let payment_asset = 16_000;
 		let price = 1_000;
 
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -904,11 +904,7 @@ fn direct_purchase() {
 		));
 
 		let _ = <Test as Trait>::MultiCurrency::deposit_creating(&buyer, Some(payment_asset), price);
-		assert_ok!(Nft::direct_purchase(
-			Some(buyer).into(),
-			collection_id.clone(),
-			token_id
-		));
+		assert_ok!(Nft::buy(Some(buyer).into(), collection_id.clone(), token_id));
 		// no royalties, all proceeds to token owner
 		assert_eq!(GenericAsset::free_balance(payment_asset, &token_owner), price,);
 
@@ -927,7 +923,7 @@ fn direct_purchase() {
 }
 
 #[test]
-fn direct_purchase_with_bespoke_token_royalties() {
+fn buy_with_bespoke_token_royalties() {
 	ExtBuilder::default().build().execute_with(|| {
 		let collection_owner = 1;
 		let beneficiary_1 = 11;
@@ -944,7 +940,7 @@ fn direct_purchase_with_bespoke_token_royalties() {
 		let payment_asset = 16_000;
 		let sale_price = 1_000_004;
 
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -955,11 +951,7 @@ fn direct_purchase_with_bespoke_token_royalties() {
 		));
 
 		let _ = <Test as Trait>::MultiCurrency::deposit_creating(&buyer, Some(payment_asset), sale_price);
-		assert_ok!(Nft::direct_purchase(
-			Some(buyer).into(),
-			collection_id.clone(),
-			token_id
-		));
+		assert_ok!(Nft::buy(Some(buyer).into(), collection_id.clone(), token_id));
 		let presale_issuance = GenericAsset::total_issuance(payment_asset);
 		// royalties distributed according to `entitlements` map
 		assert_eq!(
@@ -1001,7 +993,7 @@ fn direct_purchase_with_bespoke_token_royalties() {
 }
 
 #[test]
-fn direct_purchase_with_collection_royalties() {
+fn buy_with_collection_royalties() {
 	ExtBuilder::default().build().execute_with(|| {
 		let beneficiary_1 = 11;
 		let beneficiary_2 = 12;
@@ -1018,7 +1010,7 @@ fn direct_purchase_with_collection_royalties() {
 		let payment_asset = 16_000;
 		let sale_price = 1_000;
 
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -1029,11 +1021,7 @@ fn direct_purchase_with_collection_royalties() {
 		));
 
 		let _ = <Test as Trait>::MultiCurrency::deposit_creating(&buyer, Some(payment_asset), sale_price);
-		assert_ok!(Nft::direct_purchase(
-			Some(buyer).into(),
-			collection_id.clone(),
-			token_id
-		));
+		assert_ok!(Nft::buy(Some(buyer).into(), collection_id.clone(), token_id));
 		let presale_issuance = GenericAsset::total_issuance(payment_asset);
 		let for_royalties = royalties_schedule.calculate_total_entitlement() * sale_price;
 		// token owner gets sale price less royalties
@@ -1071,7 +1059,7 @@ fn direct_purchase_with_collection_royalties() {
 }
 
 #[test]
-fn direct_purchase_fails_prechecks() {
+fn buy_fails_prechecks() {
 	ExtBuilder::default().build().execute_with(|| {
 		let (collection_id, token_id, token_owner) = setup_token();
 		let buyer = 5;
@@ -1080,11 +1068,11 @@ fn direct_purchase_fails_prechecks() {
 
 		// not for sale
 		assert_noop!(
-			Nft::direct_purchase(Some(buyer).into(), collection_id.clone(), token_id),
-			Error::<Test>::NotForDirectSale,
+			Nft::buy(Some(buyer).into(), collection_id.clone(), token_id),
+			Error::<Test>::NotForFixedPrice,
 		);
 
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -1096,27 +1084,27 @@ fn direct_purchase_fails_prechecks() {
 
 		// no permission
 		assert_noop!(
-			Nft::direct_purchase(Some(buyer + 1).into(), collection_id.clone(), token_id),
+			Nft::buy(Some(buyer + 1).into(), collection_id.clone(), token_id),
 			Error::<Test>::NoPermission,
 		);
 
 		// fund the buyer with not quite enough
 		let _ = <Test as Trait>::MultiCurrency::deposit_creating(&buyer, Some(payment_asset), price - 1);
 		assert_noop!(
-			Nft::direct_purchase(Some(buyer).into(), collection_id.clone(), token_id),
+			Nft::buy(Some(buyer).into(), collection_id.clone(), token_id),
 			prml_generic_asset::Error::<Test>::InsufficientBalance,
 		);
 	});
 }
 
 #[test]
-fn direct_listing_for_anybody() {
+fn sell_to_anybody() {
 	ExtBuilder::default().build().execute_with(|| {
 		let (collection_id, token_id, token_owner) = setup_token();
 		let payment_asset = 16_000;
 		let price = 1_000;
 
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -1128,11 +1116,7 @@ fn direct_listing_for_anybody() {
 
 		let buyer = 11;
 		let _ = <Test as Trait>::MultiCurrency::deposit_creating(&buyer, Some(payment_asset), price);
-		assert_ok!(Nft::direct_purchase(
-			Some(buyer).into(),
-			collection_id.clone(),
-			token_id
-		));
+		assert_ok!(Nft::buy(Some(buyer).into(), collection_id.clone(), token_id));
 
 		// paid
 		assert!(GenericAsset::free_balance(payment_asset, &buyer).is_zero());
@@ -1152,7 +1136,7 @@ fn direct_listing_for_anybody() {
 }
 
 #[test]
-fn direct_purchase_with_overcommitted_royalties() {
+fn buy_with_overcommitted_royalties() {
 	ExtBuilder::default().build().execute_with(|| {
 		// royalties are > 100% total which could create funds out of nothing
 		// in this case, default to 0 royalties.
@@ -1169,7 +1153,7 @@ fn direct_purchase_with_overcommitted_royalties() {
 		let buyer = 5;
 		let payment_asset = 16_000;
 		let price = 1_000;
-		assert_ok!(Nft::direct_sale(
+		assert_ok!(Nft::sell(
 			Some(token_owner).into(),
 			collection_id.clone(),
 			token_id,
@@ -1182,11 +1166,7 @@ fn direct_purchase_with_overcommitted_royalties() {
 		let _ = <Test as Trait>::MultiCurrency::deposit_creating(&buyer, Some(payment_asset), price);
 		let presale_issuance = GenericAsset::total_issuance(payment_asset);
 
-		assert_ok!(Nft::direct_purchase(
-			Some(buyer).into(),
-			collection_id.clone(),
-			token_id
-		));
+		assert_ok!(Nft::buy(Some(buyer).into(), collection_id.clone(), token_id));
 
 		assert!(bad_schedule.calculate_total_entitlement().is_zero());
 		assert_eq!(GenericAsset::free_balance(payment_asset, &token_owner), price);
@@ -1405,7 +1385,7 @@ fn close_listings_at_removes_listing_data() {
 		let price = 123_456;
 		let listings = vec![
 			// an open sale which won't be bought before closing
-			Listing::<Test>::DirectSale(DirectSaleListing::<Test> {
+			Listing::<Test>::FixedPrice(FixedPriceListing::<Test> {
 				payment_asset,
 				fixed_price: price,
 				buyer: None,
@@ -1448,7 +1428,7 @@ fn close_listings_at_removes_listing_data() {
 			assert!(Nft::listing_end_schedule(System::block_number() + 1, (collection_id.clone(), i as u32)).is_none());
 		}
 
-		assert!(has_event(RawEvent::DirectSaleClosed(collection_id.clone(), 0)));
+		assert!(has_event(RawEvent::FixedPriceClosed(collection_id.clone(), 0)));
 		assert!(has_event(RawEvent::AuctionClosed(
 			collection_id.clone(),
 			1,
@@ -1532,7 +1512,7 @@ fn auction_fails_prechecks() {
 
 		// listed for auction
 		assert_noop!(
-			Nft::direct_sale(
+			Nft::sell(
 				Some(token_owner).into(),
 				collection_id.clone(),
 				token_id,

--- a/crml/nft/src/tests.rs
+++ b/crml/nft/src/tests.rs
@@ -745,7 +745,7 @@ fn sell() {
 		)
 		.is_some());
 
-		assert!(has_event(RawEvent::FixedPriceListed(
+		assert!(has_event(RawEvent::FixedPriceSaleListed(
 			collection_id,
 			token_id,
 			Some(5),
@@ -828,7 +828,7 @@ fn cancel_sell() {
 			collection_id.clone(),
 			token_id,
 		));
-		assert!(has_event(RawEvent::FixedPriceClosed(collection_id.clone(), token_id)));
+		assert!(has_event(RawEvent::FixedPriceSaleClosed(collection_id.clone(), token_id)));
 
 		// storage cleared up
 		assert!(Nft::listings(&collection_id, token_id).is_none());
@@ -1069,7 +1069,7 @@ fn buy_fails_prechecks() {
 		// not for sale
 		assert_noop!(
 			Nft::buy(Some(buyer).into(), collection_id.clone(), token_id),
-			Error::<Test>::NotForFixedPrice,
+			Error::<Test>::NotForFixedPriceSale,
 		);
 
 		assert_ok!(Nft::sell(
@@ -1428,7 +1428,7 @@ fn close_listings_at_removes_listing_data() {
 			assert!(Nft::listing_end_schedule(System::block_number() + 1, (collection_id.clone(), i as u32)).is_none());
 		}
 
-		assert!(has_event(RawEvent::FixedPriceClosed(collection_id.clone(), 0)));
+		assert!(has_event(RawEvent::FixedPriceSaleClosed(collection_id.clone(), 0)));
 		assert!(has_event(RawEvent::AuctionClosed(
 			collection_id.clone(),
 			1,

--- a/crml/nft/src/tests.rs
+++ b/crml/nft/src/tests.rs
@@ -180,10 +180,6 @@ fn create_collection() {
 fn create_collection_invalid_schema() {
 	ExtBuilder::default().build().execute_with(|| {
 		let collection_id = b"test-collection".to_vec();
-		assert_noop!(
-			Nft::create_collection(Some(1_u64).into(), collection_id.clone(), vec![], None, None),
-			Error::<Test>::SchemaEmpty
-		);
 
 		// duplciate attribute names in schema
 		assert_noop!(
@@ -451,17 +447,6 @@ fn create_token_fails_prechecks() {
 				None
 			),
 			Error::<Test>::NoCollection
-		);
-
-		assert_noop!(
-			Nft::create_token(
-				Some(collection_owner).into(),
-				collection_id.clone(),
-				collection_owner,
-				vec![],
-				None
-			),
-			Error::<Test>::SchemaEmpty
 		);
 
 		// additional attribute vs. schema

--- a/crml/nft/src/types.rs
+++ b/crml/nft/src/types.rs
@@ -154,7 +154,7 @@ impl<AccountId> RoyaltiesSchedule<AccountId> {
 /// A type of NFT sale listing
 #[derive(Debug, Clone, Encode, Decode, PartialEq)]
 pub enum Listing<T: Trait> {
-	DirectSale(DirectSaleListing<T>),
+	FixedPrice(FixedPriceListing<T>),
 	Auction(AuctionListing<T>),
 }
 
@@ -171,7 +171,7 @@ pub struct AuctionListing<T: Trait> {
 
 /// Information about a fixed price listing
 #[derive(Debug, Clone, Encode, Decode, PartialEq)]
-pub struct DirectSaleListing<T: Trait> {
+pub struct FixedPriceListing<T: Trait> {
 	/// The asset to allow bids with
 	pub payment_asset: <<T as Trait>::MultiCurrency as MultiCurrencyAccounting>::CurrencyId,
 	/// The requested amount for a succesful sale

--- a/runtime/src/weights/crml_nft.rs
+++ b/runtime/src/weights/crml_nft.rs
@@ -35,12 +35,12 @@ impl<T: frame_system::Trait> crml_nft::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
-	fn direct_sale() -> Weight {
+	fn sell() -> Weight {
 		(75_962_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
-	fn direct_purchase() -> Weight {
+	fn buy() -> Weight {
 		(411_437_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(9 as Weight))
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))


### PR DESCRIPTION
1) Allow empty onchain schema/attributes
Allows tokens to exist where all attributes are off-chain and it's just a representation of ownership onchain

2) Renames (more familiar naming)
- `direct sale` -> `sell`
- `direct_purchase` -> `buy`
- `DirectSale/Listing*` events -> `FixedPriceSale/Listing`
