### PR TITLE
Base64 encode the message used by eth wallet signning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ dependencies = [
 name = "crml-eth-wallet"
 version = "2.0.0"
 dependencies = [
+ "base64 0.13.0",
  "cennznet-primitives",
  "crml-support",
  "frame-support",

--- a/crml/eth-wallet/Cargo.toml
+++ b/crml/eth-wallet/Cargo.toml
@@ -21,6 +21,7 @@ sp-core = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb
 sp-runtime = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
 frame-support = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
 frame-system = { git = "https://github.com/cennznet/substrate", rev = "92f06d413796bb1443b31d92bde637c90742a077", default_features = false }
+base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 hex-literal = "0.3.1"
@@ -42,5 +43,6 @@ std = [
     "sp-runtime/std",
     "frame-support/std",
     "frame-system/std",
-    "scale-info/std"
+    "scale-info/std",
+    "base64/std"
 ]

--- a/crml/eth-wallet/src/lib.rs
+++ b/crml/eth-wallet/src/lib.rs
@@ -99,9 +99,8 @@ decl_module! {
 			// convert to CENNZnet address
 			let account = T::AddressMapping::into_account_id(eth_address);
 			let nonce = <frame_system::Pallet<T>>::account_nonce(account.clone());
-			let message = &(&call, nonce).encode()[..];
-
-			if let Some(_public_key) = ecrecover(&signature, message, &eth_address) {
+			let message = base64::encode(&(&call, nonce).encode()[..]);
+			if let Some(_public_key) = ecrecover(&signature, message.as_bytes(), &eth_address) {
 				// Pay fee, increment nonce
 				let _ = Self::pay_fee(&call, &account)?;
 				<frame_system::Pallet<T>>::inc_account_nonce(&account);
@@ -143,8 +142,10 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
 		{
 			let account = T::AddressMapping::into_account_id(*eth_address);
 			let nonce = <frame_system::Pallet<T>>::account_nonce(account.clone());
-			let message = &(&call, nonce).encode()[..];
-			if let Some(_public_key) = ecrecover(&signature, message, &eth_address) {
+			// let message = base64::encode(fullMsg);
+
+			let message = base64::encode(&(&call, nonce).encode()[..]);
+			if let Some(_public_key) = ecrecover(&signature, message.as_bytes(), &eth_address) {
 				return ValidTransaction::with_tag_prefix("EthWallet")
 					.priority(T::UnsignedPriority::get())
 					.and_provides((eth_address, nonce))

--- a/crml/eth-wallet/src/lib.rs
+++ b/crml/eth-wallet/src/lib.rs
@@ -316,7 +316,8 @@ mod tests {
 			}
 			.into();
 			let nonce = <frame_system::Pallet<Test>>::account_nonce(&cennznet_address);
-			let signature = EthereumSignature::try_from(eth_sign(&ECDSA_SEED, (call.clone(), nonce).encode().as_ref()))
+			let msg = base64::encode((call.clone(), nonce).encode());
+			let signature = EthereumSignature::try_from(eth_sign(&ECDSA_SEED, msg.as_ref()))
 				.expect("valid sig");
 
 			// execute the call

--- a/crml/eth-wallet/src/lib.rs
+++ b/crml/eth-wallet/src/lib.rs
@@ -99,7 +99,7 @@ decl_module! {
 			// convert to CENNZnet address
 			let account = T::AddressMapping::into_account_id(eth_address);
 			let nonce = <frame_system::Pallet<T>>::account_nonce(account.clone());
-			let prefix = "data:application-octet;base64";
+			let prefix = "data:application-octet;base64,";
 			let msg =  base64::encode(&(&call, nonce).encode()[..]);
 			let full_msg = &[prefix.as_bytes(), msg.as_bytes()].concat()[..];
 			if let Some(_public_key) = ecrecover(&signature, full_msg, &eth_address) {
@@ -144,7 +144,7 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
 		{
 			let account = T::AddressMapping::into_account_id(*eth_address);
 			let nonce = <frame_system::Pallet<T>>::account_nonce(account.clone());
-			let prefix = "data:application-octet;base64";
+			let prefix = "data:application-octet;base64,";
 			let msg = base64::encode(&(&call, nonce).encode()[..]);
 			let full_msg = &[prefix.as_bytes(), msg.as_bytes()].concat()[..];
 
@@ -320,7 +320,7 @@ mod tests {
 			.into();
 			let nonce = <frame_system::Pallet<Test>>::account_nonce(&cennznet_address);
 			let msg = base64::encode((call.clone(), nonce).encode());
-			let prefix = "data:application-octet;base64";
+			let prefix = "data:application-octet;base64,";
 			let full_msg = &[prefix.as_bytes(), msg.as_bytes()].concat()[..];
 			let signature = EthereumSignature::try_from(eth_sign(&ECDSA_SEED, full_msg.as_ref())).expect("valid sig");
 

--- a/crml/eth-wallet/src/lib.rs
+++ b/crml/eth-wallet/src/lib.rs
@@ -317,8 +317,7 @@ mod tests {
 			.into();
 			let nonce = <frame_system::Pallet<Test>>::account_nonce(&cennznet_address);
 			let msg = base64::encode((call.clone(), nonce).encode());
-			let signature = EthereumSignature::try_from(eth_sign(&ECDSA_SEED, msg.as_ref()))
-				.expect("valid sig");
+			let signature = EthereumSignature::try_from(eth_sign(&ECDSA_SEED, msg.as_ref())).expect("valid sig");
 
 			// execute the call
 			assert_ok!(EthWallet::call(Origin::none(), Box::new(call), eth_address, signature));


### PR DESCRIPTION
This encode the eth call data before signing so that any eth wallet shows some meaningful data. 
<img width="497" alt="Screen Shot 2022-05-11 at 9 54 55 AM" src="https://user-images.githubusercontent.com/29415595/167728424-0cf2910c-28a1-435a-9749-ad63bdcd5fd6.png">

Payload from API side
```
let payload = cennznet.registry.createType('EthWalletCall', { call: call, nonce });
payload = `data:application-octet;base64,${base64Encode(payload.toHex())}`;
const signature = await ethereum.request({ method: 'personal_sign', params: [payload, address] });

```