### PR TITLE
Add geth txpool rpcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,8 @@ name = "cennznet-cli"
 version = "2.1.0-rc3"
 dependencies = [
  "cennznet-primitives",
+ "cennznet-rpc-core-txpool",
+ "cennznet-rpc-txpool",
  "cennznet-runtime",
  "crml-cennzx-rpc",
  "crml-eth-bridge",
@@ -786,6 +788,7 @@ dependencies = [
 name = "cennznet-primitives"
 version = "2.0.0"
 dependencies = [
+ "ethereum",
  "frame-support",
  "libsecp256k1 0.6.0",
  "parity-scale-codec",
@@ -793,6 +796,42 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "cennznet-rpc-core-txpool"
+version = "0.6.0"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "fc-rpc-core",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cennznet-rpc-txpool"
+version = "0.6.0"
+dependencies = [
+ "cennznet-primitives",
+ "cennznet-rpc-core-txpool",
+ "ethereum-types",
+ "fc-rpc",
+ "frame-system",
+ "jsonrpc-core",
+ "rlp",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "serde",
+ "sha3 0.9.1",
+ "sp-api",
+ "sp-blockchain",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -68,6 +68,8 @@ frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/cenn
 # cennznet dependencies
 cennznet-primitives = { path = "../primitives" }
 cennznet-runtime = { path = "../runtime" }
+cennznet-rpc-core-txpool = { path = "rpc-core/txpool" }
+cennznet-rpc-txpool = { path = "./src/rpc/txpool" }
 crml-eth-bridge = { path = "../crml/eth-bridge" }
 # cennznet custom RPCs
 crml-cennzx-rpc = { path = "../crml/cennzx/rpc" }

--- a/cli/rpc-core/txpool/Cargo.toml
+++ b/cli/rpc-core/txpool/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cennznet-rpc-core-txpool"
+authors = [ "Centrality Developers" ]
+edition = "2018"
+homepage = "https://cennz.net"
+license = "GPL-3.0-only"
+repository = "https://github.com/cennznet/cennznet/"
+version = "0.6.0"
+
+[dependencies]
+ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
+ethereum-types = "0.12.1"
+jsonrpc-core = "18.0.0"
+jsonrpc-core-client = "18.0.0"
+jsonrpc-derive = "18.0.0"
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"
+
+fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "4879da8de4141a1bfb9706a71ae9ef9f82099dd5" }

--- a/cli/rpc-core/txpool/src/lib.rs
+++ b/cli/rpc-core/txpool/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethereum_types::U256;
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+
+mod types;
+
+pub use crate::types::{Get as GetT, Summary, Transaction, TransactionMap, TxPoolResult};
+
+pub use rpc_impl_TxPool::gen_server::TxPool as TxPoolServer;
+
+#[rpc(server)]
+pub trait TxPool {
+	#[rpc(name = "txpool_content")]
+	fn content(&self) -> Result<TxPoolResult<TransactionMap<Transaction>>>;
+
+	#[rpc(name = "txpool_inspect")]
+	fn inspect(&self) -> Result<TxPoolResult<TransactionMap<Summary>>>;
+
+	#[rpc(name = "txpool_status")]
+	fn status(&self) -> Result<TxPoolResult<U256>>;
+}

--- a/cli/rpc-core/txpool/src/types/content.rs
+++ b/cli/rpc-core/txpool/src/types/content.rs
@@ -1,0 +1,97 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::GetT;
+use ethereum::{TransactionAction, TransactionV2 as EthereumTransaction};
+use ethereum_types::{H160, H256, U256};
+use fc_rpc_core::types::Bytes;
+use serde::{Serialize, Serializer};
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Transaction {
+	/// Hash
+	pub hash: H256,
+	/// Nonce
+	pub nonce: U256,
+	/// Block hash
+	#[serde(serialize_with = "block_hash_serialize")]
+	pub block_hash: Option<H256>,
+	/// Block number
+	pub block_number: Option<U256>,
+	/// Sender
+	pub from: H160,
+	/// Recipient
+	#[serde(serialize_with = "to_serialize")]
+	pub to: Option<H160>,
+	/// Transfered value
+	pub value: U256,
+	/// Gas Price
+	pub gas_price: U256,
+	/// Gas
+	pub gas: U256,
+	/// Data
+	pub input: Bytes,
+	/// Transaction Index
+	pub transaction_index: Option<U256>,
+}
+
+fn block_hash_serialize<S>(hash: &Option<H256>, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	serializer.serialize_str(&format!("0x{:x}", hash.unwrap_or_default()))
+}
+
+fn to_serialize<S>(hash: &Option<H160>, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	serializer.serialize_str(&format!("0x{:x}", hash.unwrap_or_default()))
+}
+
+impl GetT for Transaction {
+	fn get(hash: H256, from_address: H160, txn: &EthereumTransaction) -> Self {
+		let (nonce, action, value, gas_price, gas_limit, input) = match txn {
+			EthereumTransaction::Legacy(t) => (t.nonce, t.action, t.value, t.gas_price, t.gas_limit, t.input.clone()),
+			EthereumTransaction::EIP2930(t) => (t.nonce, t.action, t.value, t.gas_price, t.gas_limit, t.input.clone()),
+			EthereumTransaction::EIP1559(t) => (
+				t.nonce,
+				t.action,
+				t.value,
+				t.max_fee_per_gas,
+				t.gas_limit,
+				t.input.clone(),
+			),
+		};
+		Self {
+			hash,
+			nonce,
+			block_hash: None,
+			block_number: None,
+			from: from_address,
+			to: match action {
+				TransactionAction::Call(to) => Some(to),
+				_ => None,
+			},
+			value,
+			gas_price,
+			gas: gas_limit,
+			input: Bytes(input),
+			transaction_index: None,
+		}
+	}
+}

--- a/cli/rpc-core/txpool/src/types/inspect.rs
+++ b/cli/rpc-core/txpool/src/types/inspect.rs
@@ -1,0 +1,63 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::GetT;
+use ethereum::{TransactionAction, TransactionV2 as EthereumTransaction};
+use ethereum_types::{H160, H256, U256};
+use serde::{Serialize, Serializer};
+
+#[derive(Clone, Debug)]
+pub struct Summary {
+	pub to: Option<H160>,
+	pub value: U256,
+	pub gas: U256,
+	pub gas_price: U256,
+}
+
+impl Serialize for Summary {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let res = format!(
+			"0x{:x}: {} wei + {} gas x {} wei",
+			self.to.unwrap_or_default(),
+			self.value,
+			self.gas,
+			self.gas_price
+		);
+		serializer.serialize_str(&res)
+	}
+}
+
+impl GetT for Summary {
+	fn get(_hash: H256, _from_address: H160, txn: &EthereumTransaction) -> Self {
+		let (action, value, gas_price, gas_limit) = match txn {
+			EthereumTransaction::Legacy(t) => (t.action, t.value, t.gas_price, t.gas_limit),
+			EthereumTransaction::EIP2930(t) => (t.action, t.value, t.gas_price, t.gas_limit),
+			EthereumTransaction::EIP1559(t) => (t.action, t.value, t.max_fee_per_gas, t.gas_limit),
+		};
+		Self {
+			to: match action {
+				TransactionAction::Call(to) => Some(to),
+				_ => None,
+			},
+			value,
+			gas_price,
+			gas: gas_limit,
+		}
+	}
+}

--- a/cli/rpc-core/txpool/src/types/mod.rs
+++ b/cli/rpc-core/txpool/src/types/mod.rs
@@ -37,33 +37,3 @@ pub struct TxPoolResult<T: Serialize> {
 pub trait Get {
 	fn get(hash: H256, from_address: H160, txn: &EthereumTransaction) -> Self;
 }
-
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize)]
-#[serde(rename_all = "camelCase", untagged)]
-pub enum RequestBlockId {
-	Number(#[serde(deserialize_with = "deserialize_u32_0x")] u32),
-	Hash(H256),
-	Tag(RequestBlockTag),
-}
-
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum RequestBlockTag {
-	Earliest,
-	Latest,
-	Pending,
-}
-
-fn deserialize_u32_0x<'de, D>(deserializer: D) -> Result<u32, D::Error>
-where
-	D: Deserializer<'de>,
-{
-	let buf = String::deserialize(deserializer)?;
-
-	let parsed = match buf.strip_prefix("0x") {
-		Some(buf) => u32::from_str_radix(&buf, 16),
-		None => u32::from_str_radix(&buf, 10),
-	};
-
-	parsed.map_err(|e| Error::custom(format!("parsing error: {:?} from '{}'", e, buf)))
-}

--- a/cli/rpc-core/txpool/src/types/mod.rs
+++ b/cli/rpc-core/txpool/src/types/mod.rs
@@ -1,0 +1,69 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+mod content;
+mod inspect;
+
+use ethereum::TransactionV2 as EthereumTransaction;
+use ethereum_types::{H160, H256, U256};
+use serde::Serialize;
+use serde::{de::Error, Deserialize, Deserializer};
+use std::collections::HashMap;
+
+pub use self::content::Transaction;
+pub use self::inspect::Summary;
+
+pub type TransactionMap<T> = HashMap<H160, HashMap<U256, T>>;
+
+#[derive(Debug, Serialize)]
+pub struct TxPoolResult<T: Serialize> {
+	pub pending: T,
+	pub queued: T,
+}
+
+pub trait Get {
+	fn get(hash: H256, from_address: H160, txn: &EthereumTransaction) -> Self;
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum RequestBlockId {
+	Number(#[serde(deserialize_with = "deserialize_u32_0x")] u32),
+	Hash(H256),
+	Tag(RequestBlockTag),
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RequestBlockTag {
+	Earliest,
+	Latest,
+	Pending,
+}
+
+fn deserialize_u32_0x<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	let buf = String::deserialize(deserializer)?;
+
+	let parsed = match buf.strip_prefix("0x") {
+		Some(buf) => u32::from_str_radix(&buf, 16),
+		None => u32::from_str_radix(&buf, 10),
+	};
+
+	parsed.map_err(|e| Error::custom(format!("parsing error: {:?} from '{}'", e, buf)))
+}

--- a/cli/src/rpc.rs
+++ b/cli/src/rpc.rs
@@ -19,7 +19,10 @@
 
 #![warn(missing_docs)]
 
-use cennznet_primitives::types::{AccountId, AssetId, Balance, Block, BlockNumber, Hash, Index};
+use cennznet_primitives::{
+	txpool::TxPoolRuntimeApi,
+	types::{AccountId, AssetId, Balance, Block, BlockNumber, Hash, Index},
+};
 use cennznet_runtime::Runtime;
 use ethy_gadget::notification::EthyEventProofStream;
 use fc_rpc::{
@@ -184,9 +187,12 @@ where
 	C::Api: crml_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: crml_generic_asset_rpc::GenericAssetRuntimeApi<Block, AssetId, Balance, AccountId>,
 	C::Api: crml_governance_rpc::GovernanceRuntimeApi<Block, AccountId>,
+	C::Api: TxPoolRuntimeApi<Block>,
 	P: TransactionPool<Block = Block> + 'static,
 	SC: SelectChain<Block> + 'static,
 {
+	use cennznet_rpc_core_txpool::TxPoolServer;
+	use cennznet_rpc_txpool::TxPool;
 	use crml_cennzx_rpc::{Cennzx, CennzxApi};
 	use crml_generic_asset_rpc::{GenericAsset, GenericAssetApi};
 	use crml_governance_rpc::{Governance, GovernanceApi};
@@ -319,6 +325,7 @@ where
 		),
 		overrides,
 	)));
+	io.extend_with(TxPoolServer::to_delegate(TxPool::new(client.clone(), graph.clone())));
 
 	io
 }

--- a/cli/src/rpc/txpool/Cargo.toml
+++ b/cli/src/rpc/txpool/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "cennznet-rpc-txpool"
+authors = [ "Centrality Developers" ]
+edition = "2018"
+homepage = "https://cennz.net"
+license = "GPL-3.0-only"
+repository = "https://github.com/cennznet/cennznet"
+version = "0.6.0"
+
+[dependencies]
+jsonrpc-core = "18.0.0"
+rlp = "0.5"
+serde = { version = "1.0", features = [ "derive" ] }
+sha3 = "0.9"
+
+# Moonbeam
+cennznet-rpc-core-txpool = { path = "../../../rpc-core/txpool" }
+cennznet-primitives = { path = "../../../../primitives" }
+
+# Substrate
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6" }
+sc-transaction-pool = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6" }
+sc-transaction-pool-api = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6" }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6" }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6" }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6" }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6" }
+
+# Frontier
+ethereum-types = "0.12.1"
+fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "4879da8de4141a1bfb9706a71ae9ef9f82099dd5" }

