### PR TITLE
Add content-length header to ethereum http requests

### DIFF
--- a/crml/eth-bridge/src/lib.rs
+++ b/crml/eth-bridge/src/lib.rs
@@ -59,7 +59,11 @@ use sp_runtime::{
 	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity, ValidTransaction},
 	DispatchError, Percent, RuntimeAppPublic,
 };
+#[cfg(not(feature = "std"))]
+use sp_std::alloc::string::ToString;
 use sp_std::{convert::TryInto, prelude::*};
+#[cfg(std)]
+use std::string::ToString;
 
 /// The type to sign and send transactions.
 const UNSIGNED_TXS_PRIORITY: u64 = 100;
@@ -603,7 +607,7 @@ impl<T: Config> Module<T> {
 			})
 	}
 
-	/// This function uses the `offchain::http` API to query the remote github information,
+	/// This function uses the `offchain::http` API to query the remote ethereum information,
 	/// and returns the JSON response as vector of bytes.
 	fn query_eth_client<R: serde::Serialize>(request_body: R) -> Result<Vec<u8>, Error<T>> {
 		// Load eth http URI from offchain storage
@@ -624,14 +628,16 @@ impl<T: Config> Module<T> {
 		const HEADER_CONTENT_TYPE: &str = "application/json";
 		log!(info, "💎 sending request to: {}", eth_http_uri);
 		let body = serde_json::to_string::<R>(&request_body).unwrap();
+		let body_raw = body.as_bytes();
 		// Initiate an external HTTP GET request. This is using high-level wrappers from `sp_runtime`.
-		let request = rt_offchain::http::Request::post(eth_http_uri, vec![body.as_bytes()]);
+		let request = rt_offchain::http::Request::post(eth_http_uri, vec![body_raw]);
 		log!(trace, "💎 request: {:?}", request);
 
 		// Keeping the offchain worker execution time reasonable, so limiting the call to be within 3s.
 		let timeout = sp_io::offchain::timestamp().add(rt_offchain::Duration::from_millis(REQUEST_TTL_MS));
 		let pending = request
 			.add_header("Content-Type", HEADER_CONTENT_TYPE)
+			.add_header("Content-Length", &body_raw.len().to_string())
 			.deadline(timeout) // Setting the timeout time
 			.send() // Sending the request out by the host
 			.map_err(|err| {


### PR DESCRIPTION
Same as PR #533 bringing to `develop` branch this time.

closes #532 