### PR TITLE
Spike/upgrade nft v3

### DIFF
--- a/crml/nft/rpc/runtime-api/src/lib.rs
+++ b/crml/nft/rpc/runtime-api/src/lib.rs
@@ -20,14 +20,14 @@
 
 use cennznet_primitives::types::{CollectionId, SerialNumber, SeriesId, TokenId};
 use codec::Codec;
-use crml_nft::{CollectionInfo, Config, Listing, ListingId, TokenInfo};
+use crml_nft::pallet::{CollectionInfo, Config, Listing, ListingId, TokenInfo};
 use sp_std::prelude::*;
 
 sp_api::decl_runtime_apis! {
 	/// The RPC API to interact with NFT module
 	pub trait NftApi<AccountId, T> where
 		AccountId: Codec,
-		T: Config,
+		T: Config + crml_nft::pallet::Config,
 	{
 		/// Find all the tokens owned by `who` in a given collection
 		fn collected_tokens(

--- a/crml/nft/rpc/runtime-api/src/lib.rs
+++ b/crml/nft/rpc/runtime-api/src/lib.rs
@@ -27,7 +27,7 @@ sp_api::decl_runtime_apis! {
 	/// The RPC API to interact with NFT module
 	pub trait NftApi<AccountId, T> where
 		AccountId: Codec,
-		T: Config + crml_nft::pallet::Config,
+		T: Config,
 	{
 		/// Find all the tokens owned by `who` in a given collection
 		fn collected_tokens(

--- a/crml/nft/rpc/src/lib.rs
+++ b/crml/nft/rpc/src/lib.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use cennznet_primitives::types::{BlockNumber, CollectionId, SerialNumber, SeriesId, TokenId};
 use codec::Codec;
-use crml_nft::{CollectionInfo, Config, Listing, ListingResponse, ListingResponseWrapper, TokenInfo};
+use crml_nft::pallet::{CollectionInfo, Config, Listing, ListingResponse, ListingResponseWrapper, TokenInfo};
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use sp_api::ProvideRuntimeApi;

--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -32,6 +32,8 @@
 //!  Individual tokens within a series. Globally identifiable by a tuple of (collection, series, serial number)
 //!
 
+pub use pallet::*;
+
 use cennznet_primitives::types::{AssetId, Balance, CollectionId, SerialNumber, SeriesId, TokenId};
 use crml_support::{IsTokenOwner, MultiCurrency, OnTransferSubscriber};
 use frame_support::{
@@ -56,62 +58,89 @@ mod tests;
 mod weights;
 use weights::WeightInfo;
 
-mod migration;
-mod types;
-pub use types::*;
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use self::log;
 
-// Interface for determining ownership of an NFT from some account
-impl<T: Config> IsTokenOwner for Module<T> {
-	type AccountId = T::AccountId;
+	// Interface for determining ownership of an NFT from some account
+	impl<T: Config> IsTokenOwner for Pallet<T> {
+		type AccountId = T::AccountId;
 
-	fn check_ownership(account: &Self::AccountId, token_id: &TokenId) -> bool {
-		&Self::token_owner((token_id.0, token_id.1), token_id.2) == account
+		fn check_ownership(account: &Self::AccountId, token_id: &TokenId) -> bool {
+			&Self::token_owner((token_id.0, token_id.1), token_id.2) == account
+		}
 	}
-}
 
-pub trait Config: frame_system::Config {
-	/// The system event type
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-	/// Default auction / sale length in blocks
-	type DefaultListingDuration: Get<Self::BlockNumber>;
-	/// Maximum byte length of an NFT attribute
-	type MaxAttributeLength: Get<u8>;
-	/// Handles a multi-currency fungible asset system
-	type MultiCurrency: MultiCurrency<AccountId = Self::AccountId, CurrencyId = AssetId, Balance = Balance>;
-	/// Provides the public call to weight mapping
-	type WeightInfo: WeightInfo;
-	/// Handler for when an NFT has been transferred
-	type OnTransferSubscription: OnTransferSubscriber;
-}
+	type OriginFor<T> = <T as frame_system::Config>::Origin;
+	type AccountOf<T> = <T as frame_system::Config>::AccountId;
+	type BalanceOf<T> = <<T as Config>::MultiCurrency as MultiCurrency>::Balance;
 
-decl_event!(
-	pub enum Event<T> where
-		CollectionId = CollectionId,
-		<T as frame_system::Config>::AccountId,
-		AssetId = AssetId,
-		Balance = Balance,
-		Reason = AuctionClosureReason,
-		SeriesId = SeriesId,
-		SerialNumber = SerialNumber,
-		TokenCount = TokenCount,
-		CollectionNameType = CollectionNameType,
-		Permill = Permill,
-		MarketplaceId = MarketplaceId,
+	/// The maximum number of attributes in an NFT collection schema
+	pub const MAX_SCHEMA_FIELDS: u32 = 16;
+	/// The maximum length of valid collection IDs
+	pub const MAX_COLLECTION_NAME_LENGTH: u8 = 32;
+	/// The maximum amount of listings to return
+	pub const MAX_COLLECTION_LISTING_LIMIT: u16 = 100;
+	/// The logging target for this module
+	pub(crate) const LOG_TARGET: &str = "nft";
+
+	// syntactic sugar for logging.
+	#[macro_export]
+	macro_rules! log {
+	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+		log::$level!(
+			target: crate::LOG_TARGET,
+			$patter $(, $values)*
+		)
+	};
+	}
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The system event type
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		/// Default auction / sale length in blocks
+		type DefaultListingDuration: Get<Self::BlockNumber>;
+		/// Maximum byte length of an NFT attribute
+		type MaxAttributeLength: Get<u8>;
+		/// Handles a multi-currency fungible asset system
+		type MultiCurrency: MultiCurrency<AccountId = Self::AccountId, CurrencyId = AssetId, Balance = Balance>;
+		/// Provides the public call to weight mapping
+		type WeightInfo: WeightInfo;
+		/// Handler for when an NFT has been transferred
+		type OnTransferSubscription: OnTransferSubscriber;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub (super) trait Store)]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub (super) fn deposit_event)]
+	pub enum Event<T: Config>
+	where
+		CollectionNameType: CollectionNameType,
+		TokenCount: TokenCount,
+		ListingId: ListingId,
+		MarketplaceId: MarketplaceId,
 	{
 		/// A new token collection was created (collection, name, owner)
-		CreateCollection(CollectionId, CollectionNameType, AccountId),
+		CreateCollection(CollectionId, CollectionNameType, AccountOf<T>),
 		/// A new series of tokens was created (collection, series id, quantity, owner)
-		CreateSeries(CollectionId, SeriesId, TokenCount, AccountId),
+		CreateSeries(CollectionId, SeriesId, TokenCount, AccountOf<T>),
 		/// Token(s) were created (collection, series id, quantity, owner)
-		CreateTokens(CollectionId, SeriesId, TokenCount, AccountId),
+		CreateTokens(CollectionId, SeriesId, TokenCount, AccountOf<T>),
 		/// Token(s) were transferred (previous owner, token Ids, new owner)
-		Transfer(AccountId, CollectionId, SeriesId, Vec<SerialNumber>, AccountId),
+		Transfer(AccountOf<T>, CollectionId, SeriesId, Vec<SerialNumber>, AccountOf<T>),
 		/// Tokens were burned (collection, series id, serial numbers)
 		Burn(CollectionId, SeriesId, Vec<SerialNumber>),
 		/// A fixed price sale has been listed (collection, listing, marketplace_id)
 		FixedPriceSaleListed(CollectionId, ListingId, Option<MarketplaceId>),
 		/// A fixed price sale has completed (collection, listing, buyer))
-		FixedPriceSaleComplete(CollectionId, ListingId, AccountId),
+		FixedPriceSaleComplete(CollectionId, ListingId, AccountOf<T>),
 		/// A fixed price sale has closed without selling (collection, listing)
 		FixedPriceSaleClosed(CollectionId, ListingId),
 		///A fixed price sale has had its price updated (collection, listing)
@@ -119,19 +148,17 @@ decl_event!(
 		/// An auction has opened (collection, listing, marketplace_id)
 		AuctionOpen(CollectionId, ListingId, Option<MarketplaceId>),
 		/// An auction has sold (collection, listing, payment asset, bid, new owner)
-		AuctionSold(CollectionId, ListingId, AssetId, Balance, AccountId),
+		AuctionSold(CollectionId, ListingId, AssetId, Balance, AccountOf<T>),
 		/// An auction has closed without selling (collection, listing, reason)
 		AuctionClosed(CollectionId, ListingId, Reason),
 		/// A new highest bid was placed (collection, listing, amount)
 		Bid(CollectionId, ListingId, Balance),
 		/// An account has been registered as a marketplace (account, entitlement, marketplace_id)
-		RegisteredMarketplace(AccountId, Permill, MarketplaceId),
+		RegisteredMarketplace(AccountOf<T>, Permill, MarketplaceId),
 	}
-);
 
-decl_error! {
-	/// Error for the staking module.
-	pub enum Error for Module<T: Config> {
+	#[pallet::error]
+	pub enum Error<T> {
 		/// A collection with the same ID already exists
 		CollectionIdExists,
 		/// Given collection name is invalid (invalid utf-8, too long, empty)
@@ -148,6 +175,8 @@ decl_error! {
 		NoCollection,
 		/// The token does not exist
 		NoToken,
+		/// The token is not listed for sale
+		NotForSale,
 		/// The token is not listed for fixed price sale
 		NotForFixedPriceSale,
 		/// The token is not listed for auction sale
@@ -171,92 +200,175 @@ decl_error! {
 		/// The Series name has been set
 		NameAlreadySet,
 		/// The metadata path is invalid (non-utf8 or empty)
-		InvalidMetadataPath
+		InvalidMetadataPath,
 	}
-}
 
-decl_storage! {
-	trait Store for Module<T: Config> as Nft {
-		/// Map from collection to owner address
-		pub CollectionOwner get(fn collection_owner): map hasher(twox_64_concat) CollectionId => Option<T::AccountId>;
-		/// Map from collection to its human friendly name
-		pub CollectionName get(fn collection_name): map hasher(twox_64_concat) CollectionId => CollectionNameType;
-		/// Map from collection to its defacto royalty scheme
-		pub CollectionRoyalties get(fn collection_royalties): map hasher(twox_64_concat) CollectionId => Option<RoyaltiesSchedule<T::AccountId>>;
-		/// Map from a token to lock status if any
-		pub TokenLocks get(fn token_locks): map hasher(twox_64_concat) TokenId => Option<TokenLockReason>;
-		/// Map from a token to its owner
-		/// The token Id is split in this map to allow better indexing (collection, series) + (serial number)
-		pub TokenOwner get(fn token_owner): double_map hasher(twox_64_concat) (CollectionId, SeriesId), hasher(twox_64_concat) SerialNumber => T::AccountId;
-		/// Count of tokens owned by an address, supports ERC721 `balanceOf`
-		pub TokenBalance get(fn token_balance): map hasher(blake2_128_concat) T::AccountId => BTreeMap<(CollectionId, SeriesId), TokenCount>;
-		/// The next available marketplace id
-		pub NextMarketplaceId get(fn next_marketplace_id): MarketplaceId;
-		/// Map from marketplace account_id to royalties schedule
-		pub RegisteredMarketplaces get(fn registered_marketplaces): map hasher(twox_64_concat) MarketplaceId => Marketplace<T::AccountId>;
-		/// Map from (collection, series) to its attributes (deprecated)
-		pub SeriesAttributes get(fn series_attributes): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Vec<NFTAttributeValue>;
-		/// Map from series to its human friendly name
-		pub SeriesName get(fn series_name): map hasher(twox_64_concat) (CollectionId, SeriesId) => CollectionNameType;
-		/// Map from (collection, series) to configured royalties schedule
-		pub SeriesRoyalties get(fn series_royalties): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Option<RoyaltiesSchedule<T::AccountId>>;
-		/// Map from a (collection, series) to its total issuance
-		pub SeriesIssuance get(fn series_issuance): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId =>  TokenCount;
-		/// Map from a token series to its metadata reference scheme
-		pub SeriesMetadataScheme get(fn series_metadata_scheme): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Option<MetadataScheme>;
-		/// DEPRECATED: Migrate to seriesMetadataScheme. Read-only for NFTs created in v46
-		pub SeriesMetadataURI get(fn series_metadata_uri): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Option<Vec<u8>>;
-		/// The next available collection Id
-		NextCollectionId get(fn next_collection_id): CollectionId;
-		/// The next group Id within an NFT collection
-		/// It is used as material to generate the global `TokenId`
-		NextSeriesId get(fn next_series_id): map hasher(twox_64_concat) CollectionId => SeriesId;
-		/// The next available serial number in a given (collection, series)
-		NextSerialNumber get(fn next_serial_number): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => SerialNumber;
-		/// The next available listing Id
-		pub NextListingId get(fn next_listing_id): ListingId;
-		/// NFT sale/auction listings keyed by collection id and token id
-		pub Listings get(fn listings): map hasher(twox_64_concat) ListingId => Option<Listing<T>>;
-		/// Map from collection to any open listings
-		pub OpenCollectionListings get(fn open_collection_listings): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) ListingId => bool;
-		/// Winning bids on open listings. keyed by collection id and token id
-		pub ListingWinningBid get(fn listing_winning_bid): map hasher(twox_64_concat) ListingId => Option<(T::AccountId, Balance)>;
-		/// Block numbers where listings will close. Value is `true` if at block number `listing_id` is scheduled to close.
-		pub ListingEndSchedule get(fn listing_end_schedule): double_map hasher(twox_64_concat) T::BlockNumber, hasher(twox_64_concat) ListingId => bool;
-		/// Version of this module's storage schema
-		StorageVersion build(|_: &GenesisConfig| Releases::V2 as u32): u32;
+	/// Map from collection to owner address
+	#[pallet::storage]
+	#[pallet::getter(fn collection_owner)]
+	pub type CollectionOwner<T: Config> = StorageMap<_, Twox64Concat, CollectionId, T::AccountId>;
+
+	/// Map from collection to its human friendly name
+	#[pallet::storage]
+	#[pallet::getter(fn collection_name)]
+	pub type CollectionName<T: Config> = StorageMap<_, Twox64Concat, CollectionId, CollectionNameType, ValueQuery>;
+
+	/// Map from collection to its defacto royalty scheme
+	#[pallet::storage]
+	#[pallet::getter(fn collection_royalties)]
+	pub type CollectionRoyalties<T: Config> =
+		StorageMap<_, Twox64Concat, CollectionId, RoyaltiesSchedule<T::AccountId>>;
+
+	/// Map from a token to lock status if any
+	#[pallet::storage]
+	#[pallet::getter(fn token_locks)]
+	pub type TokenLocks<T: Config> = StorageMap<_, Twox64Concat, TokenId, TokenLockReason>;
+
+	/// Map from a token to its owner
+	/// The token Id is split in this map to allow better indexing (collection, series) + (serial number)
+	#[pallet::storage]
+	#[pallet::getter(fn token_owner)]
+	pub type TokenOwner<T: Config> = StorageDoubleMap<
+		_,
+		Twox64Concat,
+		(CollectionId, SeriesId),
+		Twox64Concat,
+		SerialNumber,
+		T::AccountId,
+		ValueQuery,
+	>;
+
+	/// Count of tokens owned by an address, supports ERC721 `balanceOf`
+	#[pallet::storage]
+	#[pallet::getter(fn token_balance)]
+	pub type TokenBalance<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AccountId, BTreeMap<(CollectionId, SeriesId), TokenCount>, ValueQuery>;
+
+	/// The next available marketplace id
+	#[pallet::storage]
+	#[pallet::getter(fn next_marketplace_id)]
+	pub type NextMarketplaceId<T: Config> = StorageValue<_, MarketplaceId, ValueQuery>;
+
+	/// Map from marketplace account_id to royalties schedule
+	#[pallet::storage]
+	#[pallet::getter(fn registered_marketplaces)]
+	pub type RegisteredMarketplaces<T: Config> =
+		StorageMap<_, Twox64Concat, MarketplaceId, Marketplace<T::AccountId>, ValueQuery>;
+
+	/// Map from (collection, series) to its attributes (deprecated)
+	#[pallet::storage]
+	#[pallet::getter(fn series_attributes)]
+	pub type SeriesAttributes<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, CollectionId, Twox64Concat, SeriesId, Vec<NFTAttributeValue>, ValueQuery>;
+
+	/// Map from series to its human friendly name
+	#[pallet::storage]
+	#[pallet::getter(fn series_name)]
+	pub type SeriesName<T: Config> =
+		StorageMap<_, Twox64Concat, (CollectionId, SeriesId), CollectionNameType, ValueQuery>;
+
+	/// Map from (collection, series) to configured royalties schedule
+	#[pallet::storage]
+	#[pallet::getter(fn series_royalties)]
+	pub type SeriesRoyalties<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, CollectionId, Twox64Concat, SeriesId, RoyaltiesSchedule<T::AccountId>>;
+
+	/// Map from a (collection, series) to its total issuance
+	#[pallet::storage]
+	#[pallet::getter(fn series_issuance)]
+	pub type SeriesIssuance<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, CollectionId, Twox64Concat, SeriesId, TokenCount, ValueQuery>;
+
+	/// Map from a token series to its metadata reference scheme
+	#[pallet::storage]
+	#[pallet::getter(fn series_metadata_scheme)]
+	pub type SeriesMetadataScheme<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, CollectionId, Twox64Concat, SeriesId, MetadataScheme>;
+
+	/// DEPRECATED: Migrate to seriesMetadataScheme. Read-only for NFTs created in v46
+	#[pallet::storage]
+	#[pallet::getter(fn series_metadata_uri)]
+	pub type SeriesMetadataURI<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, CollectionId, Twox64Concat, SeriesId, Vec<u8>>;
+
+	/// The next available collection Id
+	#[pallet::storage]
+	#[pallet::getter(fn next_collection_id)]
+	pub(super) type NextCollectionId<T: Config> = StorageValue<_, CollectionId, ValueQuery>;
+
+	/// The next group Id within an NFT collection
+	/// It is used as material to generate the global `TokenId`
+	#[pallet::storage]
+	#[pallet::getter(fn next_series_id)]
+	pub(super) type NextSeriesId<T: Config> = StorageMap<_, Twox64Concat, CollectionId, SeriesId, ValueQuery>;
+
+	/// The next available serial number in a given (collection, series)
+	#[pallet::storage]
+	#[pallet::getter(fn next_serial_number)]
+	pub(super) type NextSerialNumber<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, CollectionId, Twox64Concat, SeriesId, SerialNumber, ValueQuery>;
+
+	/// The next available listing Id
+	#[pallet::storage]
+	#[pallet::getter(fn next_listing_id)]
+	pub type NextListingId<T: Config> = StorageValue<_, ListingId, ValueQuery>;
+
+	/// NFT sale/auction listings keyed by collection id and token id
+	#[pallet::storage]
+	#[pallet::getter(fn listings)]
+	pub type Listings<T: Config> = StorageMap<_, Twox64Concat, ListingId, Listing<T>>;
+
+	/// Map from collection to any open listings
+	#[pallet::storage]
+	#[pallet::getter(fn open_collection_listings)]
+	pub type OpenCollectionListings<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, CollectionId, Twox64Concat, ListingId, bool, ValueQuery>;
+
+	/// Winning bids on open listings. keyed by collection id and token id
+	#[pallet::storage]
+	#[pallet::getter(fn listing_winning_bid)]
+	pub type ListingWinningBid<T: Config> = StorageMap<_, Twox64Concat, ListingId, (T::AccountId, Balance)>;
+
+	/// Block numbers where listings will close. Value is `true` if at block number `listing_id` is scheduled to close.
+	#[pallet::storage]
+	#[pallet::getter(fn listing_end_schedule)]
+	pub type ListingEndSchedule<T: Config> =
+		StorageDoubleMap<_, Twox64Concat, T::BlockNumber, Twox64Concat, ListingId, bool, ValueQuery>;
+
+	/// Version of this module's storage schema
+	#[pallet::storage]
+	pub(super) type StorageVersion<T: Config> = StorageValue<_, u32, ValueQuery>;
+
+	#[pallet::genesis_config]
+	#[derive(Default, Serialize, Deserialize)]
+	pub struct GenesisConfig {}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+		fn build(&self) {
+			{
+				let builder: fn(&Self) -> _ = |_: &GenesisConfig| Releases::V2 as u32;
+				let data = &builder(self);
+				let v: &u32 = data;
+				StorageVersion::<T>::put::<&u32>(v);
+			}
+		}
 	}
-}
 
-/// The maximum number of attributes in an NFT collection schema
-pub const MAX_SCHEMA_FIELDS: u32 = 16;
-/// The maximum length of valid collection IDs
-pub const MAX_COLLECTION_NAME_LENGTH: u8 = 32;
-/// The maximum amount of listings to return
-pub const MAX_COLLECTION_LISTING_LIMIT: u16 = 100;
-/// The logging target for this module
-pub(crate) const LOG_TARGET: &str = "nft";
-
-// syntactic sugar for logging.
-#[macro_export]
-macro_rules! log {
-	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
-		log::$level!(
-			target: crate::LOG_TARGET,
-			$patter $(, $values)*
-		)
-	};
-}
-
-decl_module! {
-	pub struct Module<T: Config> for enum Call where origin: T::Origin, system = frame_system {
-		type Error = Error<T>;
-
-		fn deposit_event() = default;
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		/// Check and close all expired listings
+		fn on_initialize(now: BlockNumberFor<T>) -> Weight {
+			// TODO: this is unbounded and could become costly
+			// https://github.com/cennznet/cennznet/issues/444
+			let removed_count = Self::close_listings_at(now);
+			// 'buy' weight is comparable to successful closure of an auction
+			T::WeightInfo::buy() * removed_count as Weight
+		}
 
 		fn on_runtime_upgrade() -> Weight {
-			use migration::v1_storage;
 			use frame_support::IterableStorageMap;
+			use migration::v1_storage;
 
 			if StorageVersion::get() == Releases::V1 as u32 {
 				StorageVersion::put(Releases::V2 as u32);
@@ -275,7 +387,7 @@ decl_module! {
 							buyer,
 							tokens,
 							royalties_schedule,
-						}) => types::Listing::<T>::FixedPrice(types::FixedPriceListing {
+						}) => Listing::<T>::FixedPrice(FixedPriceListing {
 							fixed_price,
 							close,
 							payment_asset,
@@ -292,7 +404,7 @@ decl_module! {
 							seller,
 							tokens,
 							royalties_schedule,
-						}) => types::Listing::<T>::Auction(types::AuctionListing {
+						}) => Listing::<T>::Auction(AuctionListing {
 							reserve_price,
 							close,
 							payment_asset,
@@ -311,27 +423,29 @@ decl_module! {
 				Zero::zero()
 			}
 		}
+	}
 
-		/// Check and close all expired listings
-		fn on_initialize(now: T::BlockNumber) -> Weight {
-			// TODO: this is unbounded and could become costly
-			// https://github.com/cennznet/cennznet/issues/444
-			let removed_count = Self::close_listings_at(now);
-			// 'buy' weight is comparable to successful closure of an auction
-			T::WeightInfo::buy() * removed_count as Weight
-		}
-
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 		/// Set the owner of a collection
 		/// Caller must be the current collection owner
-		#[weight = T::WeightInfo::set_owner()]
-		fn migrate_to_metadata_scheme(origin, collection_id: CollectionId, series_id: SeriesId, scheme: MetadataScheme) -> DispatchResult {
+		#[pallet::weight(T::WeightInfo::set_owner())]
+		pub fn migrate_to_metadata_scheme(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			series_id: SeriesId,
+			scheme: MetadataScheme,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 			if let Some(owner) = Self::collection_owner(collection_id) {
 				ensure!(owner == origin, Error::<T>::NoPermission);
 				// anti-rug
-				ensure!(SeriesMetadataScheme::get(collection_id, series_id).is_none(), Error::<T>::NoPermission);
+				ensure!(
+					SeriesMetadataScheme::get(collection_id, series_id).is_none(),
+					Error::<T>::NoPermission
+				);
 				SeriesMetadataScheme::insert(collection_id, series_id, scheme);
-				Ok(())
+				Ok(().into())
 			} else {
 				Err(Error::<T>::NoCollection.into())
 			}
@@ -339,13 +453,17 @@ decl_module! {
 
 		/// Set the owner of a collection
 		/// Caller must be the current collection owner
-		#[weight = T::WeightInfo::set_owner()]
-		fn set_owner(origin, collection_id: CollectionId, new_owner: T::AccountId) -> DispatchResult {
+		#[pallet::weight(T::WeightInfo::set_owner())]
+		pub fn set_owner(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			new_owner: T::AccountId,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 			if let Some(owner) = Self::collection_owner(collection_id) {
 				ensure!(owner == origin, Error::<T>::NoPermission);
 				<CollectionOwner<T>>::insert(collection_id, new_owner);
-				Ok(())
+				Ok(().into())
 			} else {
 				Err(Error::<T>::NoCollection.into())
 			}
@@ -353,18 +471,32 @@ decl_module! {
 
 		/// Set the name of a series
 		/// Caller must be the current collection owner
-		#[weight = T::WeightInfo::set_owner()]
-		fn set_series_name(origin, collection_id: CollectionId, series_id: SeriesId, name: CollectionNameType) -> DispatchResult {
+		#[pallet::weight(T::WeightInfo::set_owner())]
+		pub fn set_series_name(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			series_id: SeriesId,
+			name: CollectionNameType,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 			if let Some(owner) = Self::collection_owner(collection_id) {
 				ensure!(owner == origin, Error::<T>::NoPermission);
-				ensure!(SeriesMetadataScheme::contains_key(collection_id, series_id), Error::<T>::NoSeries);
-				ensure!(!SeriesName::contains_key((collection_id, series_id)), Error::<T>::NameAlreadySet);
-				ensure!(!name.is_empty() && name.len() <= MAX_COLLECTION_NAME_LENGTH as usize, Error::<T>::CollectionNameInvalid);
+				ensure!(
+					SeriesMetadataScheme::contains_key(collection_id, series_id),
+					Error::<T>::NoSeries
+				);
+				ensure!(
+					!SeriesName::contains_key((collection_id, series_id)),
+					Error::<T>::NameAlreadySet
+				);
+				ensure!(
+					!name.is_empty() && name.len() <= MAX_COLLECTION_NAME_LENGTH as usize,
+					Error::<T>::CollectionNameInvalid
+				);
 				ensure!(core::str::from_utf8(&name).is_ok(), Error::<T>::CollectionNameInvalid);
 
 				SeriesName::insert((collection_id, series_id), name);
-				Ok(())
+				Ok(().into())
 			} else {
 				Err(Error::<T>::NoCollection.into())
 			}
@@ -375,26 +507,36 @@ decl_module! {
 		/// `marketplace_account` - if specified, this account will be registered
 		/// `entitlement` - Permill, percentage of sales to go to the marketplace
 		/// If no marketplace is specified the caller will be registered
-		#[weight = 16_000_000]
-		fn register_marketplace(
-			origin,
+		#[pallet::weight(16_000_000)]
+		pub fn register_marketplace(
+			origin: OriginFor<T>,
 			marketplace_account: Option<T::AccountId>,
-			entitlement: Permill
-		) -> DispatchResult {
+			entitlement: Permill,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
-			ensure!(entitlement.deconstruct() as u32 <= Permill::ACCURACY, Error::<T>::RoyaltiesInvalid);
+			ensure!(
+				entitlement.deconstruct() as u32 <= Permill::ACCURACY,
+				Error::<T>::RoyaltiesInvalid
+			);
 			let marketplace_account = marketplace_account.unwrap_or(origin);
 			let marketplace_id = Self::next_marketplace_id();
 			let marketplace = Marketplace {
 				account: marketplace_account.clone(),
-				entitlement
+				entitlement,
 			};
 			let next_marketplace_id = NextMarketplaceId::get();
-			ensure!(next_marketplace_id.checked_add(One::one()).is_some(), Error::<T>::NoAvailableIds);
+			ensure!(
+				next_marketplace_id.checked_add(One::one()).is_some(),
+				Error::<T>::NoAvailableIds
+			);
 			<RegisteredMarketplaces<T>>::insert(&marketplace_id, marketplace);
-			Self::deposit_event(RawEvent::RegisteredMarketplace(marketplace_account, entitlement, marketplace_id));
+			Self::deposit_event(Event::RegisteredMarketplace(
+				marketplace_account,
+				entitlement,
+				marketplace_id,
+			));
 			NextMarketplaceId::mutate(|i| *i += 1);
-			Ok(())
+			Ok(().into())
 		}
 
 		/// Create a new token collection
@@ -403,19 +545,25 @@ decl_module! {
 		/// `collection_id`- 32 byte utf-8 string
 		/// `metadata_base_uri` - Base URI for off-chain metadata for tokens in this collection
 		/// `royalties_schedule` - defacto royalties plan for secondary sales, this will apply to all tokens in the collection by default.
-		#[weight = T::WeightInfo::create_collection()]
+		#[pallet::weight(T::WeightInfo::create_collection())]
 		pub fn create_collection(
-			origin,
+			origin: OriginFor<T>,
 			name: CollectionNameType,
 			royalties_schedule: Option<RoyaltiesSchedule<T::AccountId>>,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
-			ensure!(!name.is_empty() && name.len() <= MAX_COLLECTION_NAME_LENGTH as usize, Error::<T>::CollectionNameInvalid);
+			ensure!(
+				!name.is_empty() && name.len() <= MAX_COLLECTION_NAME_LENGTH as usize,
+				Error::<T>::CollectionNameInvalid
+			);
 			ensure!(core::str::from_utf8(&name).is_ok(), Error::<T>::CollectionNameInvalid);
 
 			let collection_id = NextCollectionId::get();
-			ensure!(collection_id.checked_add(One::one()).is_some(), Error::<T>::NoAvailableIds);
+			ensure!(
+				collection_id.checked_add(One::one()).is_some(),
+				Error::<T>::NoAvailableIds
+			);
 
 			// Create the collection, update ownership, and bookkeeping
 			if let Some(royalties_schedule) = royalties_schedule {
@@ -426,9 +574,9 @@ decl_module! {
 			CollectionName::insert(collection_id, &name);
 			NextCollectionId::mutate(|c| *c += 1);
 
-			Self::deposit_event(RawEvent::CreateCollection(collection_id, name, origin));
+			Self::deposit_event(Event::CreateCollection(collection_id, name, origin));
 
-			Ok(())
+			Ok(().into())
 		}
 
 		/// Create a new series
@@ -438,16 +586,16 @@ decl_module! {
 		/// `owner` - the token owner, defaults to the caller
 		/// `metadata_scheme` - The off-chain metadata referencing scheme for tokens in this series
 		/// Caller must be the collection owner
-		#[weight = T::WeightInfo::mint_series(*quantity)]
+		#[pallet::weight(T::WeightInfo::mint_series(*quantity))]
 		#[transactional]
 		pub fn mint_series(
-			origin,
+			origin: OriginFor<T>,
 			collection_id: CollectionId,
 			quantity: TokenCount,
 			owner: Option<T::AccountId>,
 			metadata_scheme: MetadataScheme,
 			royalties_schedule: Option<RoyaltiesSchedule<T::AccountId>>,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			// Permission and existence check
@@ -459,12 +607,11 @@ decl_module! {
 
 			// Check we can issue the new tokens
 			let series_id = Self::next_series_id(collection_id);
-			ensure!(
-				series_id.checked_add(One::one()).is_some(),
-				Error::<T>::NoAvailableIds
-			);
+			ensure!(series_id.checked_add(One::one()).is_some(), Error::<T>::NoAvailableIds);
 
-			let metadata_scheme = metadata_scheme.sanitize().map_err(|_| Error::<T>::InvalidMetadataPath)?;
+			let metadata_scheme = metadata_scheme
+				.sanitize()
+				.map_err(|_| Error::<T>::InvalidMetadataPath)?;
 			SeriesMetadataScheme::insert(collection_id, series_id, metadata_scheme);
 
 			// Setup royalties
@@ -480,9 +627,9 @@ decl_module! {
 			// will not overflow, asserted prior qed.
 			NextSeriesId::mutate(collection_id, |i| *i += SeriesId::one());
 
-			Self::deposit_event(RawEvent::CreateSeries(collection_id, series_id, quantity, owner));
+			Self::deposit_event(Event::CreateSeries(collection_id, series_id, quantity, owner));
 
-			Ok(())
+			Ok(().into())
 		}
 
 		/// Mint tokens for an existing series
@@ -492,15 +639,15 @@ decl_module! {
 		/// Caller must be the collection owner
 		/// -----------
 		/// Weight is O(N) where N is `quantity`
-		#[weight = T::WeightInfo::mint_additional(*quantity)]
+		#[pallet::weight(T::WeightInfo::mint_additional(*quantity))]
 		#[transactional]
-		fn mint_additional(
-			origin,
+		pub fn mint_additional(
+			origin: OriginFor<T>,
 			collection_id: CollectionId,
 			series_id: SeriesId,
 			quantity: TokenCount,
 			owner: Option<T::AccountId>,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			// Permission and existence check
@@ -519,32 +666,46 @@ decl_module! {
 			let owner = owner.unwrap_or(origin);
 
 			Self::do_mint(&owner, collection_id, series_id, serial_number, quantity)?;
-			Self::deposit_event(RawEvent::CreateTokens(collection_id, series_id, quantity, owner));
+			Self::deposit_event(Event::CreateTokens(collection_id, series_id, quantity, owner));
 
-			Ok(())
+			Ok(().into())
 		}
 
 		/// Transfer ownership of an NFT
 		/// Caller must be the token owner
-		#[weight = T::WeightInfo::transfer()]
-		fn transfer(origin, token_id: TokenId, new_owner: T::AccountId) -> DispatchResult {
+		#[pallet::weight(T::WeightInfo::transfer())]
+		pub fn transfer(
+			origin: OriginFor<T>,
+			token_id: TokenId,
+			new_owner: T::AccountId,
+		) -> DispatchResultWithPostInfo {
 			let (collection_id, series_id, serial_number) = token_id;
-			Self::transfer_batch(origin, collection_id, series_id, vec![serial_number], new_owner)
+			Self::transfer_batch(origin, collection_id, series_id, vec![serial_number], new_owner);
+			Ok(().into())
 		}
 
 		/// Transfer ownership of a batch of NFTs (atomic)
 		/// Tokens must be from the same series
 		/// Caller must be the token owner
-		#[weight = {
-			T::WeightInfo::transfer().saturating_mul(serial_numbers.len() as Weight)
-		}]
+		#[pallet::weight(
+		T::WeightInfo::transfer().saturating_mul(serial_numbers.len() as Weight)
+		)]
 		#[transactional]
-		fn transfer_batch(origin, collection_id: CollectionId, series_id: SeriesId, serial_numbers: Vec<SerialNumber>, new_owner: T::AccountId) {
+		pub fn transfer_batch(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			series_id: SeriesId,
+			serial_numbers: Vec<SerialNumber>,
+			new_owner: T::AccountId,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			ensure!(serial_numbers.len() > Zero::zero(), Error::<T>::NoToken);
 			for serial_number in serial_numbers.iter() {
-				ensure!(!TokenLocks::contains_key((collection_id, series_id, serial_number)), Error::<T>::TokenListingProtection);
+				ensure!(
+					!TokenLocks::contains_key((collection_id, series_id, serial_number)),
+					Error::<T>::TokenListingProtection
+				);
 				ensure!(
 					Self::token_owner((collection_id, series_id), serial_number) == origin,
 					Error::<T>::NoPermission
@@ -552,16 +713,24 @@ decl_module! {
 			}
 			let _ = Self::do_transfer_unchecked(collection_id, series_id, &serial_numbers, &origin, &new_owner)?;
 
-			Self::deposit_event(RawEvent::Transfer(origin, collection_id, series_id, serial_numbers, new_owner));
+			Self::deposit_event(Event::Transfer(
+				origin,
+				collection_id,
+				series_id,
+				serial_numbers,
+				new_owner,
+			));
+			Ok(().into())
 		}
 
 		/// Burn a token 🔥
 		///
 		/// Caller must be the token owner
-		#[weight = T::WeightInfo::burn()]
-		fn burn(origin, token_id: TokenId) -> DispatchResult {
+		#[pallet::weight(T::WeightInfo::burn())]
+		pub fn burn(origin: OriginFor<T>, token_id: TokenId) -> DispatchResultWithPostInfo {
 			let (collection_id, series_id, serial_number) = token_id;
-			Self::burn_batch(origin, collection_id, series_id, vec![serial_number])
+			Self::burn_batch(origin, collection_id, series_id, vec![serial_number]);
+			Ok(().into())
 		}
 
 		/// Burn some tokens 🔥
@@ -569,21 +738,32 @@ decl_module! {
 		///
 		/// Caller must be the token owner
 		/// Fails on duplicate serials
-		#[weight = {
-			T::WeightInfo::burn()
-				.saturating_add(
-					T::DbWeight::get().reads_writes(2, 1).saturating_mul(serial_numbers.len() as Weight)
-				)
-		}]
+		#[pallet::weight(
+		T::WeightInfo::burn()
+		.saturating_add(
+		T::DbWeight::get().reads_writes(2, 1).saturating_mul(serial_numbers.len() as Weight)
+		)
+		)]
 		#[transactional]
-		fn burn_batch(origin, collection_id: CollectionId, series_id: SeriesId, serial_numbers: Vec<SerialNumber>) {
+		pub fn burn_batch(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			series_id: SeriesId,
+			serial_numbers: Vec<SerialNumber>,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			ensure!(!serial_numbers.is_empty(), Error::<T>::NoToken);
 
 			for serial_number in serial_numbers.iter() {
-				ensure!(!TokenLocks::contains_key((collection_id, series_id, serial_number)), Error::<T>::TokenListingProtection);
-				ensure!(Self::token_owner((collection_id, series_id), serial_number) == origin, Error::<T>::NoPermission);
+				ensure!(
+					!TokenLocks::contains_key((collection_id, series_id, serial_number)),
+					Error::<T>::TokenListingProtection
+				);
+				ensure!(
+					Self::token_owner((collection_id, series_id), serial_number) == origin,
+					Error::<T>::NoPermission
+				);
 				<TokenOwner<T>>::remove((collection_id, series_id), serial_number);
 			}
 
@@ -597,13 +777,16 @@ decl_module! {
 						} else {
 							*balance = new_balance;
 						}
-						Ok(())
-					},
+						Ok(().into())
+					}
 					None => Err(Error::<T>::NoToken.into()),
 				}
 			})?;
 
-			if Self::series_issuance(collection_id, series_id).saturating_sub(serial_numbers.len() as TokenCount).is_zero() {
+			if Self::series_issuance(collection_id, series_id)
+				.saturating_sub(serial_numbers.len() as TokenCount)
+				.is_zero()
+			{
 				// this is the last of the tokens
 				SeriesAttributes::remove(collection_id, series_id);
 				SeriesIssuance::remove(collection_id, series_id);
@@ -613,7 +796,8 @@ decl_module! {
 				SeriesIssuance::mutate(collection_id, series_id, |q| *q = q.saturating_sub(quantity));
 			}
 
-			Self::deposit_event(RawEvent::Burn(collection_id, series_id, serial_numbers));
+			Self::deposit_event(Event::Burn(collection_id, series_id, serial_numbers));
+			Ok(().into())
 		}
 
 		/// Sell a single token at a fixed price
@@ -624,17 +808,17 @@ decl_module! {
 		/// `duration` listing duration time in blocks from now
 		/// `marketplace` optionally, the marketplace that the NFT is being sold on
 		/// Caller must be the token owner
-		#[weight = T::WeightInfo::sell()]
+		#[pallet::weight(T::WeightInfo::sell())]
 		#[transactional]
-		fn sell(
-			origin,
+		pub fn sell(
+			origin: OriginFor<T>,
 			token_id: TokenId,
 			buyer: Option<T::AccountId>,
 			payment_asset: AssetId,
 			fixed_price: Balance,
 			duration: Option<T::BlockNumber>,
 			marketplace_id: Option<MarketplaceId>,
-		) {
+		) -> DispatchResultWithPostInfo {
 			Self::sell_bundle(
 				origin,
 				vec![token_id],
@@ -644,6 +828,7 @@ decl_module! {
 				duration,
 				marketplace_id,
 			)?;
+			Ok(().into())
 		}
 
 		/// Sell a bundle of tokens at a fixed price
@@ -655,22 +840,22 @@ decl_module! {
 		/// `fixed_price` ask price
 		/// `duration` listing duration time in blocks from now
 		/// Caller must be the token owner
-		#[weight = {
-			T::WeightInfo::sell()
-				.saturating_add(
-					T::DbWeight::get().reads_writes(2, 1).saturating_mul(tokens.len() as Weight)
-				)
-		}]
+		#[pallet::weight(
+		T::WeightInfo::sell()
+		.saturating_add(
+		T::DbWeight::get().reads_writes(2, 1).saturating_mul(tokens.len() as Weight)
+		)
+		)]
 		#[transactional]
-		fn sell_bundle(
-			origin,
+		pub fn sell_bundle(
+			origin: OriginFor<T>,
 			tokens: Vec<TokenId>,
 			buyer: Option<T::AccountId>,
 			payment_asset: AssetId,
 			fixed_price: Balance,
 			duration: Option<T::BlockNumber>,
-			marketplace_id: Option<MarketplaceId>
-		) {
+			marketplace_id: Option<MarketplaceId>,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			if tokens.is_empty() {
@@ -685,81 +870,123 @@ decl_module! {
 			// use the first token's collection as representative of the bundle
 			let (bundle_collection_id, _series_id, _serial_number) = tokens[0];
 			for (collection_id, series_id, serial_number) in tokens.iter() {
-				ensure!(!TokenLocks::contains_key((collection_id, series_id, serial_number)), Error::<T>::TokenListingProtection);
-				ensure!(Self::token_owner((collection_id, series_id), serial_number) == origin, Error::<T>::NoPermission);
-				TokenLocks::insert((collection_id, series_id, serial_number), TokenLockReason::Listed(listing_id));
+				ensure!(
+					!TokenLocks::contains_key((collection_id, series_id, serial_number)),
+					Error::<T>::TokenListingProtection
+				);
+				ensure!(
+					Self::token_owner((collection_id, series_id), serial_number) == origin,
+					Error::<T>::NoPermission
+				);
+				TokenLocks::insert(
+					(collection_id, series_id, serial_number),
+					TokenLockReason::Listed(listing_id),
+				);
 			}
 
-			let listing_end_block = <frame_system::Pallet<T>>::block_number().saturating_add(duration.unwrap_or_else(T::DefaultListingDuration::get));
+			let listing_end_block = <frame_system::Pallet<T>>::block_number()
+				.saturating_add(duration.unwrap_or_else(T::DefaultListingDuration::get));
 			ListingEndSchedule::<T>::insert(listing_end_block, listing_id, true);
-			let listing = Listing::<T>::FixedPrice(
-				FixedPriceListing::<T> {
-					payment_asset,
-					fixed_price,
-					close: listing_end_block,
-					tokens: tokens.clone(),
-					buyer: buyer.clone(),
-					seller: origin.clone(),
-					royalties_schedule,
-					marketplace_id,
-				}
-			);
+			let listing = Listing::<T>::FixedPrice(FixedPriceListing::<T> {
+				payment_asset,
+				fixed_price,
+				close: listing_end_block,
+				tokens: tokens.clone(),
+				buyer: buyer.clone(),
+				seller: origin.clone(),
+				royalties_schedule,
+				marketplace_id: marketplace_id.clone(),
+			});
 
 			OpenCollectionListings::insert(bundle_collection_id, listing_id, true);
 			Listings::insert(listing_id, listing);
 			NextListingId::mutate(|i| *i += 1);
 
-			Self::deposit_event(RawEvent::FixedPriceSaleListed(bundle_collection_id, listing_id, marketplace_id));
+			Self::deposit_event(Event::FixedPriceSaleListed(
+				bundle_collection_id,
+				listing_id,
+				marketplace_id.clone(),
+			));
+			Ok(().into())
 		}
 
 		/// Buy a token listing for its specified price
-		#[weight = T::WeightInfo::buy()]
+		#[pallet::weight(T::WeightInfo::buy())]
 		#[transactional]
-		fn buy(origin, listing_id: ListingId) {
+		pub fn buy(origin: OriginFor<T>, listing_id: ListingId) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
-			ensure!(<Listings<T>>::contains_key(listing_id), Error::<T>::NotForFixedPriceSale);
+			ensure!(
+				<Listings<T>>::contains_key(listing_id),
+				Error::<T>::NotForFixedPriceSale
+			);
 
 			if let Some(Listing::FixedPrice(listing)) = Self::listings(listing_id) {
-
 				// if buyer is specified in the listing, then `origin` must be buyer
 				if let Some(buyer) = &listing.buyer {
 					ensure!(&origin == buyer, Error::<T>::NoPermission);
 				}
 
-				let (collection_id, series_id, _serial_number) = listing.tokens.get(0).ok_or_else(|| Error::<T>::NoToken)?;
+				let (collection_id, series_id, _serial_number) =
+					listing.tokens.get(0).ok_or_else(|| Error::<T>::NoToken)?;
 
 				let royalty_fees = listing.royalties_schedule.calculate_total_entitlement();
 				if royalty_fees.is_zero() {
 					// full proceeds to seller/`current_owner`
-					T::MultiCurrency::transfer(&origin, &listing.seller, listing.payment_asset, listing.fixed_price, ExistenceRequirement::AllowDeath)?;
+					T::MultiCurrency::transfer(
+						&origin,
+						&listing.seller,
+						listing.payment_asset,
+						listing.fixed_price,
+						ExistenceRequirement::AllowDeath,
+					)?;
 				} else {
 					// withdraw funds from buyer, split between royalty payments and seller
 					let mut for_seller = listing.fixed_price;
-					let mut imbalance = T::MultiCurrency::withdraw(&origin, listing.payment_asset, listing.fixed_price, WithdrawReasons::TRANSFER, ExistenceRequirement::AllowDeath)?;
+					let mut imbalance = T::MultiCurrency::withdraw(
+						&origin,
+						listing.payment_asset,
+						listing.fixed_price,
+						WithdrawReasons::TRANSFER,
+						ExistenceRequirement::AllowDeath,
+					)?;
 					for (who, entitlement) in listing.royalties_schedule.entitlements.into_iter() {
 						let royalty = entitlement * listing.fixed_price;
 						for_seller -= royalty;
-						imbalance = match imbalance.offset(T::MultiCurrency::deposit_into_existing(&who, listing.payment_asset, royalty)?) {
+						imbalance = match imbalance.offset(T::MultiCurrency::deposit_into_existing(
+							&who,
+							listing.payment_asset,
+							royalty,
+						)?) {
 							SameOrOther::Same(value) => value,
 							SameOrOther::Other(_) | SameOrOther::None => return Err(Error::<T>::InternalPayment.into()),
 						}
 					}
-					match imbalance.offset(T::MultiCurrency::deposit_into_existing(&listing.seller, listing.payment_asset, for_seller)?) {
+					match imbalance.offset(T::MultiCurrency::deposit_into_existing(
+						&listing.seller,
+						listing.payment_asset,
+						for_seller,
+					)?) {
 						SameOrOther::Same(_) => (),
 						SameOrOther::Other(_) | SameOrOther::None => return Err(Error::<T>::InternalPayment.into()),
 					}
 				}
 
-				let serial_numbers: Vec<SerialNumber> = listing.tokens.iter().map(|token_id| {
-					TokenLocks::remove(token_id);
-					token_id.2
-				}).collect();
+				let serial_numbers: Vec<SerialNumber> = listing
+					.tokens
+					.iter()
+					.map(|token_id| {
+						TokenLocks::remove(token_id);
+						token_id.2
+					})
+					.collect();
 				OpenCollectionListings::remove(collection_id, listing_id);
 
-				let _ = Self::do_transfer_unchecked(*collection_id, *series_id, &serial_numbers, &listing.seller, &origin)?;
+				let _ =
+					Self::do_transfer_unchecked(*collection_id, *series_id, &serial_numbers, &listing.seller, &origin)?;
 				Self::remove_fixed_price_listing(listing_id);
 
-				Self::deposit_event(RawEvent::FixedPriceSaleComplete(*collection_id, listing_id, origin));
+				Self::deposit_event(Event::FixedPriceSaleComplete(*collection_id, listing_id, origin));
+				Ok(().into())
 			} else {
 				return Err(Error::<T>::NotForFixedPriceSale.into());
 			}
@@ -771,23 +998,24 @@ decl_module! {
 		/// - `payment_asset` fungible asset Id to receive payment with
 		/// - `reserve_price` winning bid must be over this threshold
 		/// - `duration` length of the auction (in blocks), uses default duration if unspecified
-		#[weight = T::WeightInfo::sell()]
-		fn auction(
-			origin,
+		#[pallet::weight(T::WeightInfo::sell())]
+		pub fn auction(
+			origin: OriginFor<T>,
 			token_id: TokenId,
 			payment_asset: AssetId,
 			reserve_price: Balance,
 			duration: Option<T::BlockNumber>,
-			marketplace_id: Option<MarketplaceId>
-		) -> DispatchResult {
+			marketplace_id: Option<MarketplaceId>,
+		) -> DispatchResultWithPostInfo {
 			Self::auction_bundle(
 				origin,
 				vec![token_id],
 				payment_asset,
 				reserve_price,
 				duration,
-				marketplace_id
-			)
+				marketplace_id,
+			);
+			Ok(().into())
 		}
 
 		/// Auction a bundle of tokens on the open market to the highest bidder
@@ -798,21 +1026,21 @@ decl_module! {
 		/// - `payment_asset` fungible asset Id to receive payment with
 		/// - `reserve_price` winning bid must be over this threshold
 		/// - `duration` length of the auction (in blocks), uses default duration if unspecified
-		#[weight = {
-			T::WeightInfo::sell()
-				.saturating_add(
-					T::DbWeight::get().reads_writes(2, 1).saturating_mul(tokens.len() as Weight)
-				)
-		}]
+		#[pallet::weight(
+		T::WeightInfo::sell()
+		.saturating_add(
+		T::DbWeight::get().reads_writes(2, 1).saturating_mul(tokens.len() as Weight)
+		)
+		)]
 		#[transactional]
-		fn auction_bundle(
-			origin,
+		pub fn auction_bundle(
+			origin: OriginFor<T>,
 			tokens: Vec<TokenId>,
 			payment_asset: AssetId,
 			reserve_price: Balance,
 			duration: Option<T::BlockNumber>,
-			marketplace_id: Option<MarketplaceId>
-		) {
+			marketplace_id: Option<MarketplaceId>,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			if tokens.is_empty() {
@@ -827,37 +1055,50 @@ decl_module! {
 			// use the first token's collection as representative of the bundle
 			let (bundle_collection_id, _series_id, _serial_number) = tokens[0];
 			for (collection_id, series_id, serial_number) in tokens.iter() {
-				ensure!(!TokenLocks::contains_key((collection_id, series_id, serial_number)), Error::<T>::TokenListingProtection);
-				ensure!(Self::token_owner((collection_id, series_id), serial_number) == origin, Error::<T>::NoPermission);
-				TokenLocks::insert((collection_id, series_id, serial_number), TokenLockReason::Listed(listing_id));
+				ensure!(
+					!TokenLocks::contains_key((collection_id, series_id, serial_number)),
+					Error::<T>::TokenListingProtection
+				);
+				ensure!(
+					Self::token_owner((collection_id, series_id), serial_number) == origin,
+					Error::<T>::NoPermission
+				);
+				TokenLocks::insert(
+					(collection_id, series_id, serial_number),
+					TokenLockReason::Listed(listing_id),
+				);
 			}
 
-			let listing_end_block =<frame_system::Pallet<T>>::block_number().saturating_add(duration.unwrap_or_else(T::DefaultListingDuration::get));
+			let listing_end_block = <frame_system::Pallet<T>>::block_number()
+				.saturating_add(duration.unwrap_or_else(T::DefaultListingDuration::get));
 			ListingEndSchedule::<T>::insert(listing_end_block, listing_id, true);
-			let listing = Listing::<T>::Auction(
-				AuctionListing::<T> {
-					payment_asset,
-					reserve_price,
-					close: listing_end_block,
-					tokens: tokens.clone(),
-					seller: origin.clone(),
-					royalties_schedule,
-					marketplace_id,
-				}
-			);
+			let listing = Listing::<T>::Auction(AuctionListing::<T> {
+				payment_asset,
+				reserve_price,
+				close: listing_end_block,
+				tokens: tokens.clone(),
+				seller: origin.clone(),
+				royalties_schedule,
+				marketplace_id: marketplace_id.clone(),
+			});
 
 			OpenCollectionListings::insert(bundle_collection_id, listing_id, true);
 			Listings::insert(listing_id, listing);
 			NextListingId::mutate(|i| *i += 1);
 
-			Self::deposit_event(RawEvent::AuctionOpen(bundle_collection_id, listing_id, marketplace_id));
+			Self::deposit_event(Event::AuctionOpen(
+				bundle_collection_id,
+				listing_id,
+				marketplace_id.clone(),
+			));
+			Ok(().into())
 		}
 
 		/// Place a bid on an open auction
 		/// - `amount` to bid (in the seller's requested payment asset)
-		#[weight = T::WeightInfo::bid()]
+		#[pallet::weight(T::WeightInfo::bid())]
 		#[transactional]
-		fn bid(origin, listing_id: ListingId, amount: Balance) {
+		pub fn bid(origin: OriginFor<T>, listing_id: ListingId, amount: BalanceOf<T>) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			if let Some(Listing::Auction(mut listing)) = Self::listings(listing_id) {
@@ -869,13 +1110,19 @@ decl_module! {
 				}
 
 				// check user has the requisite funds to make this bid
-				let balance = T::MultiCurrency::free_balance(&origin, listing.payment_asset);
-				if let Some(balance_after_bid) = balance.checked_sub(amount) {
+				let balance: BalanceOf<T> = T::MultiCurrency::free_balance(&origin, listing.payment_asset);
+				if let Some(balance_after_bid) = balance::checked_sub(&amount) {
 					// TODO: review behaviour with 3.0 upgrade: https://github.com/cennznet/cennznet/issues/414
 					// - `amount` is unused
 					// - if there are multiple locks on user asset this could return true inaccurately
 					// - `T::MultiCurrency::reserve(origin, asset_id, amount)` should be checking this internally...
-					let _ = T::MultiCurrency::ensure_can_withdraw(&origin, listing.payment_asset, amount, WithdrawReasons::RESERVE, balance_after_bid)?;
+					let _ = T::MultiCurrency::ensure_can_withdraw(
+						&origin,
+						listing.payment_asset,
+						amount,
+						WithdrawReasons::RESERVE,
+						balance_after_bid,
+					)?;
 				}
 
 				// try lock funds
@@ -902,7 +1149,8 @@ decl_module! {
 				}
 
 				let listing_collection_id = listing.tokens[0].0;
-				Self::deposit_event(RawEvent::Bid(listing_collection_id, listing_id, amount));
+				Self::deposit_event(Event::Bid(listing_collection_id, listing_id, amount));
+				Ok(().into())
 			} else {
 				return Err(Error::<T>::NotForAuction.into());
 			}
@@ -911,8 +1159,8 @@ decl_module! {
 		/// Close a sale or auction returning tokens
 		/// Requires no successful bids have been made for an auction.
 		/// Caller must be the listed seller
-		#[weight = T::WeightInfo::cancel_sale()]
-		fn cancel_sale(origin, listing_id: ListingId) {
+		#[pallet::weight(T::WeightInfo::cancel_sale())]
+		pub fn cancel_sale(origin: OriginFor<T>, listing_id: ListingId) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			match Self::listings(listing_id) {
@@ -926,11 +1174,15 @@ decl_module! {
 					let collection_id = sale.tokens[0].0;
 					OpenCollectionListings::remove(collection_id, listing_id);
 
-					Self::deposit_event(RawEvent::FixedPriceSaleClosed(collection_id, listing_id));
-				},
+					Self::deposit_event(Event::FixedPriceSaleClosed(collection_id, listing_id));
+					Ok(().into())
+				}
 				Some(Listing::<T>::Auction(auction)) => {
 					ensure!(auction.seller == origin, Error::<T>::NoPermission);
-					ensure!(Self::listing_winning_bid(listing_id).is_none(), Error::<T>::TokenListingProtection);
+					ensure!(
+						Self::listing_winning_bid(listing_id).is_none(),
+						Error::<T>::TokenListingProtection
+					);
 					Listings::<T>::remove(listing_id);
 					ListingEndSchedule::<T>::remove(auction.close, listing_id);
 					for token_id in auction.tokens.iter() {
@@ -939,9 +1191,14 @@ decl_module! {
 					let collection_id = auction.tokens[0].0;
 					OpenCollectionListings::remove(collection_id, listing_id);
 
-					Self::deposit_event(RawEvent::AuctionClosed(collection_id, listing_id, AuctionClosureReason::VendorCancelled));
-				},
-				None => {},
+					Self::deposit_event(Event::AuctionClosed(
+						collection_id,
+						listing_id,
+						AuctionClosureReason::VendorCancelled,
+					));
+					Ok(().into())
+				}
+				None => Err(Error::<T>::NotForSale)
 			}
 		}
 
@@ -950,12 +1207,12 @@ decl_module! {
 		/// `listing_id` id of the fixed price listing
 		/// `new_price` new fixed price
 		/// Caller must be the token owner
-		#[weight = T::WeightInfo::update_fixed_price()]
-		fn update_fixed_price (
-			origin,
+		#[pallet::weight(T::WeightInfo::update_fixed_price())]
+		pub fn update_fixed_price(
+			origin: OriginFor<T>,
 			listing_id: ListingId,
-			new_price: Balance
-		) -> DispatchResult {
+			new_price: Balance,
+		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
 			match Self::listings(listing_id) {
@@ -966,368 +1223,372 @@ decl_module! {
 					let collection_id = sale.tokens[0].0;
 
 					Listings::insert(listing_id, Listing::<T>::FixedPrice(sale));
-					Self::deposit_event(RawEvent::FixedPriceSalePriceUpdated(collection_id, listing_id));
-					Ok(())
-				},
+					Self::deposit_event(Event::FixedPriceSalePriceUpdated(collection_id, listing_id));
+					Ok(().into())
+				}
 				Some(Listing::<T>::Auction(_)) => Err(Error::<T>::NotForFixedPriceSale.into()),
 				None => Err(Error::<T>::NotForFixedPriceSale.into()),
 			}
 		}
 	}
-}
 
-impl<T: Config> Module<T> {
-	/// Return whether the series exists or not
-	pub fn series_exists(collection_id: CollectionId, series_id: SeriesId) -> bool {
-		SeriesMetadataScheme::contains_key(collection_id, series_id)
-	}
-	/// Construct & return the full metadata URI for a given `token_id` (analogous to ERC721 metadata token_uri)
-	pub fn token_uri(token_id: TokenId) -> Vec<u8> {
-		use core::fmt::Write;
-		if let Some(scheme) = Self::series_metadata_scheme(token_id.0, token_id.1) {
-			let mut token_uri = sp_std::Writer::default();
-			match scheme {
-				MetadataScheme::Http(path) => {
-					let path = core::str::from_utf8(&path).unwrap_or("");
-					write!(&mut token_uri, "http://{}/{}.json", path, token_id.2).expect("Not written");
-				}
-				MetadataScheme::Https(path) => {
-					let path = core::str::from_utf8(&path).unwrap_or("");
-					write!(&mut token_uri, "https://{}/{}.json", path, token_id.2).expect("Not written");
-				}
-				MetadataScheme::IpfsDir(dir_cid) => {
-					write!(
-						&mut token_uri,
-						"ipfs://{}/{}.json",
-						core::str::from_utf8(&dir_cid).unwrap_or(""),
-						token_id.2
-					)
-					.expect("Not written");
-				}
-				MetadataScheme::IpfsShared(shared_cid) => {
-					write!(
-						&mut token_uri,
-						"ipfs://{}.json",
-						core::str::from_utf8(&shared_cid).unwrap_or("")
-					)
-					.expect("Not written");
-				}
-			}
-			token_uri.inner().clone()
-		} else {
-			// should not happen
-			log!(warn, "🃏 Unexpected empty metadata scheme: {:?}", token_id);
-			Default::default()
+	impl<T: Config> Pallet<T> {
+		/// Return whether the series exists or not
+		pub fn series_exists(collection_id: CollectionId, series_id: SeriesId) -> bool {
+			SeriesMetadataScheme::contains_key(collection_id, series_id)
 		}
-	}
-	/// Check royalties will be respected on all tokens if placed into a bundle sale.
-	/// We're ok iff, all tokens in the bundle are from the:
-	/// 1) same collection and same series
-	/// 2) same collection and different series, no series royalties set (could extend to iff royalties equal)
-	/// Although possible, we do not support:
-	/// 3) different collections, no royalties allowed
-	fn check_bundle_royalties(
-		tokens: &[TokenId],
-		marketplace_id: Option<MarketplaceId>,
-	) -> Result<RoyaltiesSchedule<T::AccountId>, Error<T>> {
-		// use the first token's collection as representative of the bundle
-		let (bundle_collection_id, bundle_series_id, _serial_number) = tokens[0];
-
-		for (collection_id, series_id, _serial_number) in tokens.iter() {
-			ensure!(*collection_id == bundle_collection_id, Error::<T>::MixedBundleSale);
-			if *series_id != bundle_series_id {
-				ensure!(
-					!<SeriesRoyalties<T>>::contains_key(collection_id, series_id),
-					Error::<T>::RoyaltiesProtection
-				);
-			}
-		}
-		// series schedule takes priority if it exists
-		let mut royalties = Self::series_royalties(bundle_collection_id, bundle_series_id)
-			.unwrap_or_else(|| Self::collection_royalties(bundle_collection_id).unwrap_or_else(Default::default));
-		let royalties = match marketplace_id {
-			Some(marketplace_id) => {
-				ensure!(
-					<RegisteredMarketplaces<T>>::contains_key(marketplace_id),
-					Error::<T>::MarketplaceNotRegistered
-				);
-				let marketplace = Self::registered_marketplaces(marketplace_id);
-				royalties
-					.entitlements
-					.push((marketplace.account, marketplace.entitlement));
-				ensure!(royalties.validate(), Error::<T>::RoyaltiesInvalid);
-				royalties
-			}
-			None => royalties,
-		};
-		Ok(royalties)
-	}
-	/// Transfer the given tokens from `current_owner` to `new_owner`
-	/// Does no verification
-	fn do_transfer_unchecked(
-		collection_id: CollectionId,
-		series_id: SeriesId,
-		serial_numbers: &[SerialNumber],
-		current_owner: &T::AccountId,
-		new_owner: &T::AccountId,
-	) -> DispatchResult {
-		for serial_number in serial_numbers.iter() {
-			<TokenOwner<T>>::insert((collection_id, series_id), serial_number, new_owner);
-			let token_id: TokenId = (collection_id, series_id, *serial_number);
-			T::OnTransferSubscription::on_nft_transfer(&token_id);
-		}
-		let quantity = serial_numbers.len() as TokenCount;
-		let _ = <TokenBalance<T>>::try_mutate::<_, (), Error<T>, _>(&current_owner, |balances| {
-			match (*balances).get_mut(&(collection_id, series_id)) {
-				Some(balance) => {
-					let new_balance = balance.saturating_sub(quantity);
-					if new_balance.is_zero() {
-						balances.remove(&(collection_id, series_id));
-					} else {
-						*balance = new_balance;
+		/// Construct & return the full metadata URI for a given `token_id` (analogous to ERC721 metadata token_uri)
+		pub fn token_uri(token_id: TokenId) -> Vec<u8> {
+			use core::fmt::Write;
+			if let Some(scheme) = Self::series_metadata_scheme(token_id.0, token_id.1) {
+				let mut token_uri = sp_std::Writer::default();
+				match scheme {
+					MetadataScheme::Http(path) => {
+						let path = core::str::from_utf8(&path).unwrap_or("");
+						write!(&mut token_uri, "http://{}/{}.json", path, token_id.2).expect("Not written");
 					}
-					Ok(())
-				}
-				None => return Err(Error::NoToken.into()), // should not happen
-			}
-		});
-		<TokenBalance<T>>::mutate(&new_owner, |balances| {
-			*balances.entry((collection_id, series_id)).or_default() += quantity
-		});
-
-		Ok(())
-	}
-	/// Mint additional tokens in a series
-	fn do_mint(
-		owner: &T::AccountId,
-		collection_id: CollectionId,
-		series_id: SeriesId,
-		serial_number: SerialNumber,
-		quantity: TokenCount,
-	) -> DispatchResult {
-		ensure!(quantity > Zero::zero(), Error::<T>::NoToken);
-
-		// Mint the set tokens
-		for serial_number in serial_number..serial_number + quantity {
-			<TokenOwner<T>>::insert((collection_id, series_id), serial_number as SerialNumber, &owner);
-		}
-
-		// update token balances
-		<TokenBalance<T>>::mutate(&owner, |balances| {
-			*balances.entry((collection_id, series_id)).or_default() += quantity
-		});
-		SeriesIssuance::mutate(collection_id, series_id, |q| *q = q.saturating_add(quantity));
-		NextSerialNumber::mutate(collection_id, series_id, |q| *q = q.saturating_add(quantity));
-
-		Ok(())
-	}
-
-	/// Find the tokens owned by an `address` in the given collection
-	pub fn collected_tokens(collection_id: CollectionId, address: &T::AccountId) -> Vec<TokenId> {
-		let next_series_id = Self::next_series_id(collection_id);
-		let mut owned_tokens = Vec::<TokenId>::default();
-
-		// Search each series up until the last known series Id
-		for series_id in 0..next_series_id {
-			let mut owned_in_series: Vec<TokenId> = <TokenOwner<T>>::iter_prefix((collection_id, series_id))
-				.filter_map(|(serial_number, owner)| {
-					if &owner == address {
-						Some((collection_id, series_id, serial_number))
-					} else {
-						None
+					MetadataScheme::Https(path) => {
+						let path = core::str::from_utf8(&path).unwrap_or("");
+						write!(&mut token_uri, "https://{}/{}.json", path, token_id.2).expect("Not written");
 					}
-				})
-				.collect();
-			if !owned_in_series.is_empty() {
-				owned_in_series.sort_unstable();
-				owned_tokens.append(&mut owned_in_series);
+					MetadataScheme::IpfsDir(dir_cid) => {
+						write!(
+							&mut token_uri,
+							"ipfs://{}/{}.json",
+							core::str::from_utf8(&dir_cid).unwrap_or(""),
+							token_id.2
+						)
+						.expect("Not written");
+					}
+					MetadataScheme::IpfsShared(shared_cid) => {
+						write!(
+							&mut token_uri,
+							"ipfs://{}.json",
+							core::str::from_utf8(&shared_cid).unwrap_or("")
+						)
+						.expect("Not written");
+					}
+				}
+				token_uri.inner().clone()
+			} else {
+				// should not happen
+				log!(warn, "🃏 Unexpected empty metadata scheme: {:?}", token_id);
+				Default::default()
 			}
 		}
+		/// Check royalties will be respected on all tokens if placed into a bundle sale.
+		/// We're ok iff, all tokens in the bundle are from the:
+		/// 1) same collection and same series
+		/// 2) same collection and different series, no series royalties set (could extend to iff royalties equal)
+		/// Although possible, we do not support:
+		/// 3) different collections, no royalties allowed
+		fn check_bundle_royalties(
+			tokens: &[TokenId],
+			marketplace_id: Option<MarketplaceId>,
+		) -> Result<RoyaltiesSchedule<T::AccountId>, Error<T>> {
+			// use the first token's collection as representative of the bundle
+			let (bundle_collection_id, bundle_series_id, _serial_number) = tokens[0];
 
-		return owned_tokens;
-	}
-	/// Remove a single fixed price listing and all it's metadata
-	fn remove_fixed_price_listing(listing_id: ListingId) {
-		let listing_type = Listings::<T>::take(listing_id);
-		ListingWinningBid::<T>::remove(listing_id);
-		if let Some(Listing::<T>::FixedPrice(listing)) = listing_type {
-			ListingEndSchedule::<T>::remove(listing.close, listing_id);
-		}
-	}
-	/// Close all listings scheduled to close at this block `now`, ensuring payments and ownerships changes are made for winning bids
-	/// Metadata for listings will be removed from storage
-	/// Returns the number of listings removed
-	fn close_listings_at(now: T::BlockNumber) -> u32 {
-		let mut removed = 0_u32;
-		for (listing_id, _) in ListingEndSchedule::<T>::drain_prefix(now).into_iter() {
-			match Listings::<T>::take(listing_id) {
-				Some(Listing::FixedPrice(listing)) => {
-					// release listed tokens
-					for token_id in listing.tokens.iter() {
-						TokenLocks::remove(token_id);
-					}
-					let listing_collection_id = listing.tokens[0].0;
-					OpenCollectionListings::remove(listing_collection_id, listing_id);
-
-					Self::deposit_event(RawEvent::FixedPriceSaleClosed(listing_collection_id, listing_id));
+			for (collection_id, series_id, _serial_number) in tokens.iter() {
+				ensure!(*collection_id == bundle_collection_id, Error::<T>::MixedBundleSale);
+				if *series_id != bundle_series_id {
+					ensure!(
+						!<SeriesRoyalties<T>>::contains_key(collection_id, series_id),
+						Error::<T>::RoyaltiesProtection
+					);
 				}
-				Some(Listing::Auction(listing)) => {
-					// release listed tokens
-					for token_id in listing.tokens.iter() {
-						TokenLocks::remove(token_id);
-					}
-					let listing_collection_id = listing.tokens[0].0;
-					OpenCollectionListings::remove(listing_collection_id, listing_id);
-
-					if let Some((winner, hammer_price)) = ListingWinningBid::<T>::take(listing_id) {
-						if let Err(err) = Self::settle_auction(&listing, &winner, hammer_price) {
-							// auction settlement failed despite our prior validations.
-							// release winning bid funds
-							log!(error, "🃏 auction settlement failed: {:?}", err);
-							T::MultiCurrency::unreserve(&winner, listing.payment_asset, hammer_price);
-
-							// listing metadata is removed by now.
-							Self::deposit_event(RawEvent::AuctionClosed(
-								listing_collection_id,
-								listing_id,
-								AuctionClosureReason::SettlementFailed,
-							));
+			}
+			// series schedule takes priority if it exists
+			let mut royalties = Self::series_royalties(bundle_collection_id, bundle_series_id)
+				.unwrap_or_else(|| Self::collection_royalties(bundle_collection_id).unwrap_or_else(Default::default));
+			let royalties = match marketplace_id {
+				Some(marketplace_id) => {
+					ensure!(
+						<RegisteredMarketplaces<T>>::contains_key(marketplace_id),
+						Error::<T>::MarketplaceNotRegistered
+					);
+					let marketplace = Self::registered_marketplaces(marketplace_id);
+					royalties
+						.entitlements
+						.push((marketplace.account, marketplace.entitlement));
+					ensure!(royalties.validate(), Error::<T>::RoyaltiesInvalid);
+					royalties
+				}
+				None => royalties,
+			};
+			Ok(royalties)
+		}
+		/// Transfer the given tokens from `current_owner` to `new_owner`
+		/// Does no verification
+		fn do_transfer_unchecked(
+			collection_id: CollectionId,
+			series_id: SeriesId,
+			serial_numbers: &[SerialNumber],
+			current_owner: &T::AccountId,
+			new_owner: &T::AccountId,
+		) -> DispatchResultWithPostInfo {
+			for serial_number in serial_numbers.iter() {
+				<TokenOwner<T>>::insert((collection_id, series_id), serial_number, new_owner);
+				let token_id: TokenId = (collection_id, series_id, *serial_number);
+				T::OnTransferSubscription::on_nft_transfer(&token_id);
+			}
+			let quantity = serial_numbers.len() as TokenCount;
+			let _ = <TokenBalance<T>>::try_mutate::<_, (), Error<T>, _>(&current_owner, |balances| {
+				match (*balances).get_mut(&(collection_id, series_id)) {
+					Some(balance) => {
+						let new_balance = balance.saturating_sub(quantity);
+						if new_balance.is_zero() {
+							balances.remove(&(collection_id, series_id));
 						} else {
-							// auction settlement success
-							Self::deposit_event(RawEvent::AuctionSold(
+							*balance = new_balance;
+						}
+						Ok(().into())
+					}
+					None => return Err(Error::NoToken.into()), // should not happen
+				}
+			});
+			<TokenBalance<T>>::mutate(&new_owner, |balances| {
+				*balances.entry((collection_id, series_id)).or_default() += quantity
+			});
+
+			Ok(().into())
+		}
+		/// Mint additional tokens in a series
+		fn do_mint(
+			owner: &T::AccountId,
+			collection_id: CollectionId,
+			series_id: SeriesId,
+			serial_number: SerialNumber,
+			quantity: TokenCount,
+		) -> DispatchResultWithPostInfo {
+			ensure!(quantity > Zero::zero(), Error::<T>::NoToken);
+
+			// Mint the set tokens
+			for serial_number in serial_number..serial_number + quantity {
+				<TokenOwner<T>>::insert((collection_id, series_id), serial_number as SerialNumber, &owner);
+			}
+
+			// update token balances
+			<TokenBalance<T>>::mutate(&owner, |balances| {
+				*balances.entry((collection_id, series_id)).or_default() += quantity
+			});
+			SeriesIssuance::mutate(collection_id, series_id, |q| *q = q.saturating_add(quantity));
+			NextSerialNumber::mutate(collection_id, series_id, |q| *q = q.saturating_add(quantity));
+
+			Ok(().into())
+		}
+
+		/// Find the tokens owned by an `address` in the given collection
+		pub fn collected_tokens(collection_id: CollectionId, address: &T::AccountId) -> Vec<TokenId> {
+			let next_series_id = Self::next_series_id(collection_id);
+			let mut owned_tokens = Vec::<TokenId>::default();
+
+			// Search each series up until the last known series Id
+			for series_id in 0..next_series_id {
+				let mut owned_in_series: Vec<TokenId> = <TokenOwner<T>>::iter_prefix((collection_id, series_id))
+					.filter_map(|(serial_number, owner)| {
+						if &owner == address {
+							Some((collection_id, series_id, serial_number))
+						} else {
+							None
+						}
+					})
+					.collect();
+				if !owned_in_series.is_empty() {
+					owned_in_series.sort_unstable();
+					owned_tokens.append(&mut owned_in_series);
+				}
+			}
+
+			return owned_tokens;
+		}
+		/// Remove a single fixed price listing and all it's metadata
+		fn remove_fixed_price_listing(listing_id: ListingId) {
+			let listing_type = Listings::<T>::take(listing_id);
+			ListingWinningBid::<T>::remove(listing_id);
+			if let Some(Listing::<T>::FixedPrice(listing)) = listing_type {
+				ListingEndSchedule::<T>::remove(listing.close, listing_id);
+			}
+		}
+		/// Close all listings scheduled to close at this block `now`, ensuring payments and ownerships changes are made for winning bids
+		/// Metadata for listings will be removed from storage
+		/// Returns the number of listings removed
+		fn close_listings_at(now: T::BlockNumber) -> u32 {
+			let mut removed = 0_u32;
+			for (listing_id, _) in ListingEndSchedule::<T>::drain_prefix(now).into_iter() {
+				match Listings::<T>::take(listing_id) {
+					Some(Listing::FixedPrice(listing)) => {
+						// release listed tokens
+						for token_id in listing.tokens.iter() {
+							TokenLocks::remove(token_id);
+						}
+						let listing_collection_id = listing.tokens[0].0;
+						OpenCollectionListings::remove(listing_collection_id, listing_id);
+
+						Self::deposit_event(Event::FixedPriceSaleClosed(listing_collection_id, listing_id));
+					}
+					Some(Listing::Auction(listing)) => {
+						// release listed tokens
+						for token_id in listing.tokens.iter() {
+							TokenLocks::remove(token_id);
+						}
+						let listing_collection_id = listing.tokens[0].0;
+						OpenCollectionListings::remove(listing_collection_id, listing_id);
+
+						if let Some((winner, hammer_price)) = ListingWinningBid::<T>::take(listing_id) {
+							if let Err(err) = Self::settle_auction(&listing, &winner, hammer_price) {
+								// auction settlement failed despite our prior validations.
+								// release winning bid funds
+								log!(error, "🃏 auction settlement failed: {:?}", err.into());
+								T::MultiCurrency::unreserve(&winner, listing.payment_asset, hammer_price);
+
+								// listing metadata is removed by now.
+								Self::deposit_event(Event::AuctionClosed(
+									listing_collection_id,
+									listing_id,
+									AuctionClosureReason::SettlementFailed,
+								));
+							} else {
+								// auction settlement success
+								Self::deposit_event(Event::AuctionSold(
+									listing_collection_id,
+									listing_id,
+									listing.payment_asset,
+									hammer_price,
+									winner,
+								));
+							}
+						} else {
+							// normal closure, no acceptable bids
+							// listing metadata is removed by now.
+							Self::deposit_event(Event::AuctionClosed(
 								listing_collection_id,
 								listing_id,
-								listing.payment_asset,
-								hammer_price,
-								winner,
+								AuctionClosureReason::ExpiredNoBids,
 							));
 						}
-					} else {
-						// normal closure, no acceptable bids
-						// listing metadata is removed by now.
-						Self::deposit_event(RawEvent::AuctionClosed(
-							listing_collection_id,
-							listing_id,
-							AuctionClosureReason::ExpiredNoBids,
-						));
 					}
+					None => (),
 				}
-				None => (),
+				removed += 1;
 			}
-			removed += 1;
+
+			removed
 		}
+		/// Settle an auction listing (guaranteed to be atomic).
+		/// - transfer funds from winning bidder to entitled royalty accounts and seller
+		/// - transfer ownership to the winning bidder
+		#[transactional]
+		fn settle_auction(
+			listing: &AuctionListing<T>,
+			winner: &T::AccountId,
+			hammer_price: Balance,
+		) -> DispatchResultWithPostInfo {
+			let for_royalties = listing.royalties_schedule.calculate_total_entitlement() * hammer_price;
+			let mut for_seller = hammer_price;
 
-		removed
-	}
-	/// Settle an auction listing (guaranteed to be atomic).
-	/// - transfer funds from winning bidder to entitled royalty accounts and seller
-	/// - transfer ownership to the winning bidder
-	#[transactional]
-	fn settle_auction(listing: &AuctionListing<T>, winner: &T::AccountId, hammer_price: Balance) -> DispatchResult {
-		let for_royalties = listing.royalties_schedule.calculate_total_entitlement() * hammer_price;
-		let mut for_seller = hammer_price;
+			// do royalty payments
+			if !for_royalties.is_zero() {
+				let entitlements = listing.royalties_schedule.entitlements.clone();
+				for (who, entitlement) in entitlements.into_iter() {
+					let royalty = entitlement * hammer_price;
+					let _ = T::MultiCurrency::repatriate_reserved(&winner, listing.payment_asset, &who, royalty)?;
+					for_seller -= royalty;
+				}
+			}
 
-		// do royalty payments
-		if !for_royalties.is_zero() {
-			let entitlements = listing.royalties_schedule.entitlements.clone();
-			for (who, entitlement) in entitlements.into_iter() {
-				let royalty = entitlement * hammer_price;
-				let _ = T::MultiCurrency::repatriate_reserved(&winner, listing.payment_asset, &who, royalty)?;
-				for_seller -= royalty;
+			let seller_balance = T::MultiCurrency::free_balance(&listing.seller, listing.payment_asset);
+			let _ = T::MultiCurrency::repatriate_reserved(&winner, listing.payment_asset, &listing.seller, for_seller)?;
+
+			// The implementation of `repatriate_reserved` may take less than the required amount and succeed
+			// this should not happen but could for reasons outside the control of this module
+			ensure!(
+				T::MultiCurrency::free_balance(&listing.seller, listing.payment_asset)
+					>= seller_balance.saturating_add(for_seller),
+				Error::<T>::InternalPayment
+			);
+			// all tokens have the same collection and series id
+			let (collection_id, series_id, _) = listing.tokens[0];
+			let serial_numbers: Vec<SerialNumber> = listing.tokens.iter().map(|id| id.2).collect();
+			Self::do_transfer_unchecked(collection_id, series_id, &serial_numbers, &listing.seller, &winner)
+		}
+		/// Get collection information from given collection_id
+		pub fn collection_info<AccountId>(collection_id: CollectionId) -> Option<CollectionInfo<T::AccountId>> {
+			let name = Self::collection_name(&collection_id);
+			let owner = Self::collection_owner(&collection_id).unwrap_or(Default::default());
+
+			if name.is_empty() {
+				None
+			} else {
+				let royalties = match <CollectionRoyalties<T>>::get(&collection_id) {
+					Some(r) => r.entitlements,
+					None => Vec::new(),
+				};
+				Some(CollectionInfo { name, owner, royalties })
 			}
 		}
-
-		let seller_balance = T::MultiCurrency::free_balance(&listing.seller, listing.payment_asset);
-		let _ = T::MultiCurrency::repatriate_reserved(&winner, listing.payment_asset, &listing.seller, for_seller)?;
-
-		// The implementation of `repatriate_reserved` may take less than the required amount and succeed
-		// this should not happen but could for reasons outside the control of this module
-		ensure!(
-			T::MultiCurrency::free_balance(&listing.seller, listing.payment_asset)
-				>= seller_balance.saturating_add(for_seller),
-			Error::<T>::InternalPayment
-		);
-		// all tokens have the same collection and series id
-		let (collection_id, series_id, _) = listing.tokens[0];
-		let serial_numbers: Vec<SerialNumber> = listing.tokens.iter().map(|id| id.2).collect();
-		Self::do_transfer_unchecked(collection_id, series_id, &serial_numbers, &listing.seller, &winner)
-	}
-	/// Get collection information from given collection_id
-	pub fn collection_info<AccountId>(collection_id: CollectionId) -> Option<CollectionInfo<T::AccountId>> {
-		let name = Self::collection_name(&collection_id);
-		let owner = Self::collection_owner(&collection_id).unwrap_or(Default::default());
-
-		if name.is_empty() {
-			None
-		} else {
-			let royalties = match <CollectionRoyalties<T>>::get(&collection_id) {
+		/// Find the attributes and owner from a series
+		pub fn token_info(
+			collection_id: CollectionId,
+			series_id: SeriesId,
+			serial_number: SerialNumber,
+		) -> TokenInfo<T::AccountId> {
+			let attributes = Self::series_attributes(collection_id, series_id);
+			let owner = Self::token_owner((collection_id, series_id), serial_number);
+			let royalties = match <SeriesRoyalties<T>>::get(collection_id, series_id) {
 				Some(r) => r.entitlements,
-				None => Vec::new(),
+				None => match <CollectionRoyalties<T>>::get(&collection_id) {
+					Some(r) => r.entitlements,
+					None => Vec::new(),
+				},
 			};
-			Some(CollectionInfo { name, owner, royalties })
+			TokenInfo {
+				attributes,
+				owner,
+				royalties,
+			}
 		}
-	}
-	/// Find the attributes and owner from a series
-	pub fn token_info(
-		collection_id: CollectionId,
-		series_id: SeriesId,
-		serial_number: SerialNumber,
-	) -> TokenInfo<T::AccountId> {
-		let attributes = Self::series_attributes(collection_id, series_id);
-		let owner = Self::token_owner((collection_id, series_id), serial_number);
-		let royalties = match <SeriesRoyalties<T>>::get(collection_id, series_id) {
-			Some(r) => r.entitlements,
-			None => match <CollectionRoyalties<T>>::get(&collection_id) {
-				Some(r) => r.entitlements,
-				None => Vec::new(),
-			},
-		};
-		TokenInfo {
-			attributes,
-			owner,
-			royalties,
-		}
-	}
-	/// Get list of all NFT listings within a range
-	pub fn collection_listings(
-		collection_id: CollectionId,
-		cursor: u128,
-		limit: u16,
-	) -> (Option<u128>, Vec<(ListingId, Listing<T>)>) {
-		let mut listing_ids = OpenCollectionListings::iter_prefix(collection_id)
-			.map(|(listing_id, _)| listing_id)
-			.collect::<Vec<u128>>();
-		listing_ids.sort();
-		let last_id = listing_ids.last().copied();
-		let mut highest_cursor: u128 = 0;
+		/// Get list of all NFT listings within a range
+		pub fn collection_listings(
+			collection_id: CollectionId,
+			cursor: u128,
+			limit: u16,
+		) -> (Option<u128>, Vec<(ListingId, Listing<T>)>) {
+			let mut listing_ids = OpenCollectionListings::iter_prefix(collection_id)
+				.map(|(listing_id, _)| listing_id)
+				.collect::<Vec<u128>>();
+			listing_ids.sort();
+			let last_id = listing_ids.last().copied();
+			let mut highest_cursor: u128 = 0;
 
-		let response: Vec<(ListingId, Listing<T>)> = listing_ids
-			.into_iter()
-			.filter(|listing_id| listing_id >= &cursor)
-			.take(sp_std::cmp::min(limit, MAX_COLLECTION_LISTING_LIMIT).into())
-			.map(|listing_id| {
-				highest_cursor = listing_id;
-				match Self::listings(listing_id) {
-					Some(listing) => Some((listing_id, listing)),
-					None => {
-						log!(error, "🃏 Unexpected empty listing: {:?}", listing_id);
+			let response: Vec<(ListingId, Listing<T>)> = listing_ids
+				.into_iter()
+				.filter(|listing_id| listing_id >= &cursor)
+				.take(sp_std::cmp::min(limit, MAX_COLLECTION_LISTING_LIMIT).into())
+				.map(|listing_id| {
+					highest_cursor = listing_id;
+					match Self::listings(listing_id) {
+						Some(listing) => Some((listing_id, listing)),
+						None => {
+							log!(error, "🃏 Unexpected empty listing: {:?}", listing_id);
+							None
+						}
+					}
+				})
+				.flatten()
+				.collect();
+
+			let new_cursor = match last_id {
+				Some(id) => {
+					if highest_cursor != id {
+						Some(highest_cursor + 1)
+					} else {
 						None
 					}
 				}
-			})
-			.flatten()
-			.collect();
-
-		let new_cursor = match last_id {
-			Some(id) => {
-				if highest_cursor != id {
-					Some(highest_cursor + 1)
-				} else {
-					None
-				}
-			}
-			None => None,
-		};
-		(new_cursor, response)
+				None => None,
+			};
+			(new_cursor, response)
+		}
 	}
 }

--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -50,7 +50,6 @@ pub mod pallet {
 	use crate::weights::WeightInfo;
 	use cennznet_primitives::types::{AssetId, Balance, CollectionId, SerialNumber, SeriesId, TokenId};
 	use crml_support::{IsTokenOwner, MultiCurrency, OnTransferSubscriber};
-	use frame_support::pallet_prelude::*;
 	use frame_support::{
 		pallet_prelude::*,
 		traits::{ExistenceRequirement, Imbalance, SameOrOther, WithdrawReasons},
@@ -91,7 +90,7 @@ pub mod pallet {
 	macro_rules! log {
 	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
 		log::$level!(
-			target: crate::LOG_TARGET,
+			target: self::LOG_TARGET,
 			$patter $(, $values)*
 		)
 	};

--- a/crml/nft/src/migration.rs
+++ b/crml/nft/src/migration.rs
@@ -1,8 +1,10 @@
 #[allow(dead_code)]
-use crate::pallet::{AuctionListing, FixedPriceListing, Listing, Listings, StorageVersion, CollectionId, Config, SeriesId, log};
+use crate::pallet::{
+	log, AuctionListing, CollectionId, Config, FixedPriceListing, Listing, Listings, SeriesId, StorageVersion,
+};
 use crate::types::{ListingId, MultiCurrency, Releases, RoyaltiesSchedule};
 use cennznet_primitives::types::TokenId;
-use frame_support::{IterableStorageMap, StoragePrefixedMap, weights::Weight};
+use frame_support::{weights::Weight, IterableStorageMap, StoragePrefixedMap};
 use sp_runtime::traits::Zero;
 use sp_std::prelude::*;
 

--- a/crml/nft/src/migration.rs
+++ b/crml/nft/src/migration.rs
@@ -1,18 +1,22 @@
 #[allow(dead_code)]
-pub mod v1_storage {
-	use crate::{CollectionId, Config, ListingId, MultiCurrency, RoyaltiesSchedule, SeriesId, TokenId};
-	use codec::{Decode, Encode};
-	use scale_info::TypeInfo;
-	use sp_std::prelude::*;
+use crate::pallet::{AuctionListing, FixedPriceListing, Listing, Listings, StorageVersion, CollectionId, Config, SeriesId, log};
+use crate::types::{ListingId, MultiCurrency, Releases, RoyaltiesSchedule};
+use cennznet_primitives::types::TokenId;
+use frame_support::{IterableStorageMap, StoragePrefixedMap, weights::Weight};
+use sp_runtime::traits::Zero;
+use sp_std::prelude::*;
 
-	#[derive(Decode, Encode, Debug, Clone, PartialEq, TypeInfo)]
+pub mod v1_storage {
+	use super::*;
+
+	#[derive(codec::Encode, codec::Decode, Debug, Clone, PartialEq, scale_info::TypeInfo)]
 	pub enum MetadataBaseURI {
 		Ipfs,
 		Https(Vec<u8>),
 	}
 
 	/// A type of NFT sale listing
-	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
+	#[derive(Debug, Clone, codec::Encode, codec::Decode, PartialEq, Eq, scale_info::TypeInfo)]
 	#[scale_info(skip_type_params(T))]
 	pub enum Listing<T: Config> {
 		FixedPrice(FixedPriceListing<T>),
@@ -20,7 +24,7 @@ pub mod v1_storage {
 	}
 
 	/// Information about an auction listing v1
-	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
+	#[derive(Debug, Clone, codec::Encode, codec::Decode, PartialEq, Eq, scale_info::TypeInfo)]
 	#[scale_info(skip_type_params(T))]
 	pub struct AuctionListing<T: Config> {
 		/// The asset to allow bids with
@@ -38,7 +42,7 @@ pub mod v1_storage {
 	}
 
 	/// Information about a fixed price listing v1
-	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
+	#[derive(Debug, Clone, codec::Encode, codec::Decode, PartialEq, Eq, scale_info::TypeInfo)]
 	#[scale_info(skip_type_params(T))]
 	pub struct FixedPriceListing<T: Config> {
 		/// The asset to allow bids with
@@ -57,7 +61,6 @@ pub mod v1_storage {
 		pub royalties_schedule: RoyaltiesSchedule<T::AccountId>,
 	}
 
-	pub struct Module<T>(sp_std::marker::PhantomData<T>);
 	frame_support::decl_storage! {
 		trait Store for Module<T: Config> as Nft {
 			pub IsSingleIssue get(fn is_single_issue): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => bool;
@@ -65,5 +68,64 @@ pub mod v1_storage {
 			pub SeriesMetadataURI get(fn series_metadata_uri): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Option<Vec<u8>>;
 			pub Listings get(fn listings): map hasher(twox_64_concat) ListingId => Option<Listing<T>>;
 		}
+	}
+
+	frame_support::decl_module! {
+		pub struct Module<T: Config> for enum Call where origin: T::Origin { }
+	}
+}
+
+pub fn migrate_to_v2<T: Config>() -> Weight {
+	if StorageVersion::<T>::get() == Releases::V1 as u32 {
+		StorageVersion::<T>::put(Releases::V2 as u32);
+		v1_storage::CollectionMetadataURI::remove_all(None);
+		v1_storage::IsSingleIssue::remove_all(None);
+
+		let listings: Vec<(ListingId, v1_storage::Listing<T>)> = v1_storage::Listings::<T>::iter().collect();
+		let weight = listings.len() as Weight;
+		for (listing_id, listing) in listings {
+			let listing_migrated = match listing {
+				v1_storage::Listing::<T>::FixedPrice(v1_storage::FixedPriceListing {
+					fixed_price,
+					close,
+					payment_asset,
+					seller,
+					buyer,
+					tokens,
+					royalties_schedule,
+				}) => Listing::<T>::FixedPrice(FixedPriceListing {
+					fixed_price,
+					close,
+					payment_asset,
+					seller,
+					buyer,
+					tokens,
+					royalties_schedule,
+					marketplace_id: None,
+				}),
+				v1_storage::Listing::<T>::Auction(v1_storage::AuctionListing {
+					reserve_price,
+					close,
+					payment_asset,
+					seller,
+					tokens,
+					royalties_schedule,
+				}) => Listing::<T>::Auction(AuctionListing {
+					reserve_price,
+					close,
+					payment_asset,
+					seller,
+					tokens,
+					royalties_schedule,
+					marketplace_id: None,
+				}),
+			};
+			Listings::insert(listing_id, listing_migrated);
+		}
+
+		log!(warn, "🃏 listings migrated");
+		return 6_000_000 as Weight + weight * 100_000;
+	} else {
+		Zero::zero()
 	}
 }

--- a/crml/nft/src/types.rs
+++ b/crml/nft/src/types.rs
@@ -15,10 +15,10 @@
 
 //! NFT module types
 
-use crate::Config;
+use crate::pallet::Config;
 use cennznet_primitives::types::{AssetId, Balance, BlockNumber, SerialNumber, TokenId};
 use codec::{Decode, Encode};
-use crml_support::MultiCurrency;
+pub use crml_support::MultiCurrency;
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize, Serializer};

--- a/evm-precompiles/utils/src/data.rs
+++ b/evm-precompiles/utils/src/data.rs
@@ -64,6 +64,10 @@ impl From<&[u8]> for Bytes {
 	}
 }
 
+impl From<[u8;4]> for Bytes {
+	fn from(a: [u8;4]) -> Self { Self(a.to_vec()) }
+}
+
 impl From<&str> for Bytes {
 	fn from(a: &str) -> Self {
 		a.as_bytes().into()

--- a/evm-precompiles/utils/src/data.rs
+++ b/evm-precompiles/utils/src/data.rs
@@ -64,8 +64,10 @@ impl From<&[u8]> for Bytes {
 	}
 }
 
-impl From<[u8;4]> for Bytes {
-	fn from(a: [u8;4]) -> Self { Self(a.to_vec()) }
+impl From<[u8; 4]> for Bytes {
+	fn from(a: [u8; 4]) -> Self {
+		Self(a.to_vec())
+	}
 }
 
 impl From<&str> for Bytes {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -86,7 +86,7 @@ pub use crml_generic_asset::{
 	StakingAssetCurrency,
 };
 use crml_governance::{ProposalId, ProposalVoteInfo};
-use crml_nft::{CollectionInfo, Listing, ListingId, TokenInfo};
+use crml_nft::pallet::{CollectionInfo, Listing, ListingId, TokenInfo};
 use crml_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
 pub use crml_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use fp_rpc::TransactionStatus;
@@ -251,7 +251,7 @@ parameter_types! {
 	/// Only applies to string/vec allocated types
 	pub const MaxAttributeLength: u8 = 140;
 }
-impl crml_nft::Config for Runtime {
+impl crml_nft::pallet::Config for Runtime {
 	type Event = Event;
 	type MultiCurrency = GenericAsset;
 	type MaxAttributeLength = MaxAttributeLength;
@@ -850,7 +850,7 @@ construct_runtime!(
 		Historical: session_historical::{Pallet},
 		Cennzx: crml_cennzx::{Pallet, Call, Storage, Config<T>, Event<T>},
 		Rewards: crml_staking_rewards::{Pallet, Call, Storage, Config, Event<T>},
-		Nft: crml_nft::{Pallet, Call, Storage, Event<T>},
+		Nft: crml_nft::pallet::{Pallet, Call, Storage, Event<T>},
 		Governance: crml_governance::{Pallet, Call, Storage, Event},
 		EthBridge: crml_eth_bridge::{Pallet, Call, Storage, Event, ValidateUnsigned},
 		Erc20Peg: crml_erc20_peg::{Pallet, Call, Storage, Config, Event<T>},


### PR DESCRIPTION
#### Description
- I did this just for fun / to gain a better understanding of substrate FRAME

#### Changes
 - wrap NFT module in pallet {}
 - use new macros, i.e. `#[frame_support::pallet]` `#[pallet::event]` `#[pallet::storage]`
 - upgrade storage items to use `StorageValue`, `StorageMap` etc.
 - update use statements for NFT module to `crml_nft::pallet::{[imports]}`

#### Notes
 - Followed [this guideline](https://docs.substrate.io/rustdocs/latest/frame_support/attr.pallet.html#upgrade-guidelines)
 - If we wanted to use this would still need a lot more work i.e. updating mocks & tests