### PR TITLE
Prepping for 2.1.0 client

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
       - "develop"
+      - "release/*"
     paths:
       - "**.rs"
       - "**.toml"
@@ -32,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: ${{ GITHUB_REF }}
           fetch-depth: 0
       - name: Build 🛠 & Publish 🐳
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,14 +694,14 @@ dependencies = [
 
 [[package]]
 name = "cennznet"
-version = "2.1.0-rc7"
+version = "2.1.0"
 dependencies = [
  "cennznet-cli",
 ]
 
 [[package]]
 name = "cennznet-cli"
-version = "2.1.0-rc7"
+version = "2.1.0"
 dependencies = [
  "cennznet-primitives",
  "cennznet-rpc-core-txpool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "cli/src/main.rs"
 
 [package]
 name = "cennznet"
-version = "2.1.0-rc7"
+version = "2.1.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cennznet-cli"
-version = "2.1.0-rc7"
+version = "2.1.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "CENNZnet node implementation in Rust."
 edition = "2018"

--- a/genesis/azalea.raw.json
+++ b/genesis/azalea.raw.json
@@ -18,7 +18,7 @@
   "telemetryEndpoints": null,
   "protocolId": "cennznet-azalea-v1",
   "properties": {
-    "frontierGenesisBlockNumber": "12179483"
+    "frontierGenesisBlockNumber": "12300000"
   },
   "consensusEngine": null,
   "genesis": {

--- a/genesis/nikau.raw.json
+++ b/genesis/nikau.raw.json
@@ -7,7 +7,7 @@
   "telemetryEndpoints": null,
   "protocolId": "cennznet-nikau-v1",
   "properties": {
-    "frontierGenesisBlockNumber": "2226331"
+    "frontierGenesisBlockNumber": "2298800"
   },
   "consensusEngine": null,
   "genesis": {

--- a/genesis/rata.raw.json
+++ b/genesis/rata.raw.json
@@ -7,7 +7,7 @@
   "telemetryEndpoints": null,
   "protocolId": "cennznet-rata-v1",
   "properties": {
-    "frontierGenesisBlockNumber": "2170000"
+    "frontierGenesisBlockNumber": "2176846"
   },
   "forkBlocks": null,
   "badBlocks": null,


### PR DESCRIPTION
Set client to 2.1.0

Update the frontier sync blocks
azalea - ~1pm Thursday 31st of March
nikau - ~3pm Tuesday 22nd of March
rata - updated to block of the update

Fix image builder to build the branch that triggered the workflow (partially closes #502) 