### PR TITLE
evm multicurrency precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,7 @@ dependencies = [
  "pallet-evm-precompile-simple",
  "pallet-evm-precompiles-erc20",
  "pallet-evm-precompiles-erc721",
+ "pallet-evm-precompiles-fee-payment",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-im-online",
@@ -4919,6 +4920,25 @@ dependencies = [
  "cennznet-primitives",
  "crml-nft",
  "crml-token-approvals",
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "num_enum",
+ "pallet-evm",
+ "parity-scale-codec",
+ "precompile-utils",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-evm-precompiles-fee-payment"
+version = "2.0.0"
+dependencies = [
+ "cennznet-primitives",
+ "crml-eth-wallet",
  "fp-evm",
  "frame-support",
  "frame-system",

--- a/evm-precompiles/fee-payment/Cargo.toml
+++ b/evm-precompiles/fee-payment/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "pallet-evm-precompiles-fee-payment"
+version = "2.0.0"
+authors = ["Centrality Developers <support@centrality.ai>"]
+edition = "2018"
+repository = "https://github.com/cennznet/cennznet"
+
+[dependencies]
+scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
+fp-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+pallet-evm = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
+precompile-utils = { path = "../utils", default-features = false }
+frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+sp-std = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default-features = false, version = "4.0.0-dev" }
+num_enum = { version = "0.5.3", default-features = false }
+cennznet-primitives = { path = "../../primitives", default-features = false }
+crml-eth-wallet = { path = "../../crml/eth-wallet", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "crml-eth-wallet/std",
+    "scale-info/std",
+    "fp-evm/std",
+    "pallet-evm/std",
+    "frame-support/std",
+    "frame-system/std",
+    "num_enum/std",
+    "precompile-utils/std",
+    "sp-core/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "cennznet-primitives/std",
+]

--- a/evm-precompiles/fee-payment/src/lib.rs
+++ b/evm-precompiles/fee-payment/src/lib.rs
@@ -93,7 +93,7 @@ where
 	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,
 	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin: OriginTrait,
 {
-	/// Proxy remote call requests to the bridge pallet
+	/// Proxy remote call requests to the eth-wallet pallet
 	fn set_fee_asset(
 		input: &mut EvmDataReader,
 		gasometer: &mut Gasometer,

--- a/evm-precompiles/fee-payment/src/lib.rs
+++ b/evm-precompiles/fee-payment/src/lib.rs
@@ -102,10 +102,8 @@ where
 		// Parse input.
 		input.expect_arguments(gasometer, 1)?;
 		let payment_asset: u32 = input.read::<U256>(gasometer)?.saturated_into();
-
 		let origin = <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(*caller);
 
-		// New balance has changed, update approval to represent difference
 		RuntimeHelper::<Runtime>::try_dispatch(
 			Some(origin).into(),
 			crml_eth_wallet::Call::<Runtime>::set_payment_asset {

--- a/evm-precompiles/fee-payment/src/lib.rs
+++ b/evm-precompiles/fee-payment/src/lib.rs
@@ -1,0 +1,125 @@
+// Copyright 2019-2022 Centrality Investments Ltd.
+// This file is part of CENNZnet.
+
+// CENNZnet is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CENNZnet is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CENNZnet. If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use fp_evm::Precompile;
+pub use fp_evm::{Context, ExitSucceed, PrecompileOutput};
+use frame_support::{
+	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
+	traits::OriginTrait,
+};
+pub use pallet_evm::AddressMapping;
+pub use precompile_utils::{
+	error, keccak256, Address, Bytes, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier, Gasometer,
+	LogsBuilder, RuntimeHelper,
+};
+use sp_core::{H160, U256};
+use sp_runtime::SaturatedConversion;
+use sp_std::marker::PhantomData;
+
+#[precompile_utils::generate_function_selector]
+#[derive(Debug, PartialEq)]
+pub enum Action {
+	SetFeeAsset = "setFeeAsset(uint256)",
+}
+
+/// Provides access to the eth-wallet pallet
+pub struct FeePaymentPrecompile<Runtime>(PhantomData<Runtime>);
+
+impl<Runtime> Precompile for FeePaymentPrecompile<Runtime>
+where
+	Runtime: pallet_evm::Config + frame_system::Config + crml_eth_wallet::Config,
+	<Runtime as frame_system::Config>::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+	<Runtime as frame_system::Config>::Call: From<crml_eth_wallet::Call<Runtime>>,
+	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,
+	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin: OriginTrait,
+{
+	fn execute(
+		input: &[u8],
+		target_gas: Option<u64>,
+		context: &Context,
+		is_static: bool,
+	) -> EvmResult<PrecompileOutput> {
+		let mut gasometer = Gasometer::new(target_gas);
+		let gasometer = &mut gasometer;
+
+		let (mut input, selector) = match EvmDataReader::new_with_selector(gasometer, input) {
+			Ok((input, selector)) => (input, selector),
+			Err(e) => return Err(e),
+		};
+		let input = &mut input;
+
+		if let Err(err) = gasometer.check_function_modifier(
+			context,
+			is_static,
+			match selector {
+				Action::SetFeeAsset => FunctionModifier::NonPayable,
+			},
+		) {
+			return Err(err);
+		}
+
+		match selector {
+			Action::SetFeeAsset => Self::set_fee_asset(input, gasometer, &context.address),
+		}
+	}
+}
+
+impl<Runtime> FeePaymentPrecompile<Runtime> {
+	pub fn new() -> Self {
+		Self(PhantomData)
+	}
+}
+
+impl<Runtime> FeePaymentPrecompile<Runtime>
+where
+	Runtime: pallet_evm::Config + frame_system::Config + crml_eth_wallet::Config,
+	<Runtime as frame_system::Config>::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+	<Runtime as frame_system::Config>::Call: From<crml_eth_wallet::Call<Runtime>>,
+	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,
+	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin: OriginTrait,
+{
+	/// Proxy remote call requests to the bridge pallet
+	fn set_fee_asset(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+		caller: &H160,
+	) -> EvmResult<PrecompileOutput> {
+		// Parse input.
+		input.expect_arguments(gasometer, 1)?;
+		let payment_asset: u32 = input.read::<U256>(gasometer)?.saturated_into();
+
+		let origin = <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(*caller);
+
+		// New balance has changed, update approval to represent difference
+		RuntimeHelper::<Runtime>::try_dispatch(
+			Some(origin).into(),
+			crml_eth_wallet::Call::<Runtime>::set_payment_asset {
+				payment_asset: Some(payment_asset),
+			},
+			gasometer,
+		)?;
+
+		// Build output.
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: EvmDataWriter::new().write(true).build(),
+			logs: Default::default(),
+		})
+	}
+}

--- a/evm-precompiles/fee-payment/src/lib.rs
+++ b/evm-precompiles/fee-payment/src/lib.rs
@@ -16,7 +16,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use fp_evm::Precompile;
+use cennznet_primitives::types::AssetId;
+pub use fp_evm::Precompile;
 pub use fp_evm::{Context, ExitSucceed, PrecompileOutput};
 use frame_support::{
 	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
@@ -74,7 +75,7 @@ where
 		}
 
 		match selector {
-			Action::SetFeeAsset => Self::set_fee_asset(input, gasometer, &context.address),
+			Action::SetFeeAsset => Self::set_fee_asset(input, gasometer, &context.caller),
 		}
 	}
 }
@@ -101,7 +102,7 @@ where
 	) -> EvmResult<PrecompileOutput> {
 		// Parse input.
 		input.expect_arguments(gasometer, 1)?;
-		let payment_asset: u32 = input.read::<U256>(gasometer)?.saturated_into();
+		let payment_asset: AssetId = input.read::<U256>(gasometer)?.saturated_into();
 		let origin = <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(*caller);
 
 		RuntimeHelper::<Runtime>::try_dispatch(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -104,6 +104,7 @@ pallet-evm-precompile-simple = { default-features = false, git = "https://github
 pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/cennznet/frontier", rev = "890a535d105d206f7427550794c1973eeff9dd52" }
 pallet-evm-precompiles-erc721 = { path = "../evm-precompiles/erc721", default-features = false }
 pallet-evm-precompiles-erc20 = { path = "../evm-precompiles/erc20", default-features = false }
+pallet-evm-precompiles-fee-payment = { path = "../evm-precompiles/fee-payment", default-features = false }
 precompile-utils = { path = "../evm-precompiles/utils", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 
@@ -179,6 +180,7 @@ std = [
 	"pallet-evm-precompile-sha3fips/std",
 	"pallet-evm-precompiles-erc20/std",
 	"pallet-evm-precompiles-erc721/std",
+	"pallet-evm-precompiles-fee-payment/std",
 	"precompile-utils/std",
 	"rustc-hex/std",
 ]

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -9,6 +9,8 @@ use pallet_evm_precompiles_erc20::{Erc20IdConversion, Erc20PrecompileSet, ERC20_
 use pallet_evm_precompiles_erc721::{
 	Address, Erc721IdConversion, Erc721PrecompileSet, ERC721_PRECOMPILE_ADDRESS_PREFIX,
 };
+use pallet_evm_precompiles_fee_payment::FeePaymentPrecompile;
+
 use sp_core::H160;
 use sp_std::{convert::TryInto, marker::PhantomData};
 
@@ -24,7 +26,7 @@ where
 	}
 	pub fn used_addresses() -> sp_std::vec::Vec<H160> {
 		// TODO: precompute this
-		sp_std::vec![1, 2, 3, 4, 5, 9, 1024, 1026]
+		sp_std::vec![1, 2, 3, 4, 5, 9, 1024, 1026, 1211]
 			.into_iter()
 			.map(|x| hash(x))
 			.collect()
@@ -52,6 +54,9 @@ impl PrecompileSet for CENNZnetPrecompiles<Runtime> {
 			a if a == hash(1024) => Some(Sha3FIPS256::execute(input, target_gas, context, is_static)),
 			a if a == hash(1026) => Some(ECRecoverPublicKey::execute(input, target_gas, context, is_static)),
 			// CENNZnet precompiles:
+			a if a == hash(1211) => Some(FeePaymentPrecompile::<Runtime>::execute(
+				input, target_gas, context, is_static,
+			)),
 			_a if routing_prefix == ERC721_PRECOMPILE_ADDRESS_PREFIX => {
 				<Erc721PrecompileSet<Runtime> as PrecompileSet>::execute(
 					&Erc721PrecompileSet::<Runtime>::new(),

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -10,7 +10,6 @@ use pallet_evm_precompiles_erc721::{
 	Address, Erc721IdConversion, Erc721PrecompileSet, ERC721_PRECOMPILE_ADDRESS_PREFIX,
 };
 use pallet_evm_precompiles_fee_payment::FeePaymentPrecompile;
-
 use sp_core::H160;
 use sp_std::{convert::TryInto, marker::PhantomData};
 

--- a/runtime/tests/evm_precompiles_fee_payment.rs
+++ b/runtime/tests/evm_precompiles_fee_payment.rs
@@ -1,0 +1,51 @@
+/* Copyright 2019-2021 Centrality Investments Limited
+*
+* Licensed under the LGPL, Version 3.0 (the "License");
+* you may not use this file except in compliance with the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* You may obtain a copy of the License at the root of this project source code,
+* or at:
+*     https://centrality.ai/licenses/gplv3.txt
+*     https://centrality.ai/licenses/lgplv3.txt
+*/
+
+use cennznet_primitives::types::AssetId;
+use cennznet_runtime::{EthWallet, Runtime};
+use frame_support::assert_ok;
+use hex_literal::hex;
+use pallet_evm_precompiles_fee_payment::{Action, Context, EvmDataWriter, FeePaymentPrecompile, Precompile};
+use sp_core::{H160, U256};
+
+mod common;
+use common::mock::ExtBuilder;
+
+#[test]
+fn set_payment_asset() {
+	ExtBuilder::default().build().execute_with(|| {
+		let caller = H160::from_slice(&hex!("0000022EdbDcBA4bF24a2Abf89F5C230b3700000"));
+		let payment_asset: AssetId = 12;
+		let address = H160::from_low_u64_be(1211);
+		let context = Context {
+			address,
+			caller,
+			apparent_value: U256::default(),
+		};
+		let input_data = EvmDataWriter::new_with_selector(Action::SetFeeAsset)
+			.write::<U256>(payment_asset.into())
+			.build();
+
+		assert_ok!(<FeePaymentPrecompile<Runtime> as Precompile>::execute(
+			&input_data,
+			None,
+			&context,
+			false
+		));
+
+		// Check payment asset has been set in eth-wallet pallet
+		assert_eq!(EthWallet::evm_payment_asset(caller), Some(payment_asset));
+	})
+}


### PR DESCRIPTION
Adds precompiles for setting multicurrency fee preferences.
Connects to eth-wallet pallet and lets users set fee preferences through the EVM