### PR TITLE
Update NFT data model

### DIFF
--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -280,6 +280,7 @@ decl_module! {
 
 				#[allow(dead_code)]
 				mod v1_storage {
+					use sp_std::prelude::*;
 					use super::{Config, CollectionId, SeriesId};
 					use codec::{Encode, Decode};
 

--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -22,17 +22,14 @@
 //! to extend.
 //!
 //! *Collections*:
-//!  A name spacing tool for logical grouping of related tokens
-//!  Tokens within a collection can have the same royalties fees, metadata base URIs, and owner address
+//!  A name spacing construct for grouping related series
+//!  Series within a collection can share the same royalties fee schedules and owner address
 //!
 //! *Series*:
-//! A grouping of tokens within a collection namespace
-//! Tokens in the same series will have exact onchain attributes, distinguishable by a serial number.
-//! Series may be one-of-one i.e. the classic NFT
-//! A series of size 1 contains an NFT, while a series with > 1 token is considered semi-fungible
+//! Series are a grouping of tokens- equivalent to an ERC721 contract
 //!
 //! *Tokens*:
-//!  Individual tokens are uniquely identifiable by a tuple of (collection, series, serial number)
+//!  Individual tokens within a series. Globally identifiable by a tuple of (collection, series, serial number)
 //!
 
 use cennznet_primitives::types::{AssetId, Balance, BlockNumber};
@@ -92,12 +89,8 @@ decl_event!(
 		CreateCollection(CollectionId, CollectionNameType, AccountId),
 		/// A new series of tokens was created (collection, series id, quantity, owner)
 		CreateSeries(CollectionId, SeriesId, TokenCount, AccountId),
-		/// Additional tokens were added to a series (collection, series id, quantity, owner)
-		CreateAdditional(CollectionId, SeriesId, TokenCount, AccountId),
-		/// A unique token was created (collection, series id, serial number, owner)
-		CreateToken(CollectionId, TokenId, AccountId),
-		/// A new mass drop was created (collection, series id, owner)
-		CreateMassDrop(CollectionId, SeriesId, AccountId),
+		/// Token(s) were created (collection, series id, quantity, owner)
+		CreateTokens(CollectionId, SeriesId, TokenCount, AccountId),
 		/// Token(s) were transferred (previous owner, token Ids, new owner)
 		Transfer(AccountId, Vec<TokenId>, AccountId),
 		/// Tokens were burned (collection, series id, serial numbers)
@@ -172,8 +165,6 @@ decl_error! {
 		BidTooLow,
 		/// Selling tokens from different collections is not allowed
 		MixedBundleSale,
-		/// Cannot mint additional tokens in a unique issue series
-		AddToUniqueIssue,
 		/// Tokens with different individual royalties cannot be sold together
 		RoyaltiesProtection,
 		/// The account_id hasn't been registered as a marketplace
@@ -200,8 +191,8 @@ decl_error! {
 		MassDropConfigured,
 		/// Metadata URIs already changed and Mass Drop has started
 		MetadataAlreadySet,
-		/// The number of Metadata URIs supplied doesn't match the Mass Drop max supply
-		IncorrectAmountOfUris,
+		/// The series metadata scheme must be given
+		NoMetadataScheme,
 	}
 }
 
@@ -211,8 +202,6 @@ decl_storage! {
 		pub CollectionOwner get(fn collection_owner): map hasher(twox_64_concat) CollectionId => Option<T::AccountId>;
 		/// Map from collection to its human friendly name
 		pub CollectionName get(fn collection_name): map hasher(twox_64_concat) CollectionId => CollectionNameType;
-		/// Map from collection to a base metadata URI for its token's offchain attributes
-		pub CollectionMetadataURI get(fn collection_metadata_uri): map hasher(twox_64_concat) CollectionId => Option<MetadataBaseURI>;
 		/// Map from collection to its defacto royalty scheme
 		pub CollectionRoyalties get(fn collection_royalties): map hasher(twox_64_concat) CollectionId => Option<RoyaltiesSchedule<T::AccountId>>;
 		/// Map from a token to lock status if any
@@ -224,22 +213,18 @@ decl_storage! {
 		pub NextMarketplaceId get(fn next_marketplace_id): MarketplaceId;
 		/// Map from marketplace account_id to royalties schedule
 		pub RegisteredMarketplaces get(fn registered_marketplaces): map hasher(twox_64_concat) MarketplaceId => Marketplace<T::AccountId>;
-		/// Map from (collection, series) to its attributes
+		/// Map from (collection, series) to its attributes (deprecated)
 		pub SeriesAttributes get(fn series_attributes): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Vec<NFTAttributeValue>;
 		/// Map from (collection, series) to configured royalties schedule
 		pub SeriesRoyalties get(fn series_royalties): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Option<RoyaltiesSchedule<T::AccountId>>;
 		/// Map from a (collection, series) to its total issuance
 		pub SeriesIssuance get(fn series_issuance): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId =>  TokenCount;
-		/// Map from a token series to its metadata URI path. This should be joined wih the collection base path
-		pub SerialNumberMetadataURI get(fn serial_number_metadata_uri): double_map hasher(twox_64_concat) (CollectionId, SeriesId), hasher(twox_64_concat) SerialNumber => Option<Vec<u8>>;
-		/// Map from a token series to its metadata URI path. This should be joined wih the collection base path
-		pub SeriesMetadataURI get(fn series_metadata_uri): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Option<Vec<u8>>;
+		/// Map from a token series to its metadata reference scheme
+		pub SeriesMetadataScheme get(fn series_metadata_scheme): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Option<MetadataScheme>;
 		/// Map from a token series to its massdrop object
 		pub SeriesMassDrops get(fn series_mass_drops): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Option<MassDrop>;
 		/// Map from a token series to its presale whitelist
 		pub PresaleWhitelist get(fn presale_whitelist): double_map hasher(twox_64_concat) (CollectionId, SeriesId), hasher(twox_64_concat) T::AccountId => bool;
-		/// Demarcates a series limited to exactly one token
-		IsSingleIssue get(fn is_single_issue): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => bool;
 		/// The next available collection Id
 		NextCollectionId get(fn next_collection_id): CollectionId;
 		/// The next group Id within an NFT collection
@@ -376,7 +361,6 @@ decl_module! {
 		fn create_collection(
 			origin,
 			name: CollectionNameType,
-			metadata_base_uri: Option<MetadataBaseURI>,
 			royalties_schedule: Option<RoyaltiesSchedule<T::AccountId>>,
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
@@ -392,9 +376,6 @@ decl_module! {
 				ensure!(royalties_schedule.validate(), Error::<T>::RoyaltiesInvalid);
 				<CollectionRoyalties<T>>::insert(collection_id, royalties_schedule);
 			}
-			if let Some(metadata_base_uri) = metadata_base_uri {
-				CollectionMetadataURI::insert(collection_id, metadata_base_uri);
-			}
 			<CollectionOwner<T>>::insert(collection_id, &origin);
 			CollectionName::insert(collection_id, &name);
 			NextCollectionId::mutate(|c| *c += 1);
@@ -404,68 +385,6 @@ decl_module! {
 			Ok(())
 		}
 
-		/// Mint a single token (NFT)
-		///
-		/// `owner` - the token owner, defaults to the caller
-		/// `attributes` - initial values according to the NFT collection/schema
-		/// `metadata_path` - URI path to the offchain metadata relative to the collection base URI
-		/// Caller must be the collection owner
-		#[weight = T::WeightInfo::mint_series(1)]
-		#[transactional]
-		fn mint_unique(
-			origin,
-			collection_id: CollectionId,
-			owner: Option<T::AccountId>,
-			attributes: Vec<NFTAttributeValue>,
-			metadata_path: Option<Vec<u8>>,
-			royalties_schedule: Option<RoyaltiesSchedule<T::AccountId>>,
-		) {
-			let series_id = Self::next_series_id(collection_id);
-			let _ = Self::mint_series(origin, collection_id, One::one(), owner, attributes, metadata_path, royalties_schedule, None)?;
-			IsSingleIssue::insert(collection_id, series_id, true);
-		}
-
-		/// Update metadata uris for tokens in a Mass Drop
-		/// If the mass drop has started, these URIs cannot be changed
-		/// Must pass in the entire vector of URIs of the same length of the Mass Drop Max Supply
-		#[weight = 78_000_000]
-		#[transactional]
-		fn update_metadata_uris(
-			origin,
-			collection_id: CollectionId,
-			series_id: SeriesId,
-			metadata_uris: Vec<Vec<u8>>,
-		) -> DispatchResult {
-			let origin = ensure_signed(origin)?;
-			ensure!(Self::collection_owner(collection_id) == Some(origin), Error::<T>::NoPermission);
-			let mass_drop: MassDrop = Self::series_mass_drops(collection_id, series_id)
-				.ok_or(Error::<T>::NoMassDropExists)?;
-			ensure!(metadata_uris.len() as u32 == mass_drop.max_supply, Error::<T>::IncorrectAmountOfUris);
-			// Check if data already exists
-			// Check if mass drop has started, if it has, don't allow changing of data
-			let current_block = <frame_system::Module<T>>::block_number();
-			let serial_number: SerialNumber = 0;
-			if <SerialNumberMetadataURI>::contains_key((collection_id, series_id), serial_number) {
-				ensure!(
-					current_block < T::BlockNumber::from(mass_drop.activation_time),
-					Error::<T>::MetadataAlreadySet
-				);
-				if mass_drop.presale.is_some() {
-					ensure!(
-						current_block < T::BlockNumber::from(mass_drop.presale.clone().unwrap().activation_time),
-						Error::<T>::MetadataAlreadySet
-					);
-				}
-			}
-			// Loop through each metadata uri
-			let mut serial_number: SerialNumber = 0;
-			for (i, uri) in metadata_uris.iter().enumerate() {
-				serial_number = (i as u32).into();
-				SerialNumberMetadataURI::insert((collection_id, series_id), serial_number, uri);
-			}
-			Self::deposit_event(RawEvent::MetadataUpdated(collection_id, series_id, serial_number));
-			Ok(())
-		}
 		/// Buy tokens from an active mass_drop
 		/// Checks to make sure the drop has started
 		/// If the whitelist is not empty, only whitelisted accounts will be able to join
@@ -523,7 +442,7 @@ decl_module! {
 			};
 
 			Self::process_drop_payment(&origin, &owner, price, quantity, mass_drop.asset_id)?;
-			Self::do_mint_additional(&origin, collection_id, series_id, serial_number, quantity)?;
+			Self::do_mint(&origin, collection_id, series_id, serial_number, quantity)?;
 			Self::deposit_event(RawEvent::EnterMassDrop(collection_id, series_id, quantity, serial_number, origin));
 			Ok(())
 		}
@@ -631,21 +550,18 @@ decl_module! {
 			ensure!(mass_drop.validate(), Error::<T>::MassDropInvalid);
 			SeriesMassDrops::insert(collection_id, series_id, mass_drop);
 			Self::deposit_event(RawEvent::UpdatePresaleActivationTime(collection_id, series_id, new_activation_time));
-			Ok(())
 
+			Ok(())
 		}
 
-		/// Mint a series of tokens distinguishable only by a serial number (SFT)
-		/// Series can be issued additional tokens with `mint_additional`
+		/// Create a new series
+		/// Additional tokens can be minted via `mint_additional`
 		///
-		/// `quantity` - how many tokens to mint
+		/// `quantity` - number of tokens to mint now
 		/// `owner` - the token owner, defaults to the caller
-		/// `attributes` - all tokens in series will have these values
-		/// `metadata_path` - URI path to token offchain metadata relative to the collection base URI
+		/// `metadata_scheme` - The offchain metadata referencing scheme for tokens in this series
 		/// `mass_drop` - If this series is a mass_drop, define the mass_drop parameters
 		/// Caller must be the collection owner
-		/// -----------
-		/// Performs O(N) writes where N is `quantity`
 		#[weight = T::WeightInfo::mint_series(*quantity)]
 		#[transactional]
 		fn mint_series(
@@ -653,8 +569,7 @@ decl_module! {
 			collection_id: CollectionId,
 			quantity: TokenCount,
 			owner: Option<T::AccountId>,
-			attributes: Vec<NFTAttributeValue>,
-			metadata_path: Option<Vec<u8>>,
+			metadata_scheme: MetadataScheme,
 			royalties_schedule: Option<RoyaltiesSchedule<T::AccountId>>,
 			mass_drop: Option<MassDrop>
 		) -> DispatchResult {
@@ -667,12 +582,6 @@ decl_module! {
 				return Err(Error::<T>::NoCollection.into());
 			}
 
-			ensure!(attributes.len() as u32 <= MAX_SCHEMA_FIELDS, Error::<T>::SchemaMaxAttributes);
-			let max_attribute_length = T::MaxAttributeLength::get() as usize;
-			for attribute in attributes.iter() {
-				ensure!(attribute.len() <= max_attribute_length, Error::<T>::MaxAttributeLength);
-			}
-
 			// Check we can issue the new tokens
 			let series_id = Self::next_series_id(collection_id);
 			ensure!(
@@ -680,7 +589,7 @@ decl_module! {
 				Error::<T>::NoAvailableIds
 			);
 
-			// Create the mass_drop data
+			// Create the 'mass drop' data
 			if let Some(mass_drop) = mass_drop.clone() {
 				ensure!(mass_drop.validate(), Error::<T>::MassDropInvalid);
 				let current_block = <frame_system::Module<T>>::block_number();
@@ -689,50 +598,35 @@ decl_module! {
 					Error::<T>::ActivationTimeInvalid
 				);
 				SeriesMassDrops::insert(collection_id, series_id, mass_drop);
-			} else {
-				ensure!(quantity > Zero::zero(), Error::<T>::NoToken);
 			}
 
-			// Ok create the token series data
-			// All these attributes are the same in a series
-			SeriesAttributes::insert(collection_id, series_id, attributes);
-			SeriesIssuance::insert(collection_id, series_id, quantity);
-			if let Some(metadata_path) = metadata_path {
-				SeriesMetadataURI::insert(collection_id, series_id, metadata_path);
-			}
+			SeriesMetadataScheme::insert(collection_id, series_id, metadata_scheme);
+
+			// Setup royalties
 			if let Some(royalties_schedule) = royalties_schedule {
 				ensure!(royalties_schedule.validate(), Error::<T>::RoyaltiesInvalid);
 				<SeriesRoyalties<T>>::insert(collection_id, series_id, royalties_schedule);
 			}
 
 			// Now mint the series tokens
-			let owner = owner.unwrap_or_else(|| origin.clone());
-
+			let owner = owner.unwrap_or(origin);
+			SeriesIssuance::insert(collection_id, series_id, quantity);
 			for serial_number in 0..quantity as SerialNumber {
 				<TokenOwner<T>>::insert((collection_id, series_id), serial_number as SerialNumber, &owner);
 			}
-
 			// will not overflow, asserted prior qed.
 			NextSeriesId::mutate(collection_id, |i| *i += SeriesId::one());
 			NextSerialNumber::insert(collection_id, series_id, quantity as SerialNumber);
 
-			if mass_drop.is_some() {
-				Self::deposit_event(RawEvent::CreateMassDrop(collection_id, series_id, owner));
-			} else {
-				if quantity > One::one() {
-					Self::deposit_event(RawEvent::CreateSeries(collection_id, series_id, quantity, owner));
-				} else {
-					Self::deposit_event(RawEvent::CreateToken(collection_id, (collection_id, series_id, 0 as SerialNumber), owner));
-				}
-			}
+			Self::deposit_event(RawEvent::CreateSeries(collection_id, series_id, quantity, owner));
+
 			Ok(())
 		}
 
-		/// Mint additional tokens to an existing series
-		/// It will fail if the series is not semi-fungible
+		/// Mint tokens for an existing series
 		///
 		/// `quantity` - how many tokens to mint
-		/// `owner` - the token owner, defaults to the caller
+		/// `owner` - the token owner, defaults to the caller if unspecified
 		/// Caller must be the collection owner
 		/// -----------
 		/// Weight is O(N) where N is `quantity`
@@ -746,7 +640,8 @@ decl_module! {
 			owner: Option<T::AccountId>,
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
-			ensure!(Self::series_mass_drops(collection_id, series_id).is_none(), Error::<T>::MassDropConfigured);
+
+			ensure!(!SeriesMassDrops::contains_key(collection_id, series_id), Error::<T>::MassDropConfigured);
 
 			// Permission and existence check
 			if let Some(collection_owner) = Self::collection_owner(collection_id) {
@@ -761,10 +656,10 @@ decl_module! {
 				serial_number.checked_add(quantity).is_some(),
 				Error::<T>::NoAvailableIds
 			);
-			let owner = owner.unwrap_or_else(|| origin.clone());
+			let owner = owner.unwrap_or(origin);
 
-			Self::do_mint_additional(&owner, collection_id, series_id, serial_number, quantity)?;
-			Self::deposit_event(RawEvent::CreateAdditional(collection_id, series_id, quantity, owner));
+			Self::do_mint(&owner, collection_id, series_id, serial_number, quantity)?;
+			Self::deposit_event(RawEvent::CreateTokens(collection_id, series_id, quantity, owner));
 
 			Ok(())
 		}
@@ -834,9 +729,8 @@ decl_module! {
 				// this is the last of the tokens
 				SeriesAttributes::remove(collection_id, series_id);
 				SeriesIssuance::remove(collection_id, series_id);
-				SeriesMetadataURI::remove(collection_id, series_id);
+				SeriesMetadataScheme::remove(collection_id, series_id);
 				<SeriesRoyalties<T>>::remove(collection_id, series_id);
-				IsSingleIssue::remove(collection_id, series_id);
 			} else {
 				SeriesIssuance::mutate(collection_id, series_id, |q| *q = q.saturating_sub(serial_numbers.len() as TokenCount));
 			}
@@ -1220,7 +1114,7 @@ impl<T: Config> Module<T> {
 		}
 	}
 	/// Mint additional tokens in a series
-	fn do_mint_additional(
+	fn do_mint(
 		owner: &T::AccountId,
 		collection_id: CollectionId,
 		series_id: SeriesId,
@@ -1228,10 +1122,6 @@ impl<T: Config> Module<T> {
 		quantity: TokenCount,
 	) -> DispatchResult {
 		ensure!(quantity > Zero::zero(), Error::<T>::NoToken);
-		ensure!(
-			!Self::is_single_issue(collection_id, series_id),
-			Error::<T>::AddToUniqueIssue
-		);
 
 		// Mint the set tokens
 		for serial_number in serial_number..serial_number + quantity {

--- a/crml/nft/src/types.rs
+++ b/crml/nft/src/types.rs
@@ -444,6 +444,8 @@ pub enum Releases {
 	V0 = 0,
 	/// storage version > runtime v41
 	V1 = 1,
+	// storage version > runtime v46
+	V2 = 2,
 }
 
 #[cfg(test)]

--- a/crml/nft/src/types.rs
+++ b/crml/nft/src/types.rs
@@ -29,15 +29,21 @@ use variant_count::VariantCount;
 // Time before auction ends that auction is extended if a bid is placed
 pub const AUCTION_EXTENSION_PERIOD: BlockNumber = 40;
 
-/// A base metadata URI string for a collection
+/// Denotes the metadata URI referencing scheme used by a series
+/// Enable token metadata URI construction by clients
 #[derive(Decode, Encode, Debug, Clone, PartialEq)]
-pub enum MetadataBaseURI {
-	/// Collection metadata is hosted by IPFS
-	/// Its tokens' metdata will be available at `ipfs://<token_metadata_path>`
-	Ipfs,
-	/// Collection metadata is hosted by an HTTPS server
-	/// Its tokens' metdata will be avilable at `https://<domain>/<token_metadata_path>`
+pub enum MetadataScheme {
+	/// Series metadata is hosted by an HTTPS server
+	/// Inner value is the URI without trailing '/'
+	/// full metadata URI construction: `https://<domain>/<path+>/<serial_number>.json`
+	/// Https(b"example.com/metadata")
+	///
 	Https(Vec<u8>),
+	/// Series metadata is hosted by an IPFS directory
+	/// Inner value is the directory's IPFS CID
+	/// full metadata URI construction: `ipfs://<directory_CID>/<serial_number>.json`
+	/// IpfsDir(b"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+	IpfsDir(Vec<u8>),
 }
 
 /// Name of an NFT attribute


### PR DESCRIPTION
### Changes
Change NFT data model to more closely resemble the ERC721 structure for future cross-chain compatibility.
- 'Collections' are a grouping of series
- 'Series' are equivalent to ERC721 home contracts
- 'Serial numbers' are equivalent to ERC721 token address

**SFT removal**
Removes the concept of SFT/copies/unique enforced by the module, all tokens are NFTs by default.
It is much simpler to leave to the token metadata to denote/manage copies.

**Metadata Reference Schemes**
`MetadataBaseUri` renamed to `MetadataScheme`
Users can choose to store token metadata using 1 of 2 reference schemes,  either:
1) https. token URIs assembled like `https://api.example.com/metadata/<serialNumber>.json`
2) IPFS directory. token URIs assembled like: `ipfs://<directoryCID/<serialNumber>.json`
see: https://github.com/cennznet/cennznet/issues/442#issuecomment-992086784

### Removes
- mint_unique function (not needed)
- SeriesAttributes (doesn't make sense anymore, could be reintroduced as TokenAttributes)
- CollectionBaseUri

## TODO:
- [x] Add migration/storage clean up functions
- [ ] refactor OpenCollectionListings -> OpenSeriesListings, since grouping by SeriesId will become more standard

partially addresses #525 & #442 (minus a token_uri RPC method)