### PR TITLE
Rust 2021 update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "crml-generic-asset"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cennznet-primitives",
  "crml-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "crml-token-approvals"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cennznet-primitives",
  "crml-generic-asset",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "crml-transaction-payment-rpc-runtime-api"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "crml-transaction-payment",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "crml-cennzx"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cennznet-primitives",
  "cennznet-runtime",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "crml-cennzx-rpc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "crml-cennzx-rpc-runtime-api",
  "hex",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "crml-cennzx-rpc-runtime-api"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "crml-transaction-payment"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cennznet-primitives",
  "crml-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "crml-transaction-payment-rpc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "crml-transaction-payment-rpc-runtime-api",
  "jsonrpc-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "crml-erc20-peg"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cennznet-primitives",
  "crml-generic-asset",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "crml-eth-bridge"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cennznet-primitives",
  "crml-support",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "crml-eth-state-oracle"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cennznet-primitives",
  "crml-generic-asset",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "crml-generic-asset-rpc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "crml-generic-asset",
  "crml-generic-asset-rpc-runtime-api",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "crml-generic-asset-rpc-runtime-api"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "crml-generic-asset",
  "parity-scale-codec",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "crml-governance"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cennznet-primitives",
  "crml-generic-asset",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "crml-governance-rpc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "crml-governance",
  "crml-governance-rpc-runtime-api",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "crml-governance-rpc-runtime-api"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "crml-governance",
  "parity-scale-codec",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "crml-nft"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cennznet-primitives",
  "crml-generic-asset",

--- a/crml/cennzx/Cargo.toml
+++ b/crml/cennzx/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crml-cennzx"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }

--- a/crml/cennzx/rpc/Cargo.toml
+++ b/crml/cennzx/rpc/Cargo.toml
@@ -1,9 +1,9 @@
 
 [package]
 name = "crml-cennzx-rpc"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <developers@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]

--- a/crml/cennzx/rpc/runtime-api/Cargo.toml
+++ b/crml/cennzx/rpc/runtime-api/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crml-cennzx-rpc-runtime-api"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <developers@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]

--- a/crml/cennzx/rpc/src/lib.rs
+++ b/crml/cennzx/rpc/src/lib.rs
@@ -25,7 +25,7 @@ use sp_api::ProvideRuntimeApi;
 use sp_arithmetic::traits::{BaseArithmetic, SaturatedConversion};
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
-use std::{convert::TryInto, fmt::Display, str::FromStr, sync::Arc};
+use std::{fmt::Display, str::FromStr, sync::Arc};
 
 pub use self::gen_client::Client as CennzxClient;
 pub use crml_cennzx_rpc_runtime_api::{self as runtime_api, CennzxApi as CennzxRuntimeApi, CennzxResult};

--- a/crml/erc20-peg/Cargo.toml
+++ b/crml/erc20-peg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-erc20-peg"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "Module for bridging ERC20 tokens"

--- a/crml/erc20-peg/Cargo.toml
+++ b/crml/erc20-peg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crml-erc20-peg"
 version = "1.0.0"
-edition = "2018"
+edition = "2021"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "Module for bridging ERC20 tokens"
 license = "GPL-3.0"

--- a/crml/erc20-peg/src/types.rs
+++ b/crml/erc20-peg/src/types.rs
@@ -15,7 +15,6 @@
 use codec::{Decode, Encode};
 pub use crml_support::{EthAbiCodec, H160, H256, U256};
 use scale_info::TypeInfo;
-use sp_std::convert::TryInto;
 use sp_std::prelude::*;
 
 /// Ethereum address type

--- a/crml/eth-bridge/Cargo.toml
+++ b/crml/eth-bridge/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crml-eth-bridge"
 version = "1.0.0"
-edition = "2018"
+edition = "2021"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "Module for bridging Ethereum events"
 license = "GPL-3.0"

--- a/crml/eth-bridge/Cargo.toml
+++ b/crml/eth-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-eth-bridge"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "Module for bridging Ethereum events"

--- a/crml/eth-bridge/src/impls.rs
+++ b/crml/eth-bridge/src/impls.rs
@@ -22,7 +22,7 @@ use crate::{
 	REQUEST_TTL_MS,
 };
 use sp_runtime::offchain::StorageKind;
-use sp_std::{convert::TryInto, prelude::*};
+use sp_std::prelude::*;
 
 #[cfg(not(feature = "std"))]
 use sp_std::alloc::string::ToString;

