### PR TITLE
Chore/03 2022 monthly updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2118,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "evm",
  "parity-scale-codec",
@@ -2242,7 +2242,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2259,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4788,12 +4788,13 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4822,7 +4823,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4850,7 +4851,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4860,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "fp-evm",
  "num",
@@ -4871,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4882,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=dc41b4322e109265b7e12e01719dba24e1b96bdc#dc41b4322e109265b7e12e01719dba24e1b96bdc"
+source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
 dependencies = [
  "fp-evm",
  "ripemd160",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell",
@@ -210,7 +210,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.0",
+ "socket2 0.4.4",
  "waker-fn",
  "winapi 0.3.9",
 ]
@@ -234,23 +234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f38756dd9ac84671c428afbf7c9f7495feff9ec5b0710f17100098e5b354ac"
-dependencies = [
- "async-io",
- "blocking",
- "cfg-if 1.0.0",
- "event-listener",
- "futures-lite",
- "libc",
- "once_cell",
- "signal-hook",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "async-std"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,7 +243,6 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "async-lock",
- "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -315,7 +297,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -328,7 +310,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -375,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -455,10 +437,10 @@ version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
 dependencies = [
- "funty",
+ "funty 1.1.0",
  "radium 0.5.3",
  "tap",
- "wyz",
+ "wyz 0.2.0",
 ]
 
 [[package]]
@@ -467,10 +449,22 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
- "funty",
+ "funty 1.1.0",
  "radium 0.6.2",
  "tap",
- "wyz",
+ "wyz 0.2.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+dependencies = [
+ "funty 2.0.0",
+ "radium 0.7.0",
+ "tap",
+ "wyz 0.5.0",
 ]
 
 [[package]]
