### PR TITLE
Fix/632

### DIFF
--- a/crml/staking/src/lib.rs
+++ b/crml/staking/src/lib.rs
@@ -2631,6 +2631,13 @@ impl<T: Config> Module<T> {
 				Self::start_era(start_session);
 			}
 		}
+
+		// disable all offending validators that have been disabled for the whole era
+		for (index, disabled) in Self::offending_validators() {
+			if disabled {
+				T::SessionInterface::disable_validator(index);
+			}
+		}
 	}
 
 	/// End a session potentially ending an era.
@@ -2692,6 +2699,8 @@ impl<T: Config> Module<T> {
 			.collect::<Vec<T::AccountId>>();
 
 		T::Rewarder::on_end_era(validators.as_slice(), active_era.index, WasEndEraForced::take());
+		// Clear offending validators.
+		OffendingValidators::kill();
 	}
 
 	/// Plan a new era. Return the potential new staking set.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set `impl_version` to equal spec_version. If only runtime
 	// implementation chabges and behavior does not, then leave `spec_version` as
 	// is and increment `impl_version`.
-	spec_version: 57,
+	spec_version: 58,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,


### PR DESCRIPTION
in line with upstream pallet:
- Clears OffendingValidators storage on era end
- ensure validators marked as disabled for an era are disabled at the start of a new session

closes #632