### PR TITLE
Updated Staking module to latest Substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,11 +1450,12 @@ dependencies = [
 
 [[package]]
 name = "crml-staking"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "crml-generic-asset",
  "crml-support",
  "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "hex",

--- a/crml/staking/Cargo.toml
+++ b/crml/staking/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crml-staking"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/cennznet/cennznet"
 description = "CENNZnet staking pallet"
 
@@ -14,6 +14,7 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+frame-election-provider-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 pallet-session = { default-features = false, features = ["historical"], git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 pallet-staking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }

--- a/crml/staking/src/mock.rs
+++ b/crml/staking/src/mock.rs
@@ -33,7 +33,7 @@ use sp_runtime::{
 	testing::{Header, TestXt, UintAuthorityId},
 	traits::{IdentityLookup, One, Zero},
 };
-use sp_staking::offence::{OffenceDetails, OnOffenceHandler};
+use sp_staking::offence::OffenceDetails;
 use std::{
 	cell::RefCell,
 	collections::{BTreeMap, HashSet},
@@ -217,6 +217,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();
 	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 parameter_types! {
@@ -530,7 +531,7 @@ impl ExtBuilder {
 			});
 		}
 		let _ = crate::GenesisConfig::<Test> {
-			stakers,
+			stakers: stakers,
 			validator_count: self.validator_count,
 			minimum_bond: self.minimum_bond,
 			minimum_validator_count: self.minimum_validator_count,
@@ -891,11 +892,7 @@ pub(crate) fn horrible_npos_solution(do_reduce: bool) -> (CompactAssignments, Ve
 		let support = to_supports(&staked_assignment);
 		let score = (&support).evaluate();
 
-		assert!(sp_npos_elections::is_score_better::<Perbill>(
-			better_score,
-			score,
-			MinSolutionScoreBump::get(),
-		));
+		assert!(better_score.strict_threshold_better(score, MinSolutionScoreBump::get()));
 
 		score
 	};

--- a/crml/staking/src/offchain_election.rs
+++ b/crml/staking/src/offchain_election.rs
@@ -23,11 +23,13 @@ use crate::{
 };
 use codec::Decode;
 use crml_support::log;
+use frame_election_provider_support::NposSolution;
 use frame_support::{traits::Get, weights::Weight, IterableStorageMap};
 use frame_system::offchain::SubmitTransaction;
 use sp_npos_elections::{
-	reduce, to_supports, Assignment, ElectionResult, ElectionScore, EvaluateSupport, ExtendedBalance, NposSolution,
+	reduce, to_supports, Assignment, ElectionResult, ElectionScore, EvaluateSupport, ExtendedBalance,
 };
+
 use sp_runtime::{
 	offchain::storage::{MutateStorageError, StorageValueRef},
 	traits::TrailingZeroInput,
@@ -495,10 +497,16 @@ mod test {
 		fn get_npos_targets(_: u32) -> u64 {
 			unimplemented!()
 		}
-		fn set_staking_configs() -> u64 {
+		fn set_staking_configs_all_set() -> Weight {
+			unimplemented!()
+		}
+		fn set_staking_configs_all_remove() -> Weight {
 			unimplemented!()
 		}
 		fn chill_other() -> u64 {
+			unimplemented!()
+		}
+		fn force_apply_min_commission() -> Weight {
 			unimplemented!()
 		}
 	}

--- a/crml/staking/src/rewards/types.rs
+++ b/crml/staking/src/rewards/types.rs
@@ -133,12 +133,21 @@ pub type RewardPoint = u32;
 /// Reward points of an era. Used to split era total payout between validators.
 ///
 /// These points will be used to reward validators and their respective nominators.
-#[derive(PartialEq, Clone, Encode, Decode, Default, TypeInfo)]
+#[derive(PartialEq, Clone, Encode, Decode, TypeInfo)]
 pub struct EraRewardPoints<AccountId: Ord> {
 	/// Total number of points. Equals the sum of reward points for each validator.
 	pub total: RewardPoint,
 	/// The reward points earned by a given validator.
 	pub individual: BTreeMap<AccountId, RewardPoint>,
+}
+
+impl<AccountId: Ord> Default for EraRewardPoints<AccountId> {
+	fn default() -> Self {
+		Self {
+			total: Default::default(),
+			individual: BTreeMap::new(),
+		}
+	}
 }
 
 #[cfg(test)]

--- a/crml/staking/src/tests.rs
+++ b/crml/staking/src/tests.rs
@@ -1493,7 +1493,7 @@ fn slashing_validator_does_not_overflow() {
 		ErasStakers::<Test>::insert(
 			0,
 			11,
-			Exposure {
+			Exposure::<AccountId, Balance> {
 				total: stake,
 				own: 1,
 				others: vec![IndividualExposure {
@@ -2994,7 +2994,7 @@ mod offchain_election {
 			assert_eq!(
 				<Staking as sp_runtime::traits::ValidateUnsigned>::validate_unsigned(TransactionSource::Local, &inner,),
 				TransactionValidity::Err(
-					InvalidTransaction::Custom(<Error<Test>>::OffchainElectionWeakSubmission.as_u8()).into(),
+					InvalidTransaction::Custom(<Error<Test>>::OffchainElectionWeakSubmission.encode()[0]).into(),
 				),
 			)
 		})
@@ -3453,7 +3453,7 @@ mod offchain_election {
 				run_to_block(12);
 
 				let (compact, winners, mut score) = prepare_submission_with(true, true, 2, |_| {});
-				score[0] += 1;
+				score.minimal_stake += 1;
 
 				assert_noop!(
 					submit_solution(Origin::signed(10), winners, compact, score,),


### PR DESCRIPTION
Staking module build errors fixed with latest Substrate

6 tests still not passing as follows:
- new_era_elects_correct_number_of_validators
- offchain_election::nominating_and_rewards_should_work
- phragmen_should_not_overflow
- staking_should_work
- switching_roles
- wrong_vote_is_null
