### PR TITLE
Some tidy up for relayer bonding

### DIFF
--- a/crml/eth-bridge/src/lib.rs
+++ b/crml/eth-bridge/src/lib.rs
@@ -802,9 +802,10 @@ impl<T: Config> Module<T> {
 				return Err(Error::<T>::InvalidClaim.into());
 			}
 			<EventNotarizations<T>>::remove_prefix(event_claim_id, None);
-			let (_eth_tx_hash, event_type_id) = EventClaims::take(event_claim_id);
+			let (eth_tx_hash, event_type_id) = EventClaims::take(event_claim_id);
 			let (contract_address, event_signature) = TypeIdToEventType::get(event_type_id);
 			let event_data = event_data.unwrap();
+			PendingTxHashes::remove(eth_tx_hash);
 			Self::deposit_event(Event::Invalid(event_claim_id));
 
 			T::Subscribers::on_failure(event_claim_id, &contract_address, &event_signature, &event_data);

--- a/crml/eth-state-oracle/src/mock.rs
+++ b/crml/eth-state-oracle/src/mock.rs
@@ -144,7 +144,8 @@ impl BuyFeeAsset for MockBuyFeeAsset {
 			.checked_sub(amount)
 			.ok_or(DispatchError::Other("No Balance"))?;
 		GenericAsset::make_free_balance_be(&who, fee_exchange.asset_id(), new_balance);
-		GenericAsset::deposit_into_existing(&who, GenericAsset::fee_currency(), amount)?;
+		let _ = GenericAsset::deposit_into_existing(&who, GenericAsset::fee_currency(), amount)?;
+
 		Ok(amount)
 	}
 


### PR DESCRIPTION
the extra reserve checks is only if CENNZ is used (since it can have locks included in free balance)
+ the fix from develop for #676 