### PR TITLE
Updated eth-wallet module to latest Substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "crml-eth-wallet"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "base64 0.13.0",
  "cennznet-primitives",

--- a/crml/eth-wallet/Cargo.toml
+++ b/crml/eth-wallet/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crml-eth-wallet"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://docs.plasmnet.io/"
 repository = "https://github.com/staketechnologies/Plasm/"

--- a/crml/eth-wallet/src/lib.rs
+++ b/crml/eth-wallet/src/lib.rs
@@ -228,6 +228,7 @@ mod tests {
 		type BlockLength = ();
 		type SS58Prefix = ();
 		type OnSetCode = ();
+		type MaxConsumers = frame_support::traits::ConstU32<16>;
 	}
 
 	parameter_types! {


### PR DESCRIPTION
Updated eth-wallet Module to Rust 2021
Fixed mock to work with latest Substrate commit