### PR TITLE
Prerelease 2.0.0-rc5 + runtime v44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,14 +730,14 @@ dependencies = [
 
 [[package]]
 name = "cennznet"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "cennznet-cli",
 ]
 
 [[package]]
 name = "cennznet-cli"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "cennznet-primitives",
  "cennznet-runtime",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "cennznet-primitives"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "cennznet-runtime"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 dependencies = [
  "cennznet-cli",
  "cennznet-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "cli/src/main.rs"
 
 [package]
 name = "cennznet"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-cli"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "CENNZnet node implementation in Rust."
 build = "build.rs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: '3'
 services:
   node-0:
-    image: cennznet/cennznet:2.0.0-rc4
+    image: cennznet/cennznet:2.0.0-rc5
     volumes:
     - ./data/node-0:/mnt/data
     command:
@@ -25,7 +25,7 @@ services:
       - "9944:9944"
       - "30334:30333"
   node-1:
-    image: cennznet/cennznet:2.0.0-rc4
+    image: cennznet/cennznet:2.0.0-rc5
     volumes:
     - ./data/node-1:/mnt/data
     command:
@@ -41,7 +41,7 @@ services:
     ports:
       - "30335:30333"
   node-2:
-    image: cennznet/cennznet:2.0.0-rc4
+    image: cennznet/cennznet:2.0.0-rc5
     volumes:
     - ./data/node-2:/mnt/data
     command:
@@ -57,7 +57,7 @@ services:
     ports:
       - "30336:30333"
   node-3:
-    image: cennznet/cennznet:2.0.0-rc4
+    image: cennznet/cennznet:2.0.0-rc5
     volumes:
     - ./data/node-3:/mnt/data
     command:
@@ -73,7 +73,7 @@ services:
     ports:
       - "30337:30333"
   node-4:
-    image: cennznet/cennznet:2.0.0-rc4
+    image: cennznet/cennznet:2.0.0-rc5
     volumes:
     - ./data/node-4:/mnt/data
     command:
@@ -89,7 +89,7 @@ services:
     ports:
       - "30338:30333"
   node-5:
-    image: cennznet/cennznet:2.0.0-rc4
+    image: cennznet/cennznet:2.0.0-rc5
     volumes:
     - ./data/node-5:/mnt/data
     command:

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-primitives"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 repository = "https://github.com/cennznet/cennznet"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-runtime"
-version = "2.0.0-rc4"
+version = "2.0.0-rc5"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -128,8 +128,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set `impl_version` to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave `spec_version` as
 	// is and increment `impl_version`.
-	spec_version: 43,
-	impl_version: 43,
+	spec_version: 44,
+	impl_version: 44,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,
 };


### PR DESCRIPTION
Prerelease:
- Fixes for early notary key rotation
- NFT auctions auto-extend