### PR TITLE
Auto Extend Auction

### DIFF
--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -763,7 +763,6 @@ decl_module! {
 					ListingEndSchedule::<T>::remove(listing_end_block, listing_id);
 					ListingEndSchedule::<T>::insert(new_closing_block, listing_id, true);
 					listing.close = new_closing_block;
-					Listings::<T>::remove(listing_id);
 					Listings::<T>::insert(listing_id, Listing::Auction(listing.clone()));
 				}
 

--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -725,7 +725,7 @@ decl_module! {
 		fn bid(origin, listing_id: ListingId, amount: Balance) {
 			let origin = ensure_signed(origin)?;
 
-			if let Some(Listing::Auction(listing)) = Self::listings(listing_id) {
+			if let Some(Listing::Auction(mut listing)) = Self::listings(listing_id) {
 				if let Some(current_bid) = Self::listing_winning_bid(listing_id) {
 					ensure!(amount > current_bid.1, Error::<T>::BidTooLow);
 				} else {
@@ -753,6 +753,19 @@ decl_module! {
 					}
 					*maybe_current_bid = Some((origin, amount))
 				});
+
+				// Auto extend auction if bid is made within certain amount of time of auction duration
+				let listing_end_block = listing.close;
+				let current_block = <frame_system::Module<T>>::block_number();
+				let blocks_till_close = listing_end_block - current_block;
+				let new_closing_block = current_block + T::BlockNumber::from(AUCTION_EXTENSION_PERIOD);
+				if blocks_till_close <= T::BlockNumber::from(AUCTION_EXTENSION_PERIOD) {
+					ListingEndSchedule::<T>::remove(listing_end_block, listing_id);
+					ListingEndSchedule::<T>::insert(new_closing_block, listing_id, true);
+					listing.close = new_closing_block;
+					Listings::<T>::remove(listing_id);
+					Listings::<T>::insert(listing_id, Listing::Auction(listing.clone()));
+				}
 
 				let listing_collection_id = listing.tokens[0].0;
 				Self::deposit_event(RawEvent::Bid(listing_collection_id, listing_id, amount));

--- a/crml/nft/src/tests.rs
+++ b/crml/nft/src/tests.rs
@@ -1071,7 +1071,7 @@ fn auction_bundle() {
 		let _ = <Test as Config>::MultiCurrency::deposit_creating(&buyer, PAYMENT_ASSET, 1_000);
 		assert_ok!(Nft::bid(Some(buyer).into(), listing_id, 1_000));
 		// end auction
-		let _ = Nft::on_initialize(System::block_number() + 1);
+		let _ = Nft::on_initialize(System::block_number() + 40);
 
 		assert_eq!(Nft::collected_tokens(collection_id, &buyer), tokens);
 	})
@@ -1160,7 +1160,7 @@ fn auction() {
 		assert_eq!(GenericAsset::reserved_balance(payment_asset, &bidder_2), winning_bid);
 
 		// end auction
-		let _ = Nft::on_initialize(System::block_number() + 1);
+		let _ = Nft::on_initialize(System::block_number() + 40);
 
 		// no royalties, all proceeds to token owner
 		assert_eq!(GenericAsset::free_balance(payment_asset, &token_owner), winning_bid);
@@ -1252,7 +1252,7 @@ fn auction_royalty_payments() {
 		assert_ok!(Nft::bid(Some(bidder).into(), listing_id, reserve_price,));
 
 		// end auction
-		let _ = Nft::on_initialize(System::block_number() + 1);
+		let _ = Nft::on_initialize(System::block_number() + 40);
 
 		// royalties paid out
 		let presale_issuance = GenericAsset::total_issuance(payment_asset);

--- a/crml/nft/src/tests.rs
+++ b/crml/nft/src/tests.rs
@@ -1071,7 +1071,7 @@ fn auction_bundle() {
 		let _ = <Test as Config>::MultiCurrency::deposit_creating(&buyer, PAYMENT_ASSET, 1_000);
 		assert_ok!(Nft::bid(Some(buyer).into(), listing_id, 1_000));
 		// end auction
-		let _ = Nft::on_initialize(System::block_number() + 40);
+		let _ = Nft::on_initialize(System::block_number() + AUCTION_EXTENSION_PERIOD as u64);
 
 		assert_eq!(Nft::collected_tokens(collection_id, &buyer), tokens);
 	})
@@ -1160,7 +1160,7 @@ fn auction() {
 		assert_eq!(GenericAsset::reserved_balance(payment_asset, &bidder_2), winning_bid);
 
 		// end auction
-		let _ = Nft::on_initialize(System::block_number() + 40);
+		let _ = Nft::on_initialize(System::block_number() + AUCTION_EXTENSION_PERIOD as u64);
 
 		// no royalties, all proceeds to token owner
 		assert_eq!(GenericAsset::free_balance(payment_asset, &token_owner), winning_bid);
@@ -1252,7 +1252,7 @@ fn auction_royalty_payments() {
 		assert_ok!(Nft::bid(Some(bidder).into(), listing_id, reserve_price,));
 
 		// end auction
-		let _ = Nft::on_initialize(System::block_number() + 40);
+		let _ = Nft::on_initialize(System::block_number() + AUCTION_EXTENSION_PERIOD as u64);
 
 		// royalties paid out
 		let presale_issuance = GenericAsset::total_issuance(payment_asset);

--- a/crml/nft/src/tests.rs
+++ b/crml/nft/src/tests.rs
@@ -1204,18 +1204,11 @@ fn bid_auto_extends() {
 			reserve_price,
 			Some(2),
 		));
-		assert_eq!(
-			Nft::token_locks(&token_id).unwrap(),
-			TokenLockReason::Listed(listing_id)
-		);
-		assert_eq!(Nft::next_listing_id(), listing_id + 1);
-		assert!(Nft::open_collection_listings(collection_id, listing_id));
 
-		// first bidder at reserve price
+		// Place bid
 		let bidder_1 = 10;
 		let _ = <Test as Config>::MultiCurrency::deposit_creating(&bidder_1, payment_asset, reserve_price);
 		assert_ok!(Nft::bid(Some(bidder_1).into(), listing_id, reserve_price,));
-		assert_eq!(GenericAsset::reserved_balance(payment_asset, &bidder_1), reserve_price);
 
 		if let Some(Listing::Auction(listing)) = Nft::listings(listing_id) {
 			assert_eq!(listing.close, System::block_number() + AUCTION_EXTENSION_PERIOD as u64);

--- a/crml/nft/src/types.rs
+++ b/crml/nft/src/types.rs
@@ -26,6 +26,9 @@ use sp_std::prelude::*;
 use cennznet_primitives::types::{AssetId, Balance, BlockNumber};
 use variant_count::VariantCount;
 
+// Time before auction ends that auction is extended if a bid is placed
+pub const AUCTION_EXTENSION_PERIOD: BlockNumber = 40;
+
 /// A base metadata URI string for a collection
 #[derive(Decode, Encode, Debug, Clone, PartialEq)]
 pub enum MetadataBaseURI {


### PR DESCRIPTION
closes #482 
Added auction auto extend to extend an auction  by 2 minutes if the last bid was made within 2 minutes of closing time.

2 minutes is what Trademe uses for their auto extend functionality.