@@ -482,6 +476,15 @@ dependencies = [
  "crypto-mac 0.8.0",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+dependencies = [
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -550,6 +553,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding 0.2.1",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
  "generic-array 0.14.4",
 ]
 
@@ -642,9 +654,20 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cache-padded"
@@ -735,7 +758,7 @@ dependencies = [
  "node-inspect",
  "pallet-evm",
  "pallet-im-online",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-chain-spec",
@@ -793,7 +816,7 @@ dependencies = [
  "ethereum",
  "frame-support",
  "libsecp256k1 0.6.0",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-api",
  "sp-application-crypto",
@@ -900,7 +923,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-treasury",
  "pallet-utility",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "precompile-utils",
  "rustc-hex",
  "scale-info",
@@ -1025,10 +1048,40 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1106,7 +1159,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -1125,7 +1178,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "serde",
  "serde_json",
  "sp-api",
@@ -1142,7 +1195,7 @@ dependencies = [
 name = "crml-cennzx-rpc-runtime-api"
 version = "2.0.0"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "serde",
  "serde_json",
  "sp-api",
@@ -1161,7 +1214,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex-literal",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -1180,8 +1233,8 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.11.1",
  "scale-info",
  "serde",
  "serde_json",
@@ -1204,7 +1257,7 @@ dependencies = [
  "libsecp256k1 0.6.0",
  "pallet-balances",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 2.3.1",
  "scale-info",
  "serde",
  "sp-core",
@@ -1223,7 +1276,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -1241,7 +1294,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-db",
  "sc-consensus",
  "serde",
@@ -1257,7 +1310,7 @@ name = "crml-generic-asset-rpc-runtime-api"
 version = "2.0.0"
 dependencies = [
  "crml-generic-asset",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
  "sp-std",
 ]
@@ -1273,7 +1326,7 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-scheduler",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -1291,7 +1344,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-db",
  "serde",
  "sp-api",
@@ -1305,7 +1358,7 @@ name = "crml-governance-rpc-runtime-api"
 version = "2.0.0"
 dependencies = [
  "crml-governance",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
  "sp-std",
 ]
@@ -1322,7 +1375,7 @@ dependencies = [
  "frame-system",
  "hex",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "serde_json",
@@ -1343,7 +1396,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
  "sp-arithmetic",
  "sp-blockchain",
@@ -1360,7 +1413,7 @@ version = "2.1.1"
 dependencies = [
  "cennznet-primitives",
  "crml-nft",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "serde_json",
  "sp-api",
  "sp-runtime",
@@ -1384,8 +1437,8 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-curve",
  "pallet-timestamp",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.11.1",
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
@@ -1410,7 +1463,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "serde",
  "serde_json",
  "sp-api",
@@ -1424,7 +1477,7 @@ dependencies = [
 name = "crml-staking-rpc-runtime-api"
 version = "1.0.0"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
  "sp-runtime",
  "sp-std",
@@ -1440,9 +1493,9 @@ dependencies = [
  "hex-literal",
  "impl-trait-for-tuples",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "precompile-utils",
- "primitive-types",
+ "primitive-types 0.11.1",
  "serde",
  "sp-runtime",
  "sp-std",
@@ -1460,7 +1513,7 @@ dependencies = [
  "frame-system",
  "hex-literal",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -1478,7 +1531,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "serde_json",
@@ -1498,7 +1551,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
  "sp-blockchain",
  "sp-core",
@@ -1512,7 +1565,7 @@ version = "2.0.0"
 dependencies = [
  "crml-transaction-payment",
  "frame-support",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
  "sp-runtime",
 ]
@@ -1532,6 +1585,16 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.4",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -1686,6 +1749,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle 2.4.0",
+]
+
+[[package]]
 name = "directories"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,7 +1863,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1823,13 +1897,13 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "ethbloom"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
  "impl-serde",
  "scale-info",
@@ -1838,35 +1912,35 @@ dependencies = [
 
 [[package]]
 name = "ethereum"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c90e0a755da706ce0970ec0fa8cc48aabcc8e8efa1245336acf718dab06ffe"
+checksum = "23750149fe8834c0e24bb9adcbacbe06c45b9861f15df53e09f26cb7c4ab91ef"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "ethereum-types",
  "hash-db",
  "hash256-std-hasher",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "rlp",
  "rlp-derive",
  "scale-info",
  "serde",
- "sha3 0.9.1",
+ "sha3 0.10.1",
  "triehash",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.11.1",
  "scale-info",
  "uint",
 ]
@@ -1882,8 +1956,8 @@ dependencies = [
  "hex-literal",
  "libsecp256k1 0.6.0",
  "log",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.11.1",
  "sc-client-api",
  "sc-keystore",
  "sc-network",
@@ -1915,7 +1989,7 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-pubsub",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sc-rpc",
  "sc-utils",
@@ -1933,8 +2007,8 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "evm"
-version = "0.33.1"
-source = "git+https://github.com/rust-blockchain/evm?rev=52d5fe5d1fd665a495ea34cc67c5f0c6bc6dd23e#52d5fe5d1fd665a495ea34cc67c5f0c6bc6dd23e"
+version = "0.35.0"
+source = "git+https://github.com/rust-blockchain/evm?rev=0b686f8c2c83a52638917caa649dc23302fda80d#0b686f8c2c83a52638917caa649dc23302fda80d"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1943,47 +2017,46 @@ dependencies = [
  "evm-gasometer",
  "evm-runtime",
  "log",
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 3.1.2",
+ "primitive-types 0.11.1",
  "rlp",
  "scale-info",
  "serde",
- "sha3 0.8.2",
+ "sha3 0.10.1",
 ]
 
 [[package]]
 name = "evm-core"
-version = "0.33.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=52d5fe5d1fd665a495ea34cc67c5f0c6bc6dd23e#52d5fe5d1fd665a495ea34cc67c5f0c6bc6dd23e"
+version = "0.35.0"
+source = "git+https://github.com/rust-blockchain/evm?rev=0b686f8c2c83a52638917caa649dc23302fda80d#0b686f8c2c83a52638917caa649dc23302fda80d"
 dependencies = [
- "funty",
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 3.1.2",
+ "primitive-types 0.11.1",
  "scale-info",
  "serde",
 ]
 
 [[package]]
 name = "evm-gasometer"
-version = "0.33.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=52d5fe5d1fd665a495ea34cc67c5f0c6bc6dd23e#52d5fe5d1fd665a495ea34cc67c5f0c6bc6dd23e"
+version = "0.35.0"
+source = "git+https://github.com/rust-blockchain/evm?rev=0b686f8c2c83a52638917caa649dc23302fda80d#0b686f8c2c83a52638917caa649dc23302fda80d"
 dependencies = [
  "environmental",
  "evm-core",
  "evm-runtime",
- "primitive-types",
+ "primitive-types 0.11.1",
 ]
 
 [[package]]
 name = "evm-runtime"
-version = "0.33.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=52d5fe5d1fd665a495ea34cc67c5f0c6bc6dd23e#52d5fe5d1fd665a495ea34cc67c5f0c6bc6dd23e"
+version = "0.35.0"
+source = "git+https://github.com/rust-blockchain/evm?rev=0b686f8c2c83a52638917caa649dc23302fda80d#0b686f8c2c83a52638917caa649dc23302fda80d"
 dependencies = [
  "auto_impl",
  "environmental",
  "evm-core",
- "primitive-types",
- "sha3 0.8.2",
+ "primitive-types 0.11.1",
+ "sha3 0.10.1",
 ]
 
 [[package]]
@@ -2013,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2022,7 +2095,7 @@ dependencies = [
  "fp-rpc",
  "futures 0.3.17",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sc-consensus",
  "sp-api",
@@ -2039,13 +2112,12 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "fp-storage",
- "kvdb",
  "kvdb-rocksdb",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.11.1",
  "sp-core",
  "sp-database",
  "sp-runtime",
@@ -2054,14 +2126,14 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "fc-consensus",
  "fc-db",
  "fp-consensus",
  "fp-rpc",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "log",
  "sc-client-api",
  "sp-api",
@@ -2072,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2093,8 +2165,8 @@ dependencies = [
  "log",
  "lru 0.6.6",
  "pallet-evm",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "rlp",
  "rustc-hex",
@@ -2118,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2144,17 +2216,17 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ac3ff5224ef91f3c97e03eb1de2db82743427e91aaa5ac635f454f0b164f5a"
+checksum = "d9def033d8505edf199f6a5d07aa7e6d2d6185b164293b77f0efd108f4f3e11d"
 dependencies = [
  "either",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "log",
  "num-traits",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.11.1",
  "scale-info",
 ]
 
@@ -2198,9 +2270,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
 ]
 
 [[package]]
@@ -2216,10 +2288,10 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "ethereum",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "rlp",
  "sha3 0.8.2",
  "sp-core",
@@ -2230,10 +2302,10 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "evm",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "serde",
  "sp-core",
  "sp-std",
@@ -2242,12 +2314,12 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "ethereum",
  "ethereum-types",
  "fp-evm",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-api",
  "sp-core",
@@ -2259,11 +2331,11 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "ethereum",
  "frame-support",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "parity-util-mem",
  "scale-info",
  "serde",
@@ -2276,24 +2348,26 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
 ]
 
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
  "linregress",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "paste",
  "scale-info",
+ "serde",
  "sp-api",
+ "sp-application-crypto",
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
@@ -2304,37 +2378,52 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "Inflector",
  "chrono",
+ "clap 3.1.8",
  "frame-benchmarking",
  "frame-support",
  "handlebars",
+ "hash-db",
+ "hex",
+ "itertools",
+ "kvdb",
  "linked-hash-map",
  "log",
- "parity-scale-codec",
+ "memory-db",
+ "parity-scale-codec 3.1.2",
+ "rand 0.8.4",
  "sc-cli",
+ "sc-client-api",
  "sc-client-db",
  "sc-executor",
  "sc-service",
  "serde",
+ "serde_json",
+ "serde_nanos",
+ "sp-api",
+ "sp-blockchain",
  "sp-core",
+ "sp-database",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
- "structopt",
+ "sp-std",
+ "sp-storage",
+ "sp-trie",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-arithmetic",
  "sp-npos-elections",
@@ -2344,11 +2433,11 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-core",
  "sp-io",
@@ -2359,12 +2448,12 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ed5e5c346de62ca5c184b4325a6600d1eaca210666e4606fe4e449574978d0"
+checksum = "df6bb8542ef006ef0de09a5c4420787d79823c0ed7924225822362fd2bf2ff2d"
 dependencies = [
  "cfg-if 1.0.0",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
 ]
@@ -2372,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2380,7 +2469,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "once_cell",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "paste",
  "scale-info",
  "serde",
@@ -2401,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2413,7 +2502,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.0",
@@ -2425,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2435,11 +2524,11 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -2452,12 +2541,12 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-core",
  "sp-runtime",
@@ -2467,16 +2556,16 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
 ]
 
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "sp-api",
@@ -2507,6 +2596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,6 +2622,12 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2551,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2561,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
@@ -2579,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -2600,12 +2701,10 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -2624,21 +2723,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
-
-[[package]]
-name = "futures-timer"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-timer"
@@ -2648,11 +2741,10 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "autocfg",
  "futures 0.1.31",
  "futures-channel",
  "futures-core",
@@ -2663,8 +2755,6 @@ dependencies = [
  "memchr",
  "pin-project-lite 0.2.6",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -2761,11 +2851,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.7"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2774,7 +2864,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -2823,6 +2913,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,6 +2929,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -2927,9 +3032,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
- "itoa",
+ "itoa 0.4.7",
 ]
 
 [[package]]
@@ -2938,16 +3043,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "http",
  "pin-project-lite 0.2.6",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
 
 [[package]]
 name = "httpdate"
@@ -2957,11 +3062,11 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.15"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2970,9 +3075,9 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.1",
  "pin-project-lite 0.2.6",
- "socket2 0.4.0",
+ "socket2 0.4.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3061,7 +3166,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.3.1",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec 3.1.2",
 ]
 
 [[package]]
@@ -3075,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
  "serde",
 ]
@@ -3122,16 +3236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "intervalier"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
-dependencies = [
- "futures 0.3.17",
- "futures-timer 2.0.2",
-]
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,9 +3270,9 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -3178,6 +3282,12 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -3262,7 +3372,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log",
  "net2",
- "parking_lot",
+ "parking_lot 0.11.1",
  "unicase",
 ]
 
@@ -3277,7 +3387,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log",
  "parity-tokio-ipc",
- "parking_lot",
+ "parking_lot 0.11.1",
  "tower-service",
 ]
 
@@ -3291,7 +3401,7 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "log",
- "parking_lot",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "serde",
 ]
@@ -3302,7 +3412,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures 0.3.17",
  "globset",
  "jsonrpc-core",
@@ -3310,7 +3420,7 @@ dependencies = [
  "log",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "unicase",
 ]
 
@@ -3325,7 +3435,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log",
  "parity-ws",
- "parking_lot",
+ "parking_lot 0.11.1",
  "slab",
 ]
 
@@ -3356,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a3f58dc069ec0e205a27f5b45920722a46faed802a0541538241af6228f512"
+checksum = "a301d8ecb7989d4a6e2c57a49baca77d353bdbf879909debe3f375fe25d61f86"
 dependencies = [
  "parity-util-mem",
  "smallvec",
@@ -3366,20 +3476,20 @@ dependencies = [
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b6b85fc643f5acd0bffb2cc8a6d150209379267af0d41db72170021841f9f5"
+checksum = "ece7e668abd21387aeb6628130a6f4c802787f014fa46bc83221448322250357"
 dependencies = [
  "kvdb",
  "parity-util-mem",
- "parking_lot",
+ "parking_lot 0.12.0",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.14.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1b6ea8f2536f504b645ad78419c8246550e19d2c3419a167080ce08edee35a"
+checksum = "ca7fbdfd71cd663dceb0faf3367a99f8cf724514933e9867cec4995b6027cbc1"
 dependencies = [
  "fs-swap",
  "kvdb",
@@ -3387,7 +3497,7 @@ dependencies = [
  "num_cpus",
  "owning_ref",
  "parity-util-mem",
- "parking_lot",
+ "parking_lot 0.12.0",
  "regex",
  "rocksdb",
  "smallvec",
@@ -3407,9 +3517,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "libloading"
@@ -3444,7 +3554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bec54343492ba5940a6c555e512c6721139835d28c59bc22febece72dfd0d9d"
 dependencies = [
  "atomic",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures 0.3.17",
  "lazy_static",
  "libp2p-core",
@@ -3472,8 +3582,8 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
- "parking_lot",
- "pin-project 1.0.8",
+ "parking_lot 0.11.1",
+ "pin-project 1.0.10",
  "smallvec",
  "wasm-timer",
 ]
@@ -3490,15 +3600,15 @@ dependencies = [
  "either",
  "fnv",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "lazy_static",
  "libsecp256k1 0.7.0",
  "log",
  "multiaddr",
  "multihash 0.14.0",
  "multistream-select",
- "parking_lot",
- "pin-project 1.0.8",
+ "parking_lot 0.11.1",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
  "rand 0.8.4",
@@ -3564,7 +3674,7 @@ dependencies = [
  "asynchronous-codec 0.6.0",
  "base64 0.13.0",
  "byteorder",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "futures 0.3.17",
  "hex_fmt",
@@ -3606,7 +3716,7 @@ checksum = "a2297dc0ca285f3a09d1368bde02449e539b46f94d32d53233f53f6625bcd3ba"
 dependencies = [
  "arrayvec 0.5.2",
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "either",
  "fnv",
  "futures 0.3.17",
@@ -3641,7 +3751,7 @@ dependencies = [
  "log",
  "rand 0.8.4",
  "smallvec",
- "socket2 0.4.0",
+ "socket2 0.4.4",
  "void",
 ]
 
@@ -3666,12 +3776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f2cd64ef597f40e14bfce0497f50ecb63dd6d201c61796daeb4227078834fbf"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures 0.3.17",
  "libp2p-core",
  "log",
  "nohash-hasher",
- "parking_lot",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.0",
@@ -3683,7 +3793,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8772c7a99088221bb7ca9c5c0574bf55046a7ab4c319f3619b275f28c8fb87a"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "curve25519-dalek 3.1.0",
  "futures 0.3.17",
  "lazy_static",
@@ -3721,7 +3831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fba1a6ff33e4a274c89a3b1d78b9f34f32af13265cc5c46c16938262d4e945a"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures 0.3.17",
  "libp2p-core",
  "log",
@@ -3739,7 +3849,7 @@ checksum = "0f1a458bbda880107b5b36fcb9b5a1ef0c329685da0e203ed692a8ebe64cc92c"
 dependencies = [
  "futures 0.3.17",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "salsa20",
  "sha3 0.9.1",
@@ -3752,13 +3862,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2852b61c90fa8ce3c8fcc2aba76e6cefc20d648f9df29157d6b3a916278ef3e3"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3797,7 +3907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a877a4ced6d46bf84677e1974e8cf61fb434af73b2e96fb48d6cb6223a4634d8"
 dependencies = [
  "async-trait",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures 0.3.17",
  "libp2p-core",
  "libp2p-swarm",
@@ -3843,13 +3953,13 @@ checksum = "7399c5b6361ef525d41c11fcf51635724f832baf5819b30d3d873eabb4fbae4b"
 dependencies = [
  "async-io",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "if-watch",
  "ipnet",
  "libc",
  "libp2p-core",
  "log",
- "socket2 0.4.0",
+ "socket2 0.4.4",
 ]
 
 [[package]]
@@ -3904,21 +4014,24 @@ checksum = "4e7362abb8867d7187e7e93df17f460d554c997fc5c8ac57dc1259057f6889af"
 dependencies = [
  "futures 0.3.17",
  "libp2p-core",
- "parking_lot",
+ "parking_lot 0.11.1",
  "thiserror",
  "yamux",
 ]
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.20.3"
+version = "0.6.1+6.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
+checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
 dependencies = [
  "bindgen",
+ "bzip2-sys",
  "cc",
  "glob",
  "libc",
+ "libz-sys",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -4090,10 +4203,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -4216,12 +4330,12 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de006e09d04fc301a5f7e817b75aa49801c4479a8af753764416b085337ddcc5"
+checksum = "6566c70c1016f525ced45d7b7f97730a2bafb037c788211d0c186ef5b2189f0a"
 dependencies = [
  "hash-db",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.0",
  "parity-util-mem",
 ]
 
@@ -4274,14 +4388,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow 0.3.7",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -4403,10 +4518,10 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d91ec0a2440aaff5f78ec35631a7027d50386c6163aa975f7caa0d5da4b6ff8"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures 0.3.17",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "smallvec",
  "unsigned-varint 0.7.0",
 ]
@@ -4465,7 +4580,7 @@ name = "node-inspect"
 version = "0.9.0-dev"
 dependencies = [
  "derive_more",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-cli",
  "sc-client-api",
  "sc-executor",
@@ -4495,7 +4610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
  "bitvec 0.19.5",
- "funty",
+ "funty 1.1.0",
  "memchr",
  "version_check",
 ]
@@ -4552,6 +4667,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+dependencies = [
+ "arrayvec 0.4.12",
+ "itoa 0.4.7",
 ]
 
 [[package]]
@@ -4674,7 +4799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7337d80c23c2d8b1349563981bc4fb531220733743ba8115454a67b181173f0d"
 dependencies = [
  "dtoa",
- "itoa",
+ "itoa 0.4.7",
  "open-metrics-client-derive-text-encode",
  "owning_ref",
 ]
@@ -4697,6 +4822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,12 +4842,12 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-session",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-application-crypto",
  "sp-authority-discovery",
@@ -4724,12 +4858,12 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-authorship",
  "sp-runtime",
@@ -4739,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4748,7 +4882,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-application-crypto",
  "sp-consensus-babe",
@@ -4763,13 +4897,13 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-runtime",
  "sp-std",
@@ -4778,12 +4912,12 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -4794,7 +4928,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4809,7 +4943,7 @@ dependencies = [
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "rlp",
  "rustc-hex",
  "scale-info",
@@ -4823,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4836,8 +4970,8 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-timestamp",
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 3.1.2",
+ "primitive-types 0.10.1",
  "rlp",
  "scale-info",
  "serde",
@@ -4851,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4861,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "fp-evm",
  "num",
@@ -4872,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4883,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/cennznet/frontier?rev=890a535d105d206f7427550794c1973eeff9dd52#890a535d105d206f7427550794c1973eeff9dd52"
+source = "git+https://github.com/cennznet/frontier?rev=9fac81fceb918665de2e25a1ff7d5398cb2f8aba#9fac81fceb918665de2e25a1ff7d5398cb2f8aba"
 dependencies = [
  "fp-evm",
  "ripemd160",
@@ -4903,7 +5037,7 @@ dependencies = [
  "frame-system",
  "num_enum",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "precompile-utils",
  "scale-info",
  "sp-core",
@@ -4923,7 +5057,7 @@ dependencies = [
  "frame-system",
  "num_enum",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "precompile-utils",
  "scale-info",
  "sp-core",
@@ -4934,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4942,7 +5076,7 @@ dependencies = [
  "log",
  "pallet-authorship",
  "pallet-session",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-application-crypto",
  "sp-core",
@@ -4957,13 +5091,13 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-io",
  "sp-runtime",
@@ -4973,13 +5107,13 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
  "log",
  "pallet-authorship",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-application-crypto",
  "sp-core",
@@ -4992,11 +5126,11 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-io",
  "sp-runtime",
@@ -5006,13 +5140,13 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
  "log",
  "pallet-balances",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-runtime",
@@ -5023,13 +5157,13 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-io",
  "sp-runtime",
@@ -5039,14 +5173,14 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-core",
  "sp-io",
@@ -5060,7 +5194,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -5068,7 +5202,7 @@ dependencies = [
  "log",
  "pallet-authorship",
  "pallet-session",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-application-crypto",
@@ -5081,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -5092,11 +5226,11 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-io",
  "sp-runtime",
@@ -5106,13 +5240,13 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-inherents",
  "sp-io",
@@ -5124,13 +5258,13 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "pallet-balances",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-runtime",
@@ -5140,11 +5274,11 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-core",
  "sp-io",
@@ -5166,7 +5300,7 @@ dependencies = [
  "log",
  "lz4",
  "memmap2 0.2.3",
- "parking_lot",
+ "parking_lot 0.11.1",
  "rand 0.8.4",
  "snap",
 ]
@@ -5181,7 +5315,21 @@ dependencies = [
  "bitvec 0.20.4",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive",
+ "parity-scale-codec-derive 2.3.1",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b44461635bbb1a0300f100a841e571e7d919c81c73075ef5d152ffdb521066"
+dependencies = [
+ "arrayvec 0.7.1",
+ "bitvec 1.0.0",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive 3.1.2",
  "serde",
 ]
 
@@ -5190,6 +5338,18 @@ name = "parity-scale-codec-derive"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate 1.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45ed1f39709f5a89338fab50e59816b2e8815f5bb58276e7ddf9afd495f73f8"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -5219,18 +5379,18 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
+checksum = "c32561d248d352148124f036cac253a644685a21dc9fea383eb4907d7bd35a8f"
 dependencies = [
  "cfg-if 1.0.0",
  "ethereum-types",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.0",
  "impl-trait-for-tuples",
- "lru 0.6.6",
+ "lru 0.7.0",
  "parity-util-mem-derive",
- "parking_lot",
- "primitive-types",
+ "parking_lot 0.12.0",
+ "primitive-types 0.11.1",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -5293,7 +5453,17 @@ checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.3",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -5308,6 +5478,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5416,11 +5599,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
- "pin-project-internal 1.0.8",
+ "pin-project-internal 1.0.10",
 ]
 
 [[package]]
@@ -5436,9 +5619,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5528,7 +5711,7 @@ dependencies = [
  "log",
  "num_enum",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "precompile-utils-macro",
  "rlp",
  "sha3 0.9.1",
@@ -5555,7 +5738,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.5.1",
+ "impl-rlp",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.6.0",
  "impl-rlp",
  "impl-serde",
  "scale-info",
@@ -5606,22 +5801,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -5636,7 +5819,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot",
+ "parking_lot 0.11.1",
  "thiserror",
 ]
 
@@ -5646,7 +5829,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "prost-derive",
 ]
 
@@ -5656,8 +5839,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
- "bytes 1.0.1",
- "heck",
+ "bytes 1.1.0",
+ "heck 0.3.3",
  "itertools",
  "lazy_static",
  "log",
@@ -5689,19 +5872,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "prost",
-]
-
-[[package]]
-name = "pwasm-utils"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
-dependencies = [
- "byteorder",
- "log",
- "parity-wasm 0.42.2",
 ]
 
 [[package]]
@@ -5729,9 +5901,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -5747,6 +5919,12 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -5977,7 +6155,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "rustc-hex",
 ]
 
@@ -5994,9 +6172,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
+checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -6074,6 +6252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6111,7 +6295,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "log",
  "sp-core",
@@ -6122,16 +6306,15 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
- "derive_more",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "ip_network",
  "libp2p",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -6144,17 +6327,18 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-block-builder",
  "sc-client-api",
  "sc-proposer-metrics",
@@ -6172,9 +6356,9 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sp-api",
  "sp-block-builder",
@@ -6188,11 +6372,11 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.0",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-chain-spec-derive",
  "sc-network",
  "sc-telemetry",
@@ -6205,7 +6389,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -6216,16 +6400,17 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "chrono",
+ "clap 3.1.8",
  "fdlimit",
  "futures 0.3.17",
  "hex",
  "libp2p",
  "log",
  "names",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "rand 0.7.3",
  "regex",
  "rpassword",
@@ -6245,7 +6430,6 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime",
  "sp-version",
- "structopt",
  "thiserror",
  "tiny-bip39",
  "tokio",
@@ -6254,14 +6438,14 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "fnv",
  "futures 0.3.17",
  "hash-db",
  "log",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -6282,7 +6466,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -6291,8 +6475,8 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-db",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "sc-client-api",
  "sc-state-db",
  "sp-arithmetic",
@@ -6307,14 +6491,14 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "libp2p",
  "log",
- "parking_lot",
+ "parking_lot 0.12.0",
  "sc-client-api",
  "sc-utils",
  "serde",
@@ -6329,12 +6513,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-consensus-babe"
+name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
- "derive_more",
+ "futures 0.3.17",
+ "log",
+ "parity-scale-codec 3.1.2",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-slots",
+ "sc-telemetry",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-consensus-babe"
+version = "0.10.0-dev"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
+dependencies = [
+ "async-trait",
  "fork-tree",
  "futures 0.3.17",
  "log",
@@ -6342,8 +6554,8 @@ dependencies = [
  "num-bigint 0.2.6",
  "num-rational 0.2.4",
  "num-traits",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "rand 0.7.3",
  "retain_mut",
  "sc-client-api",
@@ -6369,14 +6581,14 @@ dependencies = [
  "sp-runtime",
  "sp-version",
  "substrate-prometheus-endpoint",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "derive_more",
  "futures 0.3.17",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -6393,15 +6605,16 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "fork-tree",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
@@ -6411,19 +6624,19 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "assert_matches",
  "async-trait",
- "derive_more",
  "futures 0.3.17",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sc-consensus",
+ "sc-consensus-aura",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-transaction-pool",
@@ -6432,6 +6645,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
+ "sp-consensus-aura",
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
@@ -6440,22 +6654,22 @@ dependencies = [
  "sp-runtime",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sc-consensus",
  "sc-telemetry",
- "sp-api",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -6471,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -6482,13 +6696,12 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "lazy_static",
- "libsecp256k1 0.7.0",
- "log",
- "parity-scale-codec",
- "parking_lot",
+ "lru 0.6.6",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "sc-executor-common",
  "sc-executor-wasmi",
  "sp-api",
@@ -6502,34 +6715,34 @@ dependencies = [
  "sp-trie",
  "sp-version",
  "sp-wasm-interface",
+ "tracing",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "derive_more",
  "environmental",
- "parity-scale-codec",
- "pwasm-utils",
+ "parity-scale-codec 3.1.2",
  "sc-allocator",
  "sp-core",
  "sp-maybe-compressed-blob",
  "sp-serializer",
  "sp-wasm-interface",
  "thiserror",
+ "wasm-instrument",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-allocator",
  "sc-executor-common",
  "scoped-tls",
@@ -6542,20 +6755,21 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
+ "ahash",
  "async-trait",
- "derive_more",
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "log",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "rand 0.8.4",
  "sc-block-builder",
+ "sc-chain-spec",
  "sc-client-api",
  "sc-consensus",
  "sc-keystore",
@@ -6574,14 +6788,14 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "derive_more",
  "finality-grandpa",
  "futures 0.3.17",
  "jsonrpc-core",
@@ -6589,7 +6803,7 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-pubsub",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sc-finality-grandpa",
  "sc-rpc",
@@ -6598,16 +6812,17 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "log",
  "parity-util-mem",
  "sc-client-api",
@@ -6620,35 +6835,33 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
- "derive_more",
  "hex",
- "parking_lot",
+ "parking_lot 0.12.0",
  "serde_json",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "async-std",
  "async-trait",
  "asynchronous-codec 0.5.0",
  "bitflags",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "cid",
- "derive_more",
  "either",
  "fnv",
  "fork-tree",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "hex",
  "ip_network",
  "libp2p",
@@ -6656,9 +6869,9 @@ dependencies = [
  "linked_hash_set",
  "log",
  "lru 0.7.0",
- "parity-scale-codec",
- "parking_lot",
- "pin-project 1.0.8",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -6686,10 +6899,11 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
+ "ahash",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "libp2p",
  "log",
  "lru 0.7.0",
@@ -6702,15 +6916,15 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-std",
  "async-trait",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "libp2p",
  "log",
- "parking_lot",
+ "parking_lot 0.12.0",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -6730,19 +6944,19 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "hex",
  "hyper",
  "hyper-rustls",
  "num_cpus",
  "once_cell",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "rand 0.7.3",
  "sc-client-api",
  "sc-network",
@@ -6758,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
  "libp2p",
@@ -6771,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6780,15 +6994,15 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -6811,7 +7025,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
@@ -6819,8 +7033,8 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-pubsub",
  "log",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "sc-chain-spec",
  "sc-transaction-pool-api",
  "serde",
@@ -6836,7 +7050,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
@@ -6853,21 +7067,21 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "parity-util-mem",
- "parking_lot",
- "pin-project 1.0.8",
+ "parking_lot 0.12.0",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -6917,13 +7131,13 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "parity-util-mem",
  "parity-util-mem-derive",
- "parking_lot",
+ "parking_lot 0.12.0",
  "sc-client-api",
  "sp-core",
 ]
@@ -6931,18 +7145,17 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-finality-grandpa",
- "sc-rpc-api",
  "serde",
  "serde_json",
  "sp-blockchain",
@@ -6953,14 +7166,14 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "chrono",
  "futures 0.3.17",
  "libp2p",
  "log",
- "parking_lot",
- "pin-project 1.0.8",
+ "parking_lot 0.12.0",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -6971,7 +7184,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6980,7 +7193,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "regex",
  "rustc-hash",
  "sc-client-api",
@@ -7002,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -7013,15 +7226,15 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
- "intervalier",
+ "futures-timer",
  "linked-hash-map",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "parity-util-mem",
- "parking_lot",
+ "parking_lot 0.12.0",
  "retain_mut",
  "sc-client-api",
  "sc-transaction-pool-api",
@@ -7040,9 +7253,8 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "derive_more",
  "futures 0.3.17",
  "log",
  "serde",
@@ -7054,33 +7266,35 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "lazy_static",
+ "log",
+ "parking_lot 0.12.0",
  "prometheus",
 ]
 
 [[package]]
 name = "scale-info"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
+checksum = "8980cafbe98a7ee7a9cc16b32ebce542c77883f512d83fbf2ddc8f6a85ea74c9"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec 1.0.0",
  "cfg-if 1.0.0",
  "derive_more",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info-derive",
  "serde",
 ]
 
 [[package]]
 name = "scale-info-derive"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
+checksum = "4260c630e8a8a33429d1688eff2f163f24c65a4e1b1578ef6b565061336e4b6f"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -7136,6 +7350,24 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -7214,18 +7446,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7234,12 +7466,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.72"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_nanos"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44969a61f5d316be20a42ff97816efb3b407a924d06824c3d8a49fa8450de0e"
+dependencies = [
  "serde",
 ]
 
@@ -7294,6 +7535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.1",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha3"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7319,6 +7571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+dependencies = [
+ "digest 0.10.3",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7332,16 +7594,6 @@ name = "shlex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -7395,7 +7647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
 dependencies = [
  "aes-gcm",
- "blake2",
+ "blake2 0.9.1",
  "chacha20poly1305",
  "rand 0.8.4",
  "rand_core 0.6.2",
@@ -7419,9 +7671,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -7434,7 +7686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "flate2",
  "futures 0.3.17",
  "httparse",
@@ -7446,11 +7698,11 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "hash-db",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api-proc-macro",
  "sp-core",
  "sp-runtime",
@@ -7463,9 +7715,9 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "blake2-rfc",
+ "blake2 0.10.4",
  "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
@@ -7474,10 +7726,10 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -7487,12 +7739,12 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "4.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "integer-sqrt",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-debug-derive",
@@ -7503,9 +7755,9 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-api",
  "sp-application-crypto",
@@ -7516,10 +7768,10 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
@@ -7528,9 +7780,9 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
@@ -7540,13 +7792,13 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
  "log",
  "lru 0.7.0",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "sp-api",
  "sp-consensus",
  "sp-database",
@@ -7558,13 +7810,13 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
- "futures-timer 3.0.2",
+ "futures-timer",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
@@ -7577,10 +7829,10 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-api",
  "sp-application-crypto",
@@ -7595,11 +7847,11 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
  "merlin",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-api",
@@ -7618,21 +7870,23 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-arithmetic",
  "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "schnorrkel",
  "sp-core",
  "sp-runtime",
@@ -7641,8 +7895,8 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "base58",
  "bitflags",
@@ -7660,17 +7914,17 @@ dependencies = [
  "log",
  "merlin",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "parity-util-mem",
- "parking_lot",
- "primitive-types",
+ "parking_lot 0.12.0",
+ "primitive-types 0.11.1",
  "rand 0.7.3",
  "regex",
  "scale-info",
  "schnorrkel",
+ "secp256k1",
  "secrecy",
  "serde",
- "sha2 0.9.8",
  "sp-core-hashing",
  "sp-debug-derive",
  "sp-externalities",
@@ -7681,29 +7935,28 @@ dependencies = [
  "substrate-bip39",
  "thiserror",
  "tiny-bip39",
- "tiny-keccak",
- "twox-hash",
  "wasmi",
  "zeroize",
 ]
 
 [[package]]
 name = "sp-core-hashing"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "4.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "blake2-rfc",
+ "blake2 0.10.4",
  "byteorder",
- "sha2 0.9.8",
+ "digest 0.10.3",
+ "sha2 0.10.2",
+ "sha3 0.10.1",
  "sp-std",
- "tiny-keccak",
  "twox-hash",
 ]
 
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7714,16 +7967,16 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "kvdb",
- "parking_lot",
+ "parking_lot 0.12.0",
 ]
 
 [[package]]
 name = "sp-debug-derive"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "4.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7732,11 +7985,11 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "0.11.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "environmental",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-std",
  "sp-storage",
 ]
@@ -7744,11 +7997,11 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "finality-grandpa",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-api",
@@ -7762,11 +8015,11 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -7775,15 +8028,16 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
  "hash-db",
  "libsecp256k1 0.7.0",
  "log",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
+ "secp256k1",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
@@ -7799,8 +8053,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7810,35 +8064,36 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "0.11.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
- "derive_more",
  "futures 0.3.17",
  "merlin",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "schnorrkel",
  "serde",
  "sp-core",
  "sp-externalities",
+ "thiserror",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
+ "thiserror",
  "zstd",
 ]
 
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "serde",
  "sp-arithmetic",
@@ -7851,7 +8106,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -7862,7 +8117,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7871,8 +8126,8 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "4.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -7881,8 +8136,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -7891,14 +8146,14 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "parity-util-mem",
  "paste",
  "rand 0.7.3",
@@ -7913,12 +8168,12 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "impl-trait-for-tuples",
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 3.1.2",
+ "primitive-types 0.11.1",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -7930,8 +8185,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "4.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.0",
@@ -7943,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "serde",
  "serde_json",
@@ -7952,9 +8207,9 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-api",
  "sp-core",
@@ -7966,9 +8221,9 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-runtime",
  "sp-std",
@@ -7976,14 +8231,14 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "0.11.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "hash-db",
  "log",
  "num-traits",
- "parity-scale-codec",
- "parking_lot",
+ "parity-scale-codec 3.1.2",
+ "parking_lot 0.12.0",
  "rand 0.7.3",
  "smallvec",
  "sp-core",
@@ -7999,16 +8254,16 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "4.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 
 [[package]]
 name = "sp-storage"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "impl-serde",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "ref-cast",
  "serde",
  "sp-debug-derive",
@@ -8018,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "log",
  "sp-core",
@@ -8031,12 +8286,12 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
- "futures-timer 3.0.2",
+ "futures-timer",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
@@ -8046,10 +8301,10 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "4.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sp-std",
  "tracing",
  "tracing-core",
@@ -8059,7 +8314,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -8068,11 +8323,11 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-core",
  "sp-inherents",
@@ -8083,12 +8338,12 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "hash-db",
  "memory-db",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "scale-info",
  "sp-core",
  "sp-std",
@@ -8099,13 +8354,14 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "impl-serde",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "parity-wasm 0.42.2",
  "scale-info",
  "serde",
+ "sp-core-hashing-proc-macro",
  "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
@@ -8115,9 +8371,9 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -8125,11 +8381,12 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+version = "5.0.0"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "impl-trait-for-tuples",
- "parity-scale-codec",
+ "log",
+ "parity-scale-codec 3.1.2",
  "sp-std",
  "wasmi",
 ]
@@ -8142,11 +8399,12 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ss58-registry"
-version = "1.8.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78abb01d308934b82e34e9cf1f45846d31539246501745b129539176f4f3368d"
+checksum = "7b84a70894df7a73666e0694f44b41a9571625e9546fb58a0818a565d2c7e084"
 dependencies = [
  "Inflector",
+ "num-format",
  "proc-macro2",
  "quote",
  "serde",
@@ -8186,12 +8444,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "lazy_static",
  "structopt-derive",
 ]
@@ -8202,7 +8466,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -8211,22 +8475,23 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -8246,7 +8511,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "platforms",
 ]
@@ -8254,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.17",
@@ -8262,7 +8527,7 @@ dependencies = [
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sc-rpc-api",
  "sc-transaction-pool-api",
@@ -8276,26 +8541,25 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
- "async-std",
- "derive_more",
  "futures-util",
  "hyper",
  "log",
  "prometheus",
+ "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
  "hex",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-client-api",
  "sc-client-db",
  "sc-consensus",
@@ -8316,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "cfg-if 1.0.0",
  "frame-support",
@@ -8326,7 +8590,7 @@ dependencies = [
  "memory-db",
  "pallet-babe",
  "pallet-timestamp",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "parity-util-mem",
  "sc-service",
  "scale-info",
@@ -8358,10 +8622,10 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
- "parity-scale-codec",
+ "parity-scale-codec 3.1.2",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
@@ -8377,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "futures 0.3.17",
  "substrate-test-utils-derive",
@@ -8387,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -8398,12 +8662,13 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/cennznet/substrate?rev=92f06d413796bb1443b31d92bde637c90742a077#92f06d413796bb1443b31d92bde637c90742a077"
+source = "git+https://github.com/cennznet/substrate?rev=254219721084b533626ffa16b74c415771d46747#254219721084b533626ffa16b74c415771d46747"
 dependencies = [
  "ansi_term 0.12.1",
  "build-helper",
  "cargo_metadata",
  "sp-maybe-compressed-blob",
+ "strum",
  "tempfile",
  "toml",
  "walkdir",
@@ -8466,6 +8731,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8473,6 +8747,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -8510,6 +8790,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.3+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
 ]
 
 [[package]]
@@ -8568,28 +8859,29 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
- "autocfg",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "libc",
  "memchr",
- "mio 0.7.14",
+ "mio 0.8.2",
  "num_cpus",
  "once_cell",
+ "parking_lot 0.12.0",
  "pin-project-lite 0.2.6",
  "signal-hook-registry",
+ "socket2 0.4.4",
  "tokio-macros",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8624,12 +8916,26 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite 0.2.6",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -8685,7 +8991,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "tracing",
 ]
 
@@ -8720,7 +9026,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot",
+ "parking_lot 0.11.1",
  "regex",
  "serde",
  "serde_json",
@@ -8735,12 +9041,12 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.22.6"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eac131e334e81b6b3be07399482042838adcd7957aa0010231d0813e39e02fa"
+checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
 dependencies = [
  "hash-db",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.0",
  "log",
  "rustc-hex",
  "smallvec",
@@ -8748,9 +9054,9 @@ dependencies = [
 
 [[package]]
 name = "trie-root"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652931506d2c1244d7217a70b99f56718a7b4161b37f04e7cd868072a99f68cd"
+checksum = "9a36c5ca3911ed3c9a5416ee6c679042064b93fc637ded67e25f92e68d783891"
 dependencies = [
  "hash-db",
 ]
@@ -8801,7 +9107,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot",
+ "parking_lot 0.11.1",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -8822,20 +9128,21 @@ checksum = "5e66dcbec4290c69dd03c57e76c2469ea5c7ce109c6dd4351c13055cf71ea055"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
+checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.4",
+ "cfg-if 0.1.10",
+ "digest 0.10.3",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -8923,7 +9230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
  "asynchronous-codec 0.5.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-io",
  "futures-util",
 ]
@@ -8935,7 +9242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-io",
  "futures-util",
 ]
@@ -9053,6 +9360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9130,6 +9443,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-instrument"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962e5b0401bbb6c887f54e69b8c496ea36f704df65db73e81fd5ff8dc3e63a9f"
+dependencies = [
+ "parity-wasm 0.42.2",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9137,7 +9459,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures 0.3.17",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.11.1",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -9266,6 +9588,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
 name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9291,6 +9656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x25519-dalek"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9310,7 +9684,7 @@ dependencies = [
  "futures 0.3.17",
  "log",
  "nohash-hasher",
- "parking_lot",
+ "parking_lot 0.11.1",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,56 +17,56 @@ structopt = { version = "0.3.8" }
 url = "2.2.2"
 
 serde_json = "1.0"
-sc-authority-discovery = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-core = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-service = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-authorship = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-authority-discovery = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-consensus-babe = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-consensus-babe = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-consensus-epochs = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-consensus-uncles = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-finality-grandpa = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-finality-grandpa = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-runtime = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sc-authority-discovery = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-chain-spec = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-cli = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-executor = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-service = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-inherents = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-transaction-pool = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-transaction-pool-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-authorship = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-authority-discovery = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-consensus-babe = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-consensus-babe = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-consensus = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-consensus-epochs = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-consensus-uncles = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-consensus = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-network = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-finality-grandpa = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-finality-grandpa = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-client-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-timestamp = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 # These dependencies are used for the node RPCs
 jsonrpc-core = "18.0.0"
 jsonrpc-pubsub = "18.0.0"
 node-inspect = { version = "0.9.0-dev", path = "./inspect" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-keystore = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-transaction-storage-proof = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-sync-state-rpc = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-consensus-babe-rpc = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-consensus-manual-seal = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-finality-grandpa-rpc = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-keystore = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sc-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-rpc-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-block-builder = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-keystore = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-transaction-storage-proof = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-utils = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-basic-authorship = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-consensus-slots = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-telemetry = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-sync-state-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+substrate-frame-rpc-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-consensus-babe-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-consensus-manual-seal = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-finality-grandpa-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-keystore = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 # These dependencies are used for runtime benchmarking
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+frame-benchmarking-cli = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 # cennznet dependencies
 cennznet-primitives = { path = "../primitives" }
@@ -87,24 +87,24 @@ crml-transaction-payment = { path = "../crml/transaction-payment" }
 ethy-gadget = { path = "../ethy-gadget" }
 ethy-gadget-rpc = { path = "../ethy-gadget/rpc" }
 
-pallet-im-online = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-pallet-evm = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52", version = "6.0.0-dev" }
-fc-db = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-fc-mapping-sync = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-fp-rpc = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-fp-storage = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-im-online = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+pallet-evm = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba", version = "6.0.0-dev" }
+fc-db = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+fc-mapping-sync = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+fp-rpc = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+fp-storage = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
 
 [dev-dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
-sp-keyring = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-frame-system = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+codec = { package = "parity-scale-codec", version = "3.1.0", features = ["derive"] }
+sp-keyring = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-timestamp = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 tempfile = "3.1.0"
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+substrate-build-script-utils = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 [features]
 default = []

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -88,13 +88,13 @@ ethy-gadget = { path = "../ethy-gadget" }
 ethy-gadget-rpc = { path = "../ethy-gadget/rpc" }
 
 pallet-im-online = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-pallet-evm = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc", version = "6.0.0-dev" }
-fc-db = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-fc-mapping-sync = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-fp-rpc = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-fp-storage = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+pallet-evm = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52", version = "6.0.0-dev" }
+fc-db = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fc-mapping-sync = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fp-rpc = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fp-storage = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }

--- a/cli/inspect/Cargo.toml
+++ b/cli/inspect/Cargo.toml
@@ -11,13 +11,13 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.2.0" }
+codec = { package = "parity-scale-codec", version = "3.1.0" }
 derive_more = "0.99"
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077"}
-sc-service = { version = "0.10.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-core = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-runtime = { version = "4.0.0-dev", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sc-cli = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-client-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-executor = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747"}
+sc-service = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 structopt = "0.3.8"

--- a/cli/rpc-core/txpool/Cargo.toml
+++ b/cli/rpc-core/txpool/Cargo.toml
@@ -16,4 +16,4 @@ jsonrpc-derive = "18.0.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 
-fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }

--- a/cli/rpc-core/txpool/Cargo.toml
+++ b/cli/rpc-core/txpool/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/cennznet/cennznet/"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
-ethereum-types = "0.12.1"
+ethereum = { version = "0.12.0", default-features = false, features = [ "with-codec" ] }
+ethereum-types = "0.13.1"
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 
-fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fc-rpc-core = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }

--- a/cli/src/rpc/txpool/Cargo.toml
+++ b/cli/src/rpc/txpool/Cargo.toml
@@ -29,4 +29,4 @@ sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1
 
 # Frontier
 ethereum-types = "0.12.1"
-fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }

--- a/cli/src/rpc/txpool/Cargo.toml
+++ b/cli/src/rpc/txpool/Cargo.toml
@@ -18,15 +18,15 @@ cennznet-rpc-core-txpool = { path = "../../../rpc-core/txpool" }
 cennznet-primitives = { path = "../../../../primitives" }
 
 # Substrate
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-transaction-pool = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-transaction-pool-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-transaction-pool = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-transaction-pool-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 # Frontier
-ethereum-types = "0.12.1"
-fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+ethereum-types = "0.13.1"
+fc-rpc = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }

--- a/crml/cennzx/Cargo.toml
+++ b/crml/cennzx/Cargo.toml
@@ -5,23 +5,23 @@ authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 
 [dependencies]
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 serde = { version = "1.0.102", optional = true }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-generic-asset = { path = "../generic-asset", default-features = false }
 crml-support = { path = "../support", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, optional = true }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false, optional = true }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [dev-dependencies]
 cennznet-runtime = { path = "../../runtime" }
-sp-keyring = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sp-keyring = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 [features]
 default = ["std"]

--- a/crml/cennzx/rpc/Cargo.toml
+++ b/crml/cennzx/rpc/Cargo.toml
@@ -7,21 +7,21 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
 serde = { version = "1.0.102", features = ["derive"] }
 hex = "0.4.3"
 
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 crml-cennzx-rpc-runtime-api = { version = "2.0.0", path = "./runtime-api" }
 

--- a/crml/cennzx/rpc/runtime-api/Cargo.toml
+++ b/crml/cennzx/rpc/runtime-api/Cargo.toml
@@ -7,11 +7,11 @@ license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/crml/erc20-peg/Cargo.toml
+++ b/crml/erc20-peg/Cargo.toml
@@ -7,22 +7,22 @@ description = "Module for bridging ERC20 tokens"
 license = "GPL-3.0"
 
 [dependencies]
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 serde = { version = "1.0.126", default-features = false, optional = true }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-support = { path = "../support", default-features = false }
 
 # Substrate packages
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 crml-generic-asset = { path = "../generic-asset" }
 hex-literal = { version = "0.3.1", default-features = false }
 

--- a/crml/eth-bridge/Cargo.toml
+++ b/crml/eth-bridge/Cargo.toml
@@ -8,26 +8,26 @@ license = "GPL-3.0"
 
 [dependencies]
 parking_lot = "0.11.1"
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 serde = { version = "1.0.126", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }
-ethereum-types = { version = "0.12.1", default-features = false, features = ["serialize", "codec"] }
+ethereum-types = { version = "0.13.1", default-features = false, features = ["serialize", "codec"] }
 hex = { version = "0.4.3", default-features = false }
 
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-support = { path = "../support", default-features = false }
 
 # Substrate packages
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-application-crypto = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-application-crypto = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 [features]
 default = ["std"]

--- a/crml/eth-wallet/Cargo.toml
+++ b/crml/eth-wallet/Cargo.toml
@@ -11,22 +11,22 @@ description = "FRAME pallet for eth_sign extrinsics"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0", features = ["derive"], default-features = false }
 serde = { version = "1.0.106", features = ["derive"], optional = true }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 crml-support = { path = "../support", default-features = false }
 cennznet-primitives = { path = "../../primitives", default-features = false }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default_features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default_features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default_features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default_features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default_features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default_features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.1"
 libsecp256k1 = { version = "0.6.0" }
-pallet-balances = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
-sp-keyring = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
+pallet-balances = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default_features = false }
+sp-keyring = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default_features = false }
 
 [features]
 default = ["std"]

--- a/crml/eth-wallet/Cargo.toml
+++ b/crml/eth-wallet/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.106", features = ["derive"], optional = true }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 crml-support = { path = "../support", default-features = false }
 cennznet-primitives = { path = "../../primitives", default-features = false }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
 sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
 sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
 sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }

--- a/crml/eth-wallet/src/lib.rs
+++ b/crml/eth-wallet/src/lib.rs
@@ -3,17 +3,17 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use crate::ethereum::{ecrecover, EthereumSignature};
-use codec::Encode;
-use crml_support::{TransactionFeeHandler, H160 as EthAddress};
+use crml_support::TransactionFeeHandler;
 use frame_support::{
 	decl_error, decl_event, decl_module,
 	dispatch::{DispatchInfo, Dispatchable},
-	traits::{Get, UnfilteredDispatchable},
+	traits::Get,
 	weights::GetDispatchInfo,
 	Parameter,
 };
 use frame_system::ensure_none;
 use pallet_evm::AddressMapping;
+use sp_core::{Encode, H160 as EthAddress};
 use sp_runtime::{
 	traits::IdentifyAccount,
 	transaction_validity::{
@@ -36,9 +36,9 @@ pub trait Config: frame_system::Config {
 
 	/// A signable call.
 	type Call: Parameter
-		+ Dispatchable<Info = DispatchInfo>
-		+ UnfilteredDispatchable<Origin = Self::Origin>
-		+ GetDispatchInfo;
+		+ Dispatchable<Origin = Self::Origin, Info = DispatchInfo>
+		+ GetDispatchInfo
+		+ From<frame_system::Call<Self>>;
 
 	/// Provides transaction fee handling
 	type TransactionFeeHandler: TransactionFeeHandler<AccountId = Self::AccountId, Call = <Self as Config>::Call>;
@@ -90,7 +90,7 @@ decl_module! {
 		/// account - signed by this account
 		fn call(
 			origin,
-			call: Box<<T as Config>::Call> ,
+			call: Box<<T as Config>::Call>,
 			eth_address: EthAddress,
 			signature: EthereumSignature,
 		) -> DispatchResult {

--- a/crml/generic-asset/Cargo.toml
+++ b/crml/generic-asset/Cargo.toml
@@ -8,20 +8,20 @@ repository = "https://github.com/cennznet/cennznet"
 description = "A runtime module for managing ERC-20 like fungible assets"
 
 [dependencies]
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 serde = { version = "1.0.102", optional = true }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-support = { path = "../support", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, optional = true }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false, optional = true }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [features]
 default = ["std"]

--- a/crml/generic-asset/rpc/Cargo.toml
+++ b/crml/generic-asset/rpc/Cargo.toml
@@ -8,19 +8,19 @@ repository = "https://github.com/cennznet/cennznet"
 description = "RPC interface for the generic asset module."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0" }
+codec = { package = "parity-scale-codec", version = "3.1.0" }
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
 serde = { version = "1.0.101", features = ["derive"] }
-sc-client-db = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.10.0-dev", features = ["kvdb-rocksdb", "parity-db"] }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sc-client-db = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", features = ["kvdb-rocksdb", "parity-db"] }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 crml-generic-asset = { path = "../" }
 crml-generic-asset-rpc-runtime-api = { path = "runtime-api" }
 
 [dev-dependencies]
-sc-consensus = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.10.0-dev" }
+sc-consensus = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 serde_json = "1.0.50"

--- a/crml/generic-asset/rpc/runtime-api/Cargo.toml
+++ b/crml/generic-asset/rpc/runtime-api/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/cennznet/cennznet"
 description = "Runtime API definition required by Generic Asset RPC extensions."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 crml-generic-asset = { default-features = false, path = "../../" }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [features]
 default = ["std"]

--- a/crml/governance/Cargo.toml
+++ b/crml/governance/Cargo.toml
@@ -8,22 +8,22 @@ repository = "https://github.com/cennznet/cennznet"
 description = "A runtime module for decentralized governance of the CENNZnet protocol"
 
 [dependencies]
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 serde = { version = "1.0.102", optional = true }
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-support = { path = "../support", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-pallet-scheduler = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-scheduler = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
 
 [dev-dependencies]
 crml-generic-asset = { path = "../generic-asset"}
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077"}
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077"}
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747"}
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747"}
 
 [features]
 default = ["std"]

--- a/crml/governance/rpc/Cargo.toml
+++ b/crml/governance/rpc/Cargo.toml
@@ -8,15 +8,15 @@ repository = "https://github.com/cennznet/cennznet"
 description = "RPC interface for the governance module."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0" }
+codec = { package = "parity-scale-codec", version = "3.1.0" }
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
 serde = { version = "1.0.101", features = ["derive"] }
-sc-client-db = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.10.0-dev", features = ["kvdb-rocksdb", "parity-db"] }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sc-client-db = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", features = ["kvdb-rocksdb", "parity-db"] }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 crml-governance = { path = "../" }
 crml-governance-rpc-runtime-api = { path = "runtime-api" }

--- a/crml/governance/rpc/runtime-api/Cargo.toml
+++ b/crml/governance/rpc/runtime-api/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/cennznet/cennznet"
 description = "Runtime API definition required by Governance RPC extensions."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 crml-governance = { default-features = false, path = "../../" }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [features]
 default = ["std"]

--- a/crml/nft/Cargo.toml
+++ b/crml/nft/Cargo.toml
@@ -7,21 +7,21 @@ repository = "https://github.com/cennznet/cennznet"
 description = "CENNZnet NFT module"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.102", default-features = false, features = ["derive"], optional = true }
 log = { version = "0.4.14", default-features = false }
 variant_count = "1.0.0"
 hex = { version = "0.4.3", default-features = false }
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-support = { path = "../support", default-features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
-frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, optional = true }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
+frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false, optional = true }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 crml-generic-asset = { path = "../generic-asset" }

--- a/crml/nft/rpc/Cargo.toml
+++ b/crml/nft/rpc/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
 
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 crml-nft = { path = "../" }
 crml-nft-rpc-runtime-api = { path = "./runtime-api" }

--- a/crml/nft/rpc/runtime-api/Cargo.toml
+++ b/crml/nft/rpc/runtime-api/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 crml-nft = { path = "../../", default-features = false }
 cennznet-primitives = { path = "../../../../primitives", default-features = false}
 

--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -65,7 +65,11 @@ impl<T: Config> IsTokenOwner for Module<T> {
 	type AccountId = T::AccountId;
 
 	fn check_ownership(account: &Self::AccountId, token_id: &TokenId) -> bool {
-		&Self::token_owner((token_id.0, token_id.1), token_id.2) == account
+		if let Some(owner) = &Self::token_owner((token_id.0, token_id.1), token_id.2) {
+			owner == account
+		} else {
+			false
+		}
 	}
 }
 
@@ -187,13 +191,13 @@ decl_storage! {
 		pub TokenLocks get(fn token_locks): map hasher(twox_64_concat) TokenId => Option<TokenLockReason>;
 		/// Map from a token to its owner
 		/// The token Id is split in this map to allow better indexing (collection, series) + (serial number)
-		pub TokenOwner get(fn token_owner): double_map hasher(twox_64_concat) (CollectionId, SeriesId), hasher(twox_64_concat) SerialNumber => T::AccountId;
+		pub TokenOwner get(fn token_owner): double_map hasher(twox_64_concat) (CollectionId, SeriesId), hasher(twox_64_concat) SerialNumber => Option<T::AccountId>;
 		/// Count of tokens owned by an address, supports ERC721 `balanceOf`
 		pub TokenBalance get(fn token_balance): map hasher(blake2_128_concat) T::AccountId => BTreeMap<(CollectionId, SeriesId), TokenCount>;
 		/// The next available marketplace id
 		pub NextMarketplaceId get(fn next_marketplace_id): MarketplaceId;
 		/// Map from marketplace account_id to royalties schedule
-		pub RegisteredMarketplaces get(fn registered_marketplaces): map hasher(twox_64_concat) MarketplaceId => Marketplace<T::AccountId>;
+		pub RegisteredMarketplaces get(fn registered_marketplaces): map hasher(twox_64_concat) MarketplaceId => Option<Marketplace<T::AccountId>>;
 		/// Map from (collection, series) to its attributes (deprecated)
 		pub SeriesAttributes get(fn series_attributes): double_map hasher(twox_64_concat) CollectionId, hasher(twox_64_concat) SeriesId => Vec<NFTAttributeValue>;
 		/// Map from series to its human friendly name
@@ -547,7 +551,7 @@ decl_module! {
 			for serial_number in serial_numbers.iter() {
 				ensure!(!TokenLocks::contains_key((collection_id, series_id, serial_number)), Error::<T>::TokenListingProtection);
 				ensure!(
-					Self::token_owner((collection_id, series_id), serial_number) == origin,
+					Self::token_owner((collection_id, series_id), serial_number) == Some(origin.clone()),
 					Error::<T>::NoPermission
 				);
 			}
@@ -584,7 +588,7 @@ decl_module! {
 
 			for serial_number in serial_numbers.iter() {
 				ensure!(!TokenLocks::contains_key((collection_id, series_id, serial_number)), Error::<T>::TokenListingProtection);
-				ensure!(Self::token_owner((collection_id, series_id), serial_number) == origin, Error::<T>::NoPermission);
+				ensure!(Self::token_owner((collection_id, series_id), serial_number) == Some(origin.clone()), Error::<T>::NoPermission);
 				<TokenOwner<T>>::remove((collection_id, series_id), serial_number);
 			}
 
@@ -687,7 +691,7 @@ decl_module! {
 			let (bundle_collection_id, _series_id, _serial_number) = tokens[0];
 			for (collection_id, series_id, serial_number) in tokens.iter() {
 				ensure!(!TokenLocks::contains_key((collection_id, series_id, serial_number)), Error::<T>::TokenListingProtection);
-				ensure!(Self::token_owner((collection_id, series_id), serial_number) == origin, Error::<T>::NoPermission);
+				ensure!(Self::token_owner((collection_id, series_id), serial_number) == Some(origin.clone()), Error::<T>::NoPermission);
 				TokenLocks::insert((collection_id, series_id, serial_number), TokenLockReason::Listed(listing_id));
 			}
 
@@ -829,7 +833,7 @@ decl_module! {
 			let (bundle_collection_id, _series_id, _serial_number) = tokens[0];
 			for (collection_id, series_id, serial_number) in tokens.iter() {
 				ensure!(!TokenLocks::contains_key((collection_id, series_id, serial_number)), Error::<T>::TokenListingProtection);
-				ensure!(Self::token_owner((collection_id, series_id), serial_number) == origin, Error::<T>::NoPermission);
+				ensure!(Self::token_owner((collection_id, series_id), serial_number) == Some(origin.clone()), Error::<T>::NoPermission);
 				TokenLocks::insert((collection_id, series_id, serial_number), TokenLockReason::Listed(listing_id));
 			}
 
@@ -1045,14 +1049,15 @@ impl<T: Config> Module<T> {
 		}
 		// series schedule takes priority if it exists
 		let mut royalties = Self::series_royalties(bundle_collection_id, bundle_series_id)
-			.unwrap_or_else(|| Self::collection_royalties(bundle_collection_id).unwrap_or_else(Default::default));
+			.unwrap_or_else(|| Self::collection_royalties(bundle_collection_id).unwrap_or_default());
 		let royalties = match marketplace_id {
 			Some(marketplace_id) => {
 				ensure!(
 					<RegisteredMarketplaces<T>>::contains_key(marketplace_id),
 					Error::<T>::MarketplaceNotRegistered
 				);
-				let marketplace = Self::registered_marketplaces(marketplace_id);
+				// the storage key exists checked above, its value should be `Some`
+				let marketplace = Self::registered_marketplaces(marketplace_id).unwrap();
 				royalties
 					.entitlements
 					.push((marketplace.account, marketplace.entitlement));
@@ -1256,7 +1261,7 @@ impl<T: Config> Module<T> {
 	/// Get collection information from given collection_id
 	pub fn collection_info<AccountId>(collection_id: CollectionId) -> Option<CollectionInfo<T::AccountId>> {
 		let name = Self::collection_name(&collection_id);
-		let owner = Self::collection_owner(&collection_id).unwrap_or(Default::default());
+		let owner = Self::collection_owner(&collection_id);
 
 		if name.is_empty() {
 			None

--- a/crml/nft/src/types.rs
+++ b/crml/nft/src/types.rs
@@ -110,7 +110,7 @@ pub type NFTSchema = Vec<(NFTAttributeName, NFTAttributeTypeId)>;
 pub struct CollectionInfo<AccountId> {
 	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_utf8"))]
 	pub name: CollectionNameType,
-	pub owner: AccountId,
+	pub owner: Option<AccountId>,
 	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_royalties"))]
 	pub royalties: Vec<(AccountId, Permill)>,
 }
@@ -141,7 +141,7 @@ pub fn serialize_royalties<S: Serializer, AccountId: Serialize>(
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct TokenInfo<AccountId> {
 	pub attributes: Vec<NFTAttributeValue>,
-	pub owner: AccountId,
+	pub owner: Option<AccountId>,
 	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_royalties"))]
 	pub royalties: Vec<(AccountId, Permill)>,
 }
@@ -261,10 +261,16 @@ pub enum AuctionClosureReason {
 }
 
 /// Describes the royalty scheme for secondary sales for an NFT collection/token
-#[derive(Default, Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub struct RoyaltiesSchedule<AccountId> {
 	/// Entitlements on all secondary sales, (beneficiary, % of sale price)
 	pub entitlements: Vec<(AccountId, Permill)>,
+}
+
+impl<AccountId> Default for RoyaltiesSchedule<AccountId> {
+	fn default() -> Self {
+		RoyaltiesSchedule::<AccountId> { entitlements: vec![] }
+	}
 }
 
 impl<AccountId> RoyaltiesSchedule<AccountId> {
@@ -348,7 +354,7 @@ pub enum Listing<T: Config> {
 }
 
 /// Information about a marketplace
-#[derive(Debug, Clone, Default, Encode, Decode, PartialEq, Eq, TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub struct Marketplace<AccountId> {
 	/// The marketplace account
 	pub account: AccountId,

--- a/crml/staking/Cargo.toml
+++ b/crml/staking/Cargo.toml
@@ -10,35 +10,35 @@ description = "CENNZnet staking pallet"
 static_assertions = "1.1.0"
 serde = { version = "1.0.102", optional = true }
 log = { version = "0.4.14", default-features = false }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
-frame-support = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-frame-system = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-pallet-authorship = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-pallet-session = { default-features = false, features = ["historical"], git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-pallet-staking = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-application-crypto = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-core = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-io = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-npos-elections = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-runtime = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-staking = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-std = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+frame-support = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+frame-system = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+pallet-authorship = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+pallet-session = { default-features = false, features = ["historical"], git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+pallet-staking = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-application-crypto = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-core = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-io = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-npos-elections = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-staking = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-std = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 crml-support = { default-features = false, path = "../support" }
 
 [dev-dependencies]
 hex = "0.4"
 parking_lot = "0.11.1"
 rand_chacha = { version = "0.2" }
-pallet-balances = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-pallet-staking-reward-curve = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-pallet-timestamp = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+pallet-balances = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+pallet-staking-reward-curve = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+pallet-timestamp = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 crml-generic-asset = { path = "../generic-asset" }
 crml-support = { path = "../support" }
-sp-storage = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-tracing = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-substrate-test-utils = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sp-storage = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-tracing = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+substrate-test-utils = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 [features]
 migrate = []

--- a/crml/staking/rpc/Cargo.toml
+++ b/crml/staking/rpc/Cargo.toml
@@ -12,16 +12,16 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
-sp-blockchain = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-core = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-rpc = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sp-blockchain = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-core = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-rpc = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 serde = { version = "1.0.102", features = ["derive"] }
-sp-runtime = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-api = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sp-runtime = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-api = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 crml-staking-rpc-runtime-api = { default-features = false, version = "1.0.0", path = "./runtime-api" }
 
 [dev-dependencies]

--- a/crml/staking/rpc/runtime-api/Cargo.toml
+++ b/crml/staking/rpc/runtime-api/Cargo.toml
@@ -10,10 +10,10 @@ description = "Runtime API definition required by Staking RPC extensions."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-sp-api = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-std = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-runtime = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
+sp-api = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-std = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { default-features = false, git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 [features]
 default = ["std"]

--- a/crml/support/Cargo.toml
+++ b/crml/support/Cargo.toml
@@ -8,14 +8,14 @@ repository = "https://cennznet/cennznet"
 description = "Common crml types and traits"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", default-features = false, features = ["derive"], optional = true }
-primitive-types = {version = "0.10.1", default-features = false, features = ["impl-codec", "impl-serde"] }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+primitive-types = {version = "0.11.0", default-features = false, features = ["impl-codec", "impl-serde"] }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
 impl-trait-for-tuples = "0.2.1"
 cennznet-primitives = { path = "../../primitives", default-features = false }
 precompile-utils = { path = "../../evm-precompiles/utils", default-features = false }

--- a/crml/support/Cargo.toml
+++ b/crml/support/Cargo.toml
@@ -10,7 +10,7 @@ description = "Common crml types and traits"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", default-features = false, features = ["derive"], optional = true }
-primitive-types = {version = "0.11.0", default-features = false, features = ["impl-codec", "impl-serde"] }
+primitive-types = {version = "0.11.1", default-features = false, features = ["impl-codec", "impl-serde"] }
 sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }

--- a/crml/support/Cargo.toml
+++ b/crml/support/Cargo.toml
@@ -15,7 +15,7 @@ sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d41379
 sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
 frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
 frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
 impl-trait-for-tuples = "0.2.1"
 cennznet-primitives = { path = "../../primitives", default-features = false }
 precompile-utils = { path = "../../evm-precompiles/utils", default-features = false }

--- a/crml/token-approvals/Cargo.toml
+++ b/crml/token-approvals/Cargo.toml
@@ -16,7 +16,7 @@ sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1
 sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
 crml-support = { path = "../support", default-features = false }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
 sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
 
 [dev-dependencies]

--- a/crml/token-approvals/Cargo.toml
+++ b/crml/token-approvals/Cargo.toml
@@ -7,22 +7,22 @@ repository = "https://github.com/cennznet/cennznet"
 description = "CENNZnet Token Approvals module"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.102", optional = true }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
 cennznet-primitives = { path = "../../primitives", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false  }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false  }
 crml-support = { path = "../support", default-features = false }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [dev-dependencies]
 crml-generic-asset = { path = "../generic-asset" }
 crml-nft = { path = "../nft" }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 hex-literal = { version = "0.3.1" }
 
 [features]

--- a/crml/transaction-payment/Cargo.toml
+++ b/crml/transaction-payment/Cargo.toml
@@ -7,24 +7,24 @@ repository = "https://github.com/cennznet/cennznet"
 description = "CENNZnet pallet to manage transaction payments"
 
 [dependencies]
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 serde = { version = "1.0.102", optional = true }
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-support = { path = "../support", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 smallvec = "1.6.1"
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+pallet-balances = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 smallvec = "1.6.1"
 serde_json = "1.0.50"
 

--- a/crml/transaction-payment/rpc/Cargo.toml
+++ b/crml/transaction-payment/rpc/Cargo.toml
@@ -11,13 +11,13 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0" }
+codec = { package = "parity-scale-codec", version = "3.1.0" }
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 crml-transaction-payment-rpc-runtime-api = { version = "2.0.0", path = "./runtime-api" }

--- a/crml/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/crml/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -11,10 +11,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 crml-transaction-payment = { version = "2.0.0", default-features = false, path = "../../../transaction-payment" }
 
 [features]

--- a/ethy-gadget/Cargo.toml
+++ b/ethy-gadget/Cargo.toml
@@ -12,27 +12,27 @@ log = "0.4"
 parking_lot = "0.11"
 thiserror = "1.0"
 
-codec = { version = "2.0.0", package = "parity-scale-codec", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", features = ["derive"] }
 libsecp256k1 = { version = "0.6.0" }
-prometheus = { package = "substrate-prometheus-endpoint", git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.10.0-dev"}
+prometheus = { package = "substrate-prometheus-endpoint", git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747"}
 
 cennznet-primitives = { path = "../primitives" }
 crml-support = { path = "../crml/support" }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-application-crypto = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-consensus = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.10.0-dev" }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-keystore = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.10.0-dev" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-utils = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-application-crypto = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-arithmetic = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-blockchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-consensus = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-keystore = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-utils = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
-sc-client-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-keystore = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-network = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.10.0-dev" }
-sc-network-gossip = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.10.0-dev" }
+sc-client-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-keystore = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-network = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-network-gossip = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 [dev-dependencies]
-sc-network-test = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "0.8.0" }
+sc-network-test = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", version = "0.8.0" }
 hex-literal = "*"

--- a/ethy-gadget/rpc/Cargo.toml
+++ b/ethy-gadget/rpc/Cargo.toml
@@ -16,13 +16,13 @@ jsonrpc-core-client = "18.0.0"
 jsonrpc-derive = "18.0.0"
 jsonrpc-pubsub = "18.0.0"
 
-codec = { version = "2.2.0", package = "parity-scale-codec", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", features = ["derive"] }
 
-sc-client-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-rpc = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sc-utils = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077" }
+sc-client-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-rpc = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sc-utils = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747" }
 
 ethy-gadget = { path = "../." }
 cennznet-primitives = { path = "../../primitives" }

--- a/evm-precompiles/erc20/Cargo.toml
+++ b/evm-precompiles/erc20/Cargo.toml
@@ -6,19 +6,19 @@ edition = "2018"
 repository = "https://github.com/cennznet/cennznet"
 
 [dependencies]
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-generic-asset = { path = "../../crml/generic-asset", default-features = false }
 crml-token-approvals = { path = "../../crml/token-approvals", default-features = false }
-fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
 precompile-utils = { path = "../utils", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 num_enum = { version = "0.5.3", default-features = false }
 
 [features]

--- a/evm-precompiles/erc20/Cargo.toml
+++ b/evm-precompiles/erc20/Cargo.toml
@@ -11,8 +11,8 @@ codec = { version = "2.0.0", package = "parity-scale-codec", default-features = 
 cennznet-primitives = { path = "../../primitives", default-features = false }
 crml-generic-asset = { path = "../../crml/generic-asset", default-features = false }
 crml-token-approvals = { path = "../../crml/token-approvals", default-features = false }
-fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
 precompile-utils = { path = "../utils", default-features = false }
 frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
 frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }

--- a/evm-precompiles/erc721/Cargo.toml
+++ b/evm-precompiles/erc721/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2018"
 repository = "https://github.com/cennznet/cennznet"
 
 [dependencies]
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
 crml-nft = { path = "../../crml/nft", default-features = false }
 crml-token-approvals = { path = "../../crml/token-approvals", default-features = false }
-fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
 precompile-utils = { path = "../utils", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 num_enum = { version = "0.5.3", default-features = false }
 cennznet-primitives = { path = "../../primitives", default-features = false }
 

--- a/evm-precompiles/erc721/Cargo.toml
+++ b/evm-precompiles/erc721/Cargo.toml
@@ -10,8 +10,8 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
 crml-nft = { path = "../../crml/nft", default-features = false }
 crml-token-approvals = { path = "../../crml/token-approvals", default-features = false }
-fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
 precompile-utils = { path = "../utils", default-features = false }
 frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
 frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }

--- a/evm-precompiles/erc721/src/lib.rs
+++ b/evm-precompiles/erc721/src/lib.rs
@@ -207,8 +207,10 @@ where
 		let serial_number: SerialNumber = serial_number.saturated_into();
 
 		// Fetch info.
-		let owner_account_id =
-			H256::from(crml_nft::Pallet::<Runtime>::token_owner(series_id_parts, serial_number).into());
+		let owner_account_id: H256 = match crml_nft::Pallet::<Runtime>::token_owner(series_id_parts, serial_number) {
+			Some(owner) => owner.into(),
+			None => H256::default(),
+		};
 
 		// Build output.
 		Ok(PrecompileOutput {

--- a/evm-precompiles/utils/Cargo.toml
+++ b/evm-precompiles/utils/Cargo.toml
@@ -24,8 +24,8 @@ sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb14
 sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc", default-features = false }
-pallet-evm = { git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc", default-features = false }
+fp-evm = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52", default-features = false }
+pallet-evm = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/evm-precompiles/utils/Cargo.toml
+++ b/evm-precompiles/utils/Cargo.toml
@@ -14,18 +14,18 @@ sha3 = { version = "0.9", default-features = false }
 precompile-utils-macro = { path = "macro" }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 hex-literal = { version = "*", default-features = false }
 rlp = { version = "*", default-features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52", default-features = false }
-pallet-evm = { git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52", default-features = false }
+fp-evm = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba", default-features = false }
+pallet-evm = { git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 repository = "https://github.com/cennznet/cennznet"
 
 [dependencies]
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
-codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
-ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false }
+ethereum = { version = "0.12.0", default-features = false, features = [ "with-codec" ] }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 libsecp256k1 = { version = "0.6.0", default-features = false }
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-application-crypto = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-io = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-application-crypto = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-io = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 [features]
 default = ["std"]

--- a/primitives/src/eth.rs
+++ b/primitives/src/eth.rs
@@ -21,8 +21,6 @@ use sp_core::ecdsa::Public;
 use sp_runtime::{traits::Convert, KeyTypeId};
 use sp_std::{convert::TryInto, prelude::*};
 
-use self::crypto::AuthoritySignature;
-
 /// The `ConsensusEngineId` of ETHY.
 pub const ETHY_ENGINE_ID: sp_runtime::ConsensusEngineId = *b"ETH-";
 
@@ -84,7 +82,7 @@ impl<AuthorityId> ValidatorSet<AuthorityId> {
 pub struct EthyEcdsaToEthereum;
 impl Convert<Public, Option<[u8; 20]>> for EthyEcdsaToEthereum {
 	fn convert(a: Public) -> Option<[u8; 20]> {
-		use sp_core::crypto::Public;
+		use sp_core::crypto::ByteArray;
 		let compressed_key = a.as_slice();
 
 		libsecp256k1::PublicKey::parse_slice(compressed_key, Some(libsecp256k1::PublicKeyFormat::Compressed))
@@ -159,7 +157,7 @@ pub struct EventProof {
 impl EventProof {
 	/// Return the number of collected signatures.
 	pub fn signature_count(&self) -> usize {
-		let empty_sig = AuthoritySignature::default();
+		let empty_sig = sp_core::ecdsa::Signature { 0: [0u8; 65] }.into();
 		self.signatures.iter().filter(|x| x != &&empty_sig).count()
 	}
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,66 +11,66 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 cennznet-cli = { path = "../cli", default-features = false }
-sp-keyring = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+sp-keyring = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 # when running tests for the cennznet-runtime use the "integration_config" feature flag.
 # This save us from cases such as 24 hour eras in staking/session tests.
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 cennznet-runtime = { path = ".", features = ["integration_config"] }
 libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
-ethereum = { version = "0.11.1", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.12.0", default-features = false, features = ["with-codec"] }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.1.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
 smallvec = "1.6.1"
 static_assertions = "1.1.0"
 
-pallet-authorship = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-authority-discovery = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-babe = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-grandpa = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-identity = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-im-online = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-multisig = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-offences = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-treasury = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-scheduler = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-session = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev", features = ["historical"] }
-pallet-sudo = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-timestamp = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-pallet-utility = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+pallet-authorship = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-babe = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-grandpa = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-identity = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-im-online = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-multisig = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-offences = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-treasury = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-scheduler = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-session = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false, features = ["historical"] }
+pallet-sudo = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-timestamp = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+pallet-utility = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
-frame-executive = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-frame-try-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "0.10.0-dev", optional = true }
+frame-executive = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+frame-try-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false, optional = true }
 
-sp-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-authority-discovery = {  git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev"}
-sp-block-builder = {  git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev"}
-sp-consensus-babe = {  git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "0.10.0-dev" }
-sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-inherents = {  git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-io = {  git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-offchain = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-runtime-interface = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-session = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-transaction-pool = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-version = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
-sp-staking = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+sp-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-authority-discovery = {  git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false}
+sp-block-builder = {  git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false}
+sp-consensus-babe = {  git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-inherents = {  git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-io = {  git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-offchain = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-runtime-interface = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-session = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-transaction-pool = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-version = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
+sp-staking = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 futures = { version = "0.3.1", features = ["compat"] }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+frame-system-rpc-runtime-api = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false }
 
 # Used for runtime benchmarking
-frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev", optional = true }
-frame-system-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev", optional = true }
+frame-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false, optional = true }
+frame-system-benchmarking = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", default-features = false, optional = true }
 hex-literal = { version = "0.3.1", default-features = false }
 
 cennznet-primitives = { path = "../primitives", default-features = false }
@@ -93,22 +93,22 @@ crml-eth-wallet = { path = "../crml/eth-wallet", default-features = false }
 crml-token-approvals = { path = "../crml/token-approvals", default-features = false }
 
 # EVM support
-fp-rpc = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-fp-self-contained = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-base-fee = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-ethereum = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-evm-precompile-blake2 = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-evm-precompile-modexp = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-evm-precompile-simple = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
-pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fp-rpc = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+fp-self-contained = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-base-fee = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-ethereum = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-evm-precompile-blake2 = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-evm-precompile-modexp = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-evm-precompile-simple = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
+pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "9fac81fceb918665de2e25a1ff7d5398cb2f8aba" }
 pallet-evm-precompiles-erc721 = { path = "../evm-precompiles/erc721", default-features = false }
 pallet-evm-precompiles-erc20 = { path = "../evm-precompiles/erc20", default-features = false }
 precompile-utils = { path = "../evm-precompiles/utils", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", version = "5.0.0-dev" }
+substrate-wasm-builder = { git = "https://github.com/cennznet/substrate", rev = "254219721084b533626ffa16b74c415771d46747", version = "5.0.0-dev" }
 
 [features]
 default = ["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -93,15 +93,15 @@ crml-eth-wallet = { path = "../crml/eth-wallet", default-features = false }
 crml-token-approvals = { path = "../crml/token-approvals", default-features = false }
 
 # EVM support
-fp-rpc = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-fp-self-contained = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-base-fee = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-ethereum = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-evm-precompile-blake2 = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-evm-precompile-modexp = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-evm-precompile-simple = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
-pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "dc41b4322e109265b7e12e01719dba24e1b96bdc" }
+fp-rpc = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+fp-self-contained = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-base-fee = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-ethereum = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-evm-precompile-blake2 = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-evm-precompile-modexp = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-evm-precompile-simple = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
 pallet-evm-precompiles-erc721 = { path = "../evm-precompiles/erc721", default-features = false }
 pallet-evm-precompiles-erc20 = { path = "../evm-precompiles/erc20", default-features = false }
 precompile-utils = { path = "../evm-precompiles/utils", default-features = false }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -709,7 +709,9 @@ impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
 }
 
 parameter_types! {
-	pub const DefaultBaseFeePerGas: u64 = 5_500_000_000_000; // 0.000055 CPAY per gas
+	/// Floor network base fee per gas
+	/// 0.000055 CPAY per gas
+	pub const DefaultBaseFeePerGas: u64 = 5_500_000_000_000;
 	pub const IsBaseFeeActive: bool = true;
 }
 impl pallet_base_fee::Config for Runtime {
@@ -722,9 +724,9 @@ impl pallet_base_fee::Config for Runtime {
 parameter_types! {
 	/// Ethereum ChainId
 	/// 2999 (local/dev/default)
-	/// 3000 (mainnet)
+	/// 3000 (rata)
 	/// 3001 (nikau)
-	/// 3002 (rata)
+	/// 21337 (mainnet)
 	/// NB: Configured on live chains via one-time setStorage tx at key `:EthereumChainId:`
 	pub storage EthereumChainId: u64 = 2_999;
 	pub BlockGasLimit: U256


### PR DESCRIPTION
companion PR to cennznet/substrate#24 updates CENNZnet substrate & frontier version to 03-2022 monthly release

**Changes:**
crate versions updated:
- scale-info -> 2.1x
- parity-scale-codec -> 3.1.x

`AccountId::default()` trait removed
