### PR TITLE
Add ChainId to storage

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -720,7 +720,13 @@ impl pallet_base_fee::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ChainId: u64 = 3000;
+	/// Ethereum ChainId
+	/// 2999 (local/dev/default)
+	/// 3000 (mainnet)
+	/// 3001 (nikau)
+	/// 3002 (rata)
+	/// NB: Configured on live chains via one-time setStorage tx at key `:EthereumChainId:`
+	pub storage EthereumChainId: u64 = 2_999;
 	pub BlockGasLimit: U256
 		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
 	pub PrecompilesValue: CENNZnetPrecompiles<Runtime> = CENNZnetPrecompiles::<_>::new();
@@ -746,7 +752,7 @@ impl pallet_evm::Config for Runtime {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type PrecompilesType = CENNZnetPrecompiles<Self>;
 	type PrecompilesValue = PrecompilesValue;
-	type ChainId = ChainId;
+	type ChainId = EthereumChainId;
 	type BlockGasLimit = BlockGasLimit;
 	type OnChargeTransaction = CENNZnetOnChargeEVMTransaction<Self>;
 	type FindAuthor = EthereumFindAuthor<Babe>;


### PR DESCRIPTION
Intended chain Ids
```
2999 (local/dev/default)
3000 (rata)
3001 (nikau)
1337 (mainnet)
```

config this value via storage key: `0x158653f42cf7c7edeb9b7611d006423a` / `xxhash(':EthereumChainId:', 128)`
Closes #614 