--- a/crml/eth-state-oracle/Cargo.toml
+++ b/crml/eth-state-oracle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crml-eth-state-oracle"
 version = "1.0.0"
-edition = "2018"
+edition = "2021"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "Pallet for state requests to Ethereum"
 license = "GPL-3.0"

--- a/crml/eth-state-oracle/Cargo.toml
+++ b/crml/eth-state-oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-eth-state-oracle"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Centrality Developers <support@centrality.ai>"]
 description = "Pallet for state requests to Ethereum"

--- a/crml/eth-state-oracle/src/mock.rs
+++ b/crml/eth-state-oracle/src/mock.rs
@@ -138,7 +138,7 @@ impl BuyFeeAsset for MockBuyFeeAsset {
 			.checked_sub(amount)
 			.ok_or(DispatchError::Other("No Balance"))?;
 		GenericAsset::make_free_balance_be(&who, fee_exchange.asset_id(), new_balance);
-		GenericAsset::deposit_into_existing(&who, GenericAsset::fee_currency(), amount)?;
+		let _ = GenericAsset::deposit_into_existing(&who, GenericAsset::fee_currency(), amount)?;
 		Ok(amount)
 	}
 
@@ -250,10 +250,6 @@ impl CallRequestBuilder {
 		self.0.expiry_block = expiry_block as u32;
 		self
 	}
-	pub fn input_data(mut self, input_data: &[u8]) -> Self {
-		self.0.input_data = input_data.to_vec();
-		self
-	}
 	pub fn bounty(mut self, bounty: Balance) -> Self {
 		self.0.bounty = bounty;
 		self
@@ -278,10 +274,6 @@ impl CallRequestBuilder {
 		self.0.callback_signature = callback_signature;
 		self
 	}
-	pub fn timestamp(mut self, timestamp: u64) -> Self {
-		self.0.timestamp = timestamp;
-		self
-	}
 }
 
 pub(crate) struct CallResponseBuilder(CallResponse<AccountId>);
