### PR TITLE
Adds Controller account for NFT collections

### DIFF
--- a/crml/nft/src/lib.rs
+++ b/crml/nft/src/lib.rs
@@ -207,6 +207,8 @@ decl_storage! {
 	trait Store for Module<T: Config> as Nft {
 		/// Map from collection to owner address
 		pub CollectionOwner get(fn collection_owner): map hasher(twox_64_concat) CollectionId => Option<T::AccountId>;
+		/// Map from collection to controller address
+		pub CollectionController get(fn collection_controller): map hasher(twox_64_concat) CollectionId => Option<T::AccountId>;
 		/// Map from collection to its human friendly name
 		pub CollectionName get(fn collection_name): map hasher(twox_64_concat) CollectionId => CollectionNameType;
 		/// Map from collection to its defacto royalty scheme
@@ -366,6 +368,24 @@ decl_module! {
 			}
 		}
 
+		/// Set the controller of a collection. Useful for adding permissions to ERC721 contracts
+		/// interacting with the NFT module through the EVM
+		/// Caller must be the current collection owner
+		/// Controller account has permission to call the following functions:
+		/// mint_series
+		/// mint_additional
+		#[weight = T::WeightInfo::set_owner()]
+		fn set_controller(origin, collection_id: CollectionId, controller: T::AccountId) -> DispatchResult {
+			let origin = ensure_signed(origin)?;
+			if let Some(owner) = Self::collection_owner(collection_id) {
+				ensure!(owner == origin, Error::<T>::NoPermission);
+				<CollectionController<T>>::insert(collection_id, controller);
+				Ok(())
+			} else {
+				Err(Error::<T>::NoCollection.into())
+			}
+		}
+
 		/// Set the name of a series
 		/// Caller must be the current collection owner
 		#[weight = T::WeightInfo::set_owner()]
@@ -466,10 +486,10 @@ decl_module! {
 			let origin = ensure_signed(origin)?;
 
 			// Permission and existence check
-			if let Some(collection_owner) = Self::collection_owner(collection_id) {
-				ensure!(collection_owner == origin, Error::<T>::NoPermission);
-			} else {
-				return Err(Error::<T>::NoCollection.into());
+			match (Self::collection_owner(collection_id), Self::collection_controller(collection_id)) {
+				(Some(owner), Some(controller)) => ensure!(owner == origin || controller == origin, Error::<T>::NoPermission),
+				(Some(owner), None) => ensure!(owner == origin, Error::<T>::NoPermission),
+				(None, _) => return Err(Error::<T>::NoCollection.into()),
 			}
 
 			// Check we can issue the new tokens
@@ -519,10 +539,10 @@ decl_module! {
 			let origin = ensure_signed(origin)?;
 
 			// Permission and existence check
-			if let Some(collection_owner) = Self::collection_owner(collection_id) {
-				ensure!(collection_owner == origin, Error::<T>::NoPermission);
-			} else {
-				return Err(Error::<T>::NoCollection.into());
+			match (Self::collection_owner(collection_id), Self::collection_controller(collection_id)) {
+				(Some(owner), Some(controller)) => ensure!(owner == origin || controller == origin, Error::<T>::NoPermission),
+				(Some(owner), None) => ensure!(owner == origin, Error::<T>::NoPermission),
+				(None, _) => return Err(Error::<T>::NoCollection.into()),
 			}
 
 			let serial_number = Self::next_serial_number(collection_id, series_id);

--- a/crml/nft/src/tests.rs
+++ b/crml/nft/src/tests.rs
@@ -1984,6 +1984,88 @@ fn mint_series() {
 }
 
 #[test]
+fn mint_from_controller_account() {
+	ExtBuilder::default().build().execute_with(|| {
+		let collection_owner = 1_u64;
+		let collection_id = setup_collection(collection_owner);
+		let token_owner = 2_u64;
+		let collection_controller = 3_u64;
+		let quantity = 5;
+		let series_id = Nft::next_series_id(collection_id);
+
+		// Set controller account for collection
+		assert_ok!(Nft::set_controller(
+			Some(collection_owner).into(),
+			collection_id,
+			collection_controller
+		));
+		assert_eq!(Nft::collection_controller(collection_id), Some(collection_controller));
+
+		// mint token Ids 0-4 from controller account
+		assert_ok!(Nft::mint_series(
+			Some(collection_controller).into(),
+			collection_id,
+			quantity,
+			Some(token_owner),
+			MetadataScheme::Https(b"example.com/metadata".to_vec()),
+			None,
+		));
+
+		// mint token Ids 5-7 from controller account
+		let additional_quantity = 3;
+		assert_ok!(Nft::mint_additional(
+			Some(collection_controller).into(),
+			collection_id,
+			series_id,
+			additional_quantity,
+			Some(token_owner), // new owner this time
+		));
+
+		// Check token balances are correct
+		assert_eq!(
+			Nft::next_serial_number(collection_id, series_id),
+			quantity + additional_quantity
+		);
+		assert_eq!(
+			Nft::token_balance(&token_owner).get(&(collection_id, series_id)),
+			Some(&(quantity + additional_quantity))
+		);
+
+		let quantity = 7;
+		let series_id = Nft::next_series_id(collection_id);
+		// mint new series from owner account to ensure they can still mint
+		assert_ok!(Nft::mint_series(
+			Some(collection_controller).into(),
+			collection_id,
+			quantity,
+			Some(token_owner),
+			MetadataScheme::Https(b"example.com/metadata".to_vec()),
+			None,
+		));
+
+		// mint additional tokens from owner account
+		let additional_quantity = 4;
+		assert_ok!(Nft::mint_additional(
+			Some(collection_owner).into(),
+			collection_id,
+			series_id,
+			additional_quantity,
+			Some(token_owner), // new owner this time
+		));
+
+		// Check token balances are correct
+		assert_eq!(
+			Nft::next_serial_number(collection_id, series_id),
+			quantity + additional_quantity
+		);
+		assert_eq!(
+			Nft::token_balance(&token_owner).get(&(collection_id, series_id)),
+			Some(&(quantity + additional_quantity))
+		);
+	});
+}
+
+#[test]
 fn mint_series_fails_prechecks() {
 	ExtBuilder::default().build().execute_with(|| {
 		let collection_owner = 1_u64;


### PR DESCRIPTION
Lets the collection owner add a controller account which can mint a series or additional tokens under a collection_id
This is useful for giving ERC721 contracts access to mint tokens in a series without passing ownership completely