### PR TITLE
Fixed rust version in scripts/init.sh

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-nightly_version=nightly-2020-06-25
+nightly_version=nightly-2021-02-21
 
 echo Installing the stable Rust toolchain...
 rustup install stable


### PR DESCRIPTION
Changed the rust version to match the one in the docker file 
https://github.com/cennznet/cennznet/blob/2063609970853d2fd0f353056bfeb6000ead3b96/Dockerfile#L6

This is something we should look at making a seperate constant or some other way to make sure they don't get out of sync