@@ -299,10 +291,6 @@ impl CallResponseBuilder {
 	/// Return the built CallResponse
 	pub fn build(self) -> CallResponse<AccountId> {
 		self.0
-	}
-	pub fn eth_block_number(mut self, eth_block_number: u64) -> Self {
-		self.0.eth_block_number = eth_block_number;
-		self
 	}
 	pub fn eth_block_timestamp(mut self, eth_block_timestamp: u64) -> Self {
 		self.0.eth_block_timestamp = eth_block_timestamp;

--- a/crml/eth-state-oracle/src/mock.rs
+++ b/crml/eth-state-oracle/src/mock.rs
@@ -31,7 +31,6 @@ use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 };
-use sp_std::convert::TryFrom;
 
 type AssetId = u32;
 type Balance = u128;

--- a/crml/eth-state-oracle/src/tests.rs
+++ b/crml/eth-state-oracle/src/tests.rs
@@ -143,7 +143,6 @@ fn try_callback_with_fee_preferences() {
 		let caller = 111_u64;
 		let bounty = 88 as Balance;
 		let request_id = RequestId::from(123_u32);
-		let return_data = [1_u8; 32];
 		let payment_asset_id: AssetId = 1;
 		let fee_preferences = FeePreferences { asset_id: payment_asset_id, slippage: Default::default() };
 		let request = CallRequestBuilder::new()

--- a/crml/generic-asset/Cargo.toml
+++ b/crml/generic-asset/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crml-generic-asset"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 repository = "https://github.com/cennznet/cennznet"
 description = "A runtime module for managing ERC-20 like fungible assets"

--- a/crml/generic-asset/rpc/Cargo.toml
+++ b/crml/generic-asset/rpc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crml-generic-asset-rpc"
 version = "2.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 repository = "https://github.com/cennznet/cennznet"
 description = "RPC interface for the generic asset module."

--- a/crml/generic-asset/rpc/Cargo.toml
+++ b/crml/generic-asset/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-generic-asset-rpc"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crml/generic-asset/rpc/runtime-api/Cargo.toml
+++ b/crml/generic-asset/rpc/runtime-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crml-generic-asset-rpc-runtime-api"
 version = "2.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 repository = "https://github.com/cennznet/cennznet"
 description = "Runtime API definition required by Generic Asset RPC extensions."

--- a/crml/generic-asset/rpc/runtime-api/Cargo.toml
+++ b/crml/generic-asset/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-generic-asset-rpc-runtime-api"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crml/governance/Cargo.toml
+++ b/crml/governance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-governance"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crml/governance/Cargo.toml
+++ b/crml/governance/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crml-governance"
 version = "2.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 repository = "https://github.com/cennznet/cennznet"
 description = "A runtime module for decentralized governance of the CENNZnet protocol"

--- a/crml/governance/rpc/Cargo.toml
+++ b/crml/governance/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-governance-rpc"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crml/governance/rpc/Cargo.toml
+++ b/crml/governance/rpc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crml-governance-rpc"
 version = "2.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 repository = "https://github.com/cennznet/cennznet"
 description = "RPC interface for the governance module."

--- a/crml/governance/rpc/runtime-api/Cargo.toml
+++ b/crml/governance/rpc/runtime-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crml-governance-rpc-runtime-api"
 version = "2.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 repository = "https://github.com/cennznet/cennznet"
 description = "Runtime API definition required by Governance RPC extensions."

--- a/crml/governance/rpc/runtime-api/Cargo.toml
+++ b/crml/governance/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-governance-rpc-runtime-api"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crml/nft/Cargo.toml
+++ b/crml/nft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-nft"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2021"
 repository = "https://github.com/cennznet/cennznet"

--- a/crml/nft/Cargo.toml
+++ b/crml/nft/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crml-nft"
 version = "2.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/cennznet/cennznet"
 description = "CENNZnet NFT module"
 

--- a/crml/nft/rpc/Cargo.toml
+++ b/crml/nft/rpc/Cargo.toml
@@ -3,7 +3,7 @@
 name = "crml-nft-rpc"
 version = "2.1.1"
 authors = ["Centrality Developers <developers@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]

--- a/crml/nft/rpc/runtime-api/Cargo.toml
+++ b/crml/nft/rpc/runtime-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crml-nft-rpc-runtime-api"
 version = "2.1.1"
 authors = ["Centrality Developers <developers@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]

--- a/crml/token-approvals/Cargo.toml
+++ b/crml/token-approvals/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crml-token-approvals"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/cennznet/cennznet"
 description = "CENNZnet Token Approvals module"
 

--- a/crml/transaction-payment/Cargo.toml
+++ b/crml/transaction-payment/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crml-transaction-payment"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/cennznet/cennznet"
 description = "CENNZnet pallet to manage transaction payments"
 

--- a/crml/transaction-payment/rpc/Cargo.toml
+++ b/crml/transaction-payment/rpc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crml-transaction-payment-rpc"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/cennznet/cennznet"
 description = "RPC interface for the transaction payment module."
 readme = "README.md"

--- a/crml/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/crml/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crml-transaction-payment-rpc-runtime-api"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2021"
 repository = "https://github.com/cennznet/cennznet"

--- a/crml/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/crml/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crml-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/cennznet/cennznet"
 description = "RPC runtime API for transaction payment"
 readme = "README.md"

--- a/crml/transaction-payment/rpc/src/lib.rs
+++ b/crml/transaction-payment/rpc/src/lib.rs
@@ -31,7 +31,6 @@ use sp_runtime::{
 	generic::BlockId,
 	traits::{Block as BlockT, MaybeDisplay},
 };
-use std::convert::TryInto;
 use std::sync::Arc;
 
 #[rpc]

--- a/crml/transaction-payment/src/lib.rs
+++ b/crml/transaction-payment/src/lib.rs
@@ -295,7 +295,6 @@ decl_module! {
 			// given weight == u64, we build multipliers from `diff` of two weight values, which can
 			// at most be maximum block weight. Make sure that this can fit in a multiplier without
 			// loss.
-			use sp_std::convert::TryInto;
 			assert!(
 				<Multiplier as sp_runtime::traits::Bounded>::max_value() >=
 				Multiplier::checked_from_integer(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1494,7 +1494,6 @@ fn validate_self_contained_inner(
 		};
 		let extra_validation = SignedExtra::validate_unsigned(call, &call.get_dispatch_info(), input_len)?;
 		// Then, do the controls defined by the ethereum pallet.
-		use fp_self_contained::SelfContainedCall as _;
 		let self_contained_validation = eth_call
 			.validate_self_contained(signed_info)
 			.ok_or(TransactionValidityError::Invalid(InvalidTransaction::BadProof))??;


### PR DESCRIPTION
Updates most crates to Rust 2021 and fixes several build warnings

Change-log [here](https://doc.rust-lang.org/edition-guide/rust-2021/index.html)