--- a/cli/src/rpc/txpool/src/lib.rs
+++ b/cli/src/rpc/txpool/src/lib.rs
@@ -1,0 +1,166 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethereum_types::{H160, H256, U256};
+use fc_rpc::{internal_err, public_key};
+use jsonrpc_core::Result as RpcResult;
+use sc_transaction_pool::{ChainApi, Pool};
+use sc_transaction_pool_api::InPoolTransaction;
+use serde::Serialize;
+use sha3::{Digest, Keccak256};
+use sp_api::{ApiExt, BlockId, ProvideRuntimeApi};
+use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use sp_runtime::traits::Block as BlockT;
+use std::collections::HashMap;
+use std::{marker::PhantomData, sync::Arc};
+
+use cennznet_primitives::txpool::{Transaction as TransactionV2, TxPoolResponse, TxPoolRuntimeApi};
+pub use cennznet_rpc_core_txpool::{
+	GetT, Summary, Transaction, TransactionMap, TxPool as TxPoolT, TxPoolResult, TxPoolServer,
+};
+
+pub struct TxPool<B: BlockT, C, A: ChainApi> {
+	client: Arc<C>,
+	graph: Arc<Pool<A>>,
+	_marker: PhantomData<B>,
+}
+
+impl<B, C, A> TxPool<B, C, A>
+where
+	C: ProvideRuntimeApi<B>,
+	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B> + 'static,
+	C: Send + Sync + 'static,
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	A: ChainApi<Block = B> + 'static,
+	C::Api: TxPoolRuntimeApi<B>,
+{
+	/// Use the transaction graph interface to get the extrinsics currently in the ready and future
+	/// queues.
+	fn map_build<T>(&self) -> RpcResult<TxPoolResult<TransactionMap<T>>>
+	where
+		T: GetT + Serialize,
+	{
+		// Collect transactions in the ready validated pool.
+		let txs_ready = self
+			.graph
+			.validated_pool()
+			.ready()
+			.map(|in_pool_tx| in_pool_tx.data().clone())
+			.collect();
+
+		// Collect transactions in the future validated pool.
+		let txs_future = self
+			.graph
+			.validated_pool()
+			.futures()
+			.iter()
+			.map(|(_hash, extrinsic)| extrinsic.clone())
+			.collect();
+
+		// Use the runtime to match the (here) opaque extrinsics against ethereum transactions.
+		let best_block: BlockId<B> = BlockId::Hash(self.client.info().best_hash);
+		let api = self.client.runtime_api();
+		let api_version = if let Ok(Some(api_version)) = api.api_version::<dyn TxPoolRuntimeApi<B>>(&best_block) {
+			api_version
+		} else {
+			return Err(internal_err(format!("failed to retrieve Runtime Api version")));
+		};
+		let ethereum_txns: TxPoolResponse = if api_version == 1 {
+			#[allow(deprecated)]
+			let res = api.extrinsic_filter_before_version_2(&best_block, txs_ready, txs_future)
+				.map_err(|err| internal_err(format!("fetch runtime extrinsic filter failed: {:?}", err)))?;
+			TxPoolResponse {
+				ready: res.ready.iter().map(|t| TransactionV2::Legacy(t.clone())).collect(),
+				future: res.future.iter().map(|t| TransactionV2::Legacy(t.clone())).collect(),
+			}
+		} else {
+			api.extrinsic_filter(&best_block, txs_ready, txs_future)
+				.map_err(|err| internal_err(format!("fetch runtime extrinsic filter failed: {:?}", err)))?
+		};
+		// Build the T response.
+		let mut pending = TransactionMap::<T>::new();
+		for txn in ethereum_txns.ready.iter() {
+			let hash = txn.hash();
+			let nonce = match txn {
+				TransactionV2::Legacy(t) => t.nonce,
+				TransactionV2::EIP2930(t) => t.nonce,
+				TransactionV2::EIP1559(t) => t.nonce,
+			};
+			let from_address = match public_key(txn) {
+				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice())),
+				Err(_e) => H160::default(),
+			};
+			pending
+				.entry(from_address)
+				.or_insert_with(HashMap::new)
+				.insert(nonce, T::get(hash, from_address, txn));
+		}
+		let mut queued = TransactionMap::<T>::new();
+		for txn in ethereum_txns.future.iter() {
+			let hash = txn.hash();
+			let nonce = match txn {
+				TransactionV2::Legacy(t) => t.nonce,
+				TransactionV2::EIP2930(t) => t.nonce,
+				TransactionV2::EIP1559(t) => t.nonce,
+			};
+			let from_address = match public_key(txn) {
+				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice())),
+				Err(_e) => H160::default(),
+			};
+			queued
+				.entry(from_address)
+				.or_insert_with(HashMap::new)
+				.insert(nonce, T::get(hash, from_address, txn));
+		}
+		Ok(TxPoolResult { pending, queued })
+	}
+}
+
+impl<B: BlockT, C, A: ChainApi> TxPool<B, C, A> {
+	pub fn new(client: Arc<C>, graph: Arc<Pool<A>>) -> Self {
+		Self {
+			client,
+			graph,
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<B, C, A> TxPoolT for TxPool<B, C, A>
+where
+	C: ProvideRuntimeApi<B>,
+	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
+	C: Send + Sync + 'static,
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	A: ChainApi<Block = B> + 'static,
+	C::Api: TxPoolRuntimeApi<B>,
+{
+	fn content(&self) -> RpcResult<TxPoolResult<TransactionMap<Transaction>>> {
+		self.map_build::<Transaction>()
+	}
+
+	fn inspect(&self) -> RpcResult<TxPoolResult<TransactionMap<Summary>>> {
+		self.map_build::<Summary>()
+	}
+
+	fn status(&self) -> RpcResult<TxPoolResult<U256>> {
+		let status = self.graph.validated_pool().status();
+		Ok(TxPoolResult {
+			pending: U256::from(status.ready),
+			queued: U256::from(status.future),
+		})
+	}
+}

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/cennznet/cennznet"
 [dependencies]
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
 frame-support = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6", default-features = false, version = "4.0.0-dev" }
 libsecp256k1 = { version = "0.6.0", default-features = false }
 sp-api = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb50e60e497b7ac2c521daf83af6", default-features = false }
@@ -21,6 +22,7 @@ sp-std = { git = "https://github.com/cennznet/substrate", rev = "2db18f864ae2bb5
 default = ["std"]
 std = [
 	"codec/std",
+	"ethereum/std",
 	"frame-support/std",
 	"libsecp256k1/std",
 	"sp-api/std",

--- a/primitives/src/eth.rs
+++ b/primitives/src/eth.rs
@@ -13,9 +13,8 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-//! Ethereum bridge common types
-//! shared between crml/eth-bridge runtime & ethy-gadget client
-
+//! Ethereum common types
+//! shared between crml/eth-bridge runtime and ethy-gadget client
 use codec::{Decode, Encode};
 use sp_core::ecdsa::Public;
 use sp_runtime::{traits::Convert, KeyTypeId};

--- a/primitives/src/eth.rs
+++ b/primitives/src/eth.rs
@@ -13,8 +13,9 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-//! Ethereum common types
-//! shared between crml/eth-bridge runtime and ethy-gadget client
+//! Ethereum bridge common types
+//! shared between crml/eth-bridge runtime & ethy-gadget client
+
 use codec::{Decode, Encode};
 use sp_core::ecdsa::Public;
 use sp_runtime::{traits::Convert, KeyTypeId};

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -15,10 +15,9 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Common types and traits used by CENNZnet node.
-
-#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod eth;
 pub mod traits;
+pub mod txpool;
 pub mod types;

--- a/primitives/src/txpool.rs
+++ b/primitives/src/txpool.rs
@@ -1,0 +1,38 @@
+//! Ethereum tx pool rpc runtime api & primitive types
+use codec::{Decode, Encode};
+pub use ethereum::{TransactionV0 as LegacyTransaction, TransactionV2 as Transaction};
+use sp_runtime::{traits::Block as BlockT, RuntimeDebug};
+use sp_std::vec::Vec;
+
+/// Ethereum tx pool response (legacy)
+#[derive(Eq, PartialEq, Clone, Encode, Decode, RuntimeDebug)]
+pub struct TxPoolResponseLegacy {
+	/// transactions in the ready state
+	pub ready: Vec<LegacyTransaction>,
+	/// transactions in the future state
+	pub future: Vec<LegacyTransaction>,
+}
+
+/// Ethereum tx pool response
+#[derive(Eq, PartialEq, Clone, Encode, Decode, RuntimeDebug)]
+pub struct TxPoolResponse {
+	/// transactions in the ready state
+	pub ready: Vec<Transaction>,
+	/// transactions in the future state
+	pub future: Vec<Transaction>,
+}
+
+sp_api::decl_runtime_apis! {
+	#[api_version(2)]
+	pub trait TxPoolRuntimeApi {
+		#[changed_in(2)]
+		fn extrinsic_filter(
+			xt_ready: Vec<<Block as BlockT>::Extrinsic>,
+			xt_future: Vec<<Block as BlockT>::Extrinsic>,
+		) -> TxPoolResponseLegacy;
+		fn extrinsic_filter(
+			xt_ready: Vec<<Block as BlockT>::Extrinsic>,
+			xt_future: Vec<<Block as BlockT>::Extrinsic>,
+		) -> TxPoolResponse;
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1310,6 +1310,30 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl cennznet_primitives::txpool::TxPoolRuntimeApi<Block> for Runtime {
+		fn extrinsic_filter(
+			xts_ready: Vec<<Block as BlockT>::Extrinsic>,
+			xts_future: Vec<<Block as BlockT>::Extrinsic>,
+		) -> cennznet_primitives::txpool::TxPoolResponse {
+			cennznet_primitives::txpool::TxPoolResponse {
+				ready: xts_ready
+					.into_iter()
+					.filter_map(|xt| match xt.0.function {
+						Call::Ethereum(transact { transaction }) => Some(transaction),
+						_ => None,
+					})
+					.collect(),
+				future: xts_future
+					.into_iter()
+					.filter_map(|xt| match xt.0.function {
+						Call::Ethereum(transact { transaction }) => Some(transaction),
+						_ => None,
+					})
+					.collect(),
+			}
+		}
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn dispatch_benchmark(


### PR DESCRIPTION
Adds the following geth RPCs for txpool: https://geth.ethereum.org/docs/rpc/ns-txpool
Useful for block scanners and wallets to inspect tx status