### PR TITLE
Add timestamp to state oracle callback

### DIFF
--- a/crml/eth-state-oracle/src/lib.rs
+++ b/crml/eth-state-oracle/src/lib.rs
@@ -117,6 +117,8 @@ decl_error! {
 		InsufficientFundsGas,
 		/// Paying the callback bounty to relayer failed
 		InsufficientFundsBounty,
+		/// Timestamp is either stale or from the future
+		InvalidResponseTimestamp,
 		/// Challenge already in progress
 		DuplicateChallenge,
 		/// Return data exceeded the 32 byte limit
@@ -161,7 +163,6 @@ decl_module! {
 		}
 
 		/// Try run request callbacks using idle block space
-		/// TODO: on_idle could be executed after extrinsics, is this ok?
 		fn on_idle(_now: T::BlockNumber, remaining_weight: Weight) -> Weight {
 			if ResponsesForCallback::decode_len().unwrap_or(0).is_zero() {
 				return DbWeight::get().reads(1);
@@ -197,27 +198,11 @@ decl_module! {
 				Requests::remove(call_request_id);
 				let response = Responses::<T>::take(call_request_id).unwrap();
 
-				// At this point the claimed 'return_data' is considered valid as it has
-				// passed the challenge period
-				let return_data = match response.return_data {
-					ReturnDataClaim::Ok(return_data) => return_data,
-					// this returndata exceeded the length limit so it will not be processed
-					ReturnDataClaim::ExceedsLengthLimit => {
-						Self::deposit_event(Event::CallbackErr(
-							call_request_id,
-							Error::<T>::ReturnDataExceedsLimit.into(),
-						));
-						consumed_weight = consumed_weight.saturating_add(weight_per_callback);
-						continue;
-					}
-				};
-
 				// Try run the callback, recording weight consumed
 				let callback_weight = match Self::try_callback(
 					call_request_id,
 					&request,
-					&response.reporter,
-					&return_data,
+					&response,
 				) {
 					Ok(info) => {
 						let callback_weight = info.actual_weight.unwrap_or(0);
@@ -250,14 +235,15 @@ decl_module! {
 		/// Submit response for a a remote call request
 		///
 		/// `return_data` - the claimed `returndata` of the `eth_call` RPC using the requested contract and input buffer
-		/// `eth_block_number` - the ethereum block number the request was made
+		/// `eth_block_number` - the ethereum block number where the 'returndata' was obtained
+		/// `eth_block_timestamp` - the ethereum block timestamp where the 'returndata' was obtained (unix timestamp, seconds)
 		///
 		/// Caller should be a configured relayer (i.e. authorized or staked)
 		/// Only accepts the first response for a given request
 		/// The response is not valid until `T::ChallengePeriod` blocks have passed
 		///
 		#[weight = 500_000]
-		pub fn submit_call_response(origin, request_id: RequestId, return_data: ReturnDataClaim, eth_block_number: u64) {
+		pub fn submit_call_response(origin, request_id: RequestId, return_data: ReturnDataClaim, eth_block_number: u64, eth_block_timestamp: u64) {
 			// TODO: relayer should have some bond
 			let origin = ensure_signed(origin)?;
 
@@ -279,10 +265,20 @@ decl_module! {
 			// if the type is dynamic i.e `[]T` or `bytes`, `returndata` length will be 32 * (offset + length + n)
 
 			if let Some(request) = Requests::get(request_id) {
+				// ~ average ethereum block time
+				let eth_block_time_s = 15;
+				// check response timestamp is within a sensible bound +/- 2 Ethereum blocks from the request timestamp
+				ensure!(
+					eth_block_timestamp >= (request.timestamp.saturating_sub(2 * eth_block_time_s)) &&
+					eth_block_timestamp <= (request.timestamp.saturating_add(2 * eth_block_time_s)),
+					Error::<T>::InvalidResponseTimestamp
+				);
+
 				let response = CallResponse {
 					return_data,
 					eth_block_number,
-					reporter: origin,
+					eth_block_timestamp,
+					relayer: origin,
 				};
 				<Responses<T>>::insert(request_id, response);
 				let execute_block = <frame_system::Pallet<T>>::block_number() + T::ChallengePeriod::get();
@@ -299,7 +295,7 @@ decl_module! {
 		/// Valid challenge scenarios are:
 		/// - incorrect value
 		/// - The block number of the response is stale or from the future
-		///   request.timestamp - lenience > block.timestamp > request.timestamp + lenience
+		/// - the block timestamp of the response is inaccurate
 		#[weight = 500_000]
 		pub fn submit_response_challenge(origin, request_id: RequestId) {
 			// TODO: challenger should have some bond
@@ -339,15 +335,21 @@ impl<T: Config> EthCallOracleSubscriber for Module<T> {
 
 impl<T: Config> Module<T> {
 	/// Try to execute a callback
+	/// `request_id` - the request identifier
 	/// `request` - the original request
-	/// `relayer` - the address of the relayer
-	/// `return_data` - the returndata of the request (fulfilled by the relayer)
+	/// `response` - the response info (validated)
 	fn try_callback(
 		request_id: RequestId,
 		request: &CallRequest,
-		relayer: &T::AccountId,
-		return_data: &[u8; 32],
+		response: &CallResponse<T::AccountId>,
 	) -> DispatchResultWithPostInfo {
+		// check returndata type
+		let return_data = match response.return_data {
+			ReturnDataClaim::Ok(return_data) => return_data,
+			// this returndata exceeded the length limit so it will not be processed
+			ReturnDataClaim::ExceedsLengthLimit => return Err(Error::<T>::ReturnDataExceedsLimit.into()),
+		};
+
 		// The overall gas payment process for state oracle interaction is as follows:
 		// 1) requestor pays the state oracle request fee to network via gas fees and sets a bounty amount
 		// 	  bounty should be in cpay, relayers can take jobs at their discretion (free market)
@@ -355,7 +357,6 @@ impl<T: Config> Module<T> {
 		// we can't buy gas in advance due to the potential price of gas changing between blocks, therefore:
 		// 2) require caller to precommit to a future gas_limit at time of request
 		// 3) pay for this gas_limit at the current price at the time of execution from caller account
-
 		let caller_ss58_address = T::AddressMapping::into_account_id(request.caller);
 		log!(
 			debug,
@@ -374,7 +375,7 @@ impl<T: Config> Module<T> {
 		);
 		let _ = T::MultiCurrency::transfer(
 			&caller_ss58_address,
-			relayer,
+			&response.relayer,
 			T::MultiCurrency::fee_currency(),
 			request.bounty,
 			ExistenceRequirement::AllowDeath,
@@ -411,11 +412,12 @@ impl<T: Config> Module<T> {
 		)
 		.map_err(|_| Error::<T>::InsufficientFundsGas)?;
 
-		// abi encode callback input
+		// abi encode callback input `<callbackSelector>(uint256 requestId, uint256 timestamp, bytes32 returnData)`
 		let callback_input = [
 			request.callback_signature.as_ref(),
 			EthAbiCodec::encode(&request_id).as_ref(),
-			return_data, // bytes32 are encoded as is
+			EthAbiCodec::encode(&response.eth_block_timestamp).as_ref(),
+			&return_data, // bytes32 are encoded as is
 		]
 		.concat();
 

--- a/crml/eth-state-oracle/src/mock.rs
+++ b/crml/eth-state-oracle/src/mock.rs
@@ -13,7 +13,7 @@
 *     https://centrality.ai/licenses/lgplv3.txt
 */
 
-use crate::{self as crml_eth_state_oracle, CallRequest, Config};
+use crate::{self as crml_eth_state_oracle, CallRequest, CallResponse, Config, ReturnDataClaim};
 use cennznet_primitives::types::FeePreferences;
 use crml_support::{ContractExecutor, H160, H256, U256};
 use frame_support::{
@@ -215,7 +215,7 @@ impl CallRequestBuilder {
 		})
 	}
 	pub fn build(self) -> CallRequest {
-		self.0.clone()
+		self.0
 	}
 	pub fn expiry_block(mut self, expiry_block: BlockNumber) -> Self {
 		self.0.expiry_block = expiry_block as u32;
@@ -247,6 +247,40 @@ impl CallRequestBuilder {
 	}
 	pub fn timestamp(mut self, timestamp: u64) -> Self {
 		self.0.timestamp = timestamp;
+		self
+	}
+}
+
+pub(crate) struct CallResponseBuilder(CallResponse<AccountId>);
+
+impl CallResponseBuilder {
+	/// initialize a new CallResponseBuilder
+	pub fn new() -> Self {
+		CallResponseBuilder(CallResponse {
+			return_data: ReturnDataClaim::Ok([1_u8; 32]),
+			relayer: Default::default(),
+			eth_block_number: 5,
+			eth_block_timestamp: <TestRuntime as Config>::UnixTime::now().as_secs(),
+		})
+	}
+	/// Return the built CallResponse
+	pub fn build(self) -> CallResponse<AccountId> {
+		self.0
+	}
+	pub fn eth_block_number(mut self, eth_block_number: u64) -> Self {
+		self.0.eth_block_number = eth_block_number;
+		self
+	}
+	pub fn eth_block_timestamp(mut self, eth_block_timestamp: u64) -> Self {
+		self.0.eth_block_timestamp = eth_block_timestamp;
+		self
+	}
+	pub fn relayer(mut self, relayer: AccountId) -> Self {
+		self.0.relayer = relayer;
+		self
+	}
+	pub fn return_data(mut self, return_data: ReturnDataClaim) -> Self {
+		self.0.return_data = return_data;
 		self
 	}
 }

--- a/crml/eth-state-oracle/src/tests.rs
+++ b/crml/eth-state-oracle/src/tests.rs
@@ -79,7 +79,7 @@ fn try_callback() {
 
 		let relayer = 3_u64;
 		let response = CallResponseBuilder::new()
-			.timestamp(5_u64)
+			.eth_block_timestamp(5_u64)
 			.relayer(relayer)
 			.build();
 

--- a/crml/eth-state-oracle/src/types.rs
+++ b/crml/eth-state-oracle/src/types.rs
@@ -52,8 +52,10 @@ pub struct CallRequest {
 pub struct CallResponse<AccountId> {
 	/// The 'returndata' state as claimed by `reporter`
 	pub return_data: ReturnDataClaim,
-	/// The ethereum block number where the result was recorded
+	/// The ethereum block number where the result was obtained
 	pub eth_block_number: u64,
+	/// The ethereum block timestamp where the result was obtained
+	pub eth_block_timestamp: u64,
 	/// Address of the relayer that reported this
-	pub reporter: AccountId,
+	pub relayer: AccountId,
 }

--- a/crml/eth-wallet/src/lib.rs
+++ b/crml/eth-wallet/src/lib.rs
@@ -173,7 +173,7 @@ mod tests {
 	use hex_literal::hex;
 	use libsecp256k1 as secp256k1;
 	use pallet_evm::AddressMapping;
-	use sp_core::{ecdsa, keccak_256, Pair};
+	use sp_core::keccak_256;
 	use sp_runtime::{
 		testing::{Header, H256},
 		traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
@@ -312,7 +312,6 @@ mod tests {
 	#[test]
 	fn simple_remark() {
 		new_test_ext().execute_with(|| {
-			let pair = ecdsa::Pair::from_seed(&ECDSA_SEED);
 			let eth_address: EthAddress = hex!("420aC537F1a4f78d4Dfb3A71e902be0E3d480AFB").into();
 			let cennznet_address = <Test as Config>::AddressMapping::into_account_id(eth_address);
 			let call: Call = frame_system::Call::<Test>::remark {

--- a/test-ts/contracts/StateOracleDemo.sol
+++ b/test-ts/contracts/StateOracleDemo.sol
@@ -5,7 +5,7 @@ contract StateOracleDemo {
     // log on state oracle request
     event HiToEthereum(uint256 requestId);
     // log on state oracle response
-    event HiFromEthereum(uint256 requestId, uint256 balance);
+    event HiFromEthereum(uint256 requestId, uint256 timestamp, uint256 balance);
     event Greeted(bytes32);
 
     address constant STATE_ORACLE = address(27572);
@@ -29,12 +29,13 @@ contract StateOracleDemo {
     }
 
     // Receive state oracle response
-    function ethereumSaysHi(uint256 requestId, bytes32 returnData) external {
+    function ethereumSaysHi(uint256 requestId, uint256 timestamp, bytes32 returnData) external {
         require(msg.sender == STATE_ORACLE, "must be state oracle");
         uint256 balanceOf = uint256(returnData);
 
         emit HiFromEthereum(
             requestId,
+            timestamp,
             balanceOf
         );
     }


### PR DESCRIPTION
Changes:
- state oracle callback now includes the block timestamp of the block where the request was fulfilled
- requires relayers submit the block timestamp aswell as block number

Other:
- Does a sensibility check on the submitted timestamp is +/- 30 seconds from the CENNZnet request timestamp