### PR TITLE
Fix/rata local dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 ENV CARGO_HOME=/cennznet/.cargo
 RUN cargo build --release
 
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 LABEL maintainer="support@centrality.ai"
 
 RUN apt-get update && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: '3'
 services:
   node-0:
-    image: cennznet/cennznet:2.0.0
+    image: cennznet/cennznet:2.1.2
     volumes:
     - ./data/node-0:/mnt/data
     command:
@@ -19,13 +19,14 @@ services:
       - --unsafe-ws-external
       - --unsafe-rpc-external
       - --rpc-cors=all
-      - --bootnodes=/dns4/node-5/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
+      - --node-key=b8a86173a1e505d3f221098a81f1b83a247a49f60811008feada659f50daeee4
     ports:
       - "9933:9933"
       - "9944:9944"
       - "30334:30333"
+    
   node-1:
-    image: cennznet/cennznet:2.0.0
+    image: cennznet/cennznet:2.1.2
     volumes:
     - ./data/node-1:/mnt/data
     command:
@@ -37,11 +38,11 @@ services:
       - --base-path=/mnt/data
       - --name=bob-${HOSTNAME:-localhost}-1
       - --node-key=0000000000000000000000000000000000000000000000000000000000000002
-      - --bootnodes=/dns4/node-5/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
     ports:
       - "30335:30333"
   node-2:
-    image: cennznet/cennznet:2.0.0
+    image: cennznet/cennznet:2.1.2
     volumes:
     - ./data/node-2:/mnt/data
     command:
@@ -53,11 +54,11 @@ services:
       - --base-path=/mnt/data
       - --name=charlie-${HOSTNAME:-localhost}-2
       - --node-key=0000000000000000000000000000000000000000000000000000000000000003
-      - --bootnodes=/dns4/node-5/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
     ports:
       - "30336:30333"
   node-3:
-    image: cennznet/cennznet:2.0.0
+    image: cennznet/cennznet:2.1.2
     volumes:
     - ./data/node-3:/mnt/data
     command:
@@ -69,11 +70,11 @@ services:
       - --base-path=/mnt/data
       - --name=dave-${HOSTNAME:-localhost}-3
       - --node-key=0000000000000000000000000000000000000000000000000000000000000004
-      - --bootnodes=/dns4/node-5/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
     ports:
       - "30337:30333"
   node-4:
-    image: cennznet/cennznet:2.0.0
+    image: cennznet/cennznet:2.1.2
     volumes:
     - ./data/node-4:/mnt/data
     command:
@@ -85,19 +86,19 @@ services:
       - --base-path=/mnt/data
       - --name=eve-${HOSTNAME:-localhost}-4
       - --node-key=0000000000000000000000000000000000000000000000000000000000000005
-      - --bootnodes=/dns4/node-5/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
     ports:
       - "30338:30333"
   node-5:
-    image: cennznet/cennznet:2.0.0
+    image: cennznet/cennznet:2.1.2
     volumes:
     - ./data/node-5:/mnt/data
     command:
       - --chain=/cennznet/genesis/rata.raw.json
       - --name=full-${HOSTNAME:-localhost}-5
       - --base-path=/mnt/data
-      - --node-key=8967bcbae338641d1102ff4465fda281f0bf6e9842702f3a992650d4855f5cd0
-      - --ws-external
-      - --rpc-external
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
+      - --unsafe-ws-external
+      - --unsafe-rpc-external
     ports:
       - "30339:30333"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - --unsafe-ws-external
       - --unsafe-rpc-external
       - --rpc-cors=all
-      - --node-key=b8a86173a1e505d3f221098a81f1b83a247a49f60811008feada659f50daeee4
+      - --node-key=8967bcbae338641d1102ff4465fda281f0bf6e9842702f3a992650d4855f5cd0
     ports:
       - "9933:9933"
       - "9944:9944"
@@ -38,7 +38,7 @@ services:
       - --base-path=/mnt/data
       - --name=bob-${HOSTNAME:-localhost}-1
       - --node-key=0000000000000000000000000000000000000000000000000000000000000002
-      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
     ports:
       - "30335:30333"
   node-2:
@@ -54,7 +54,7 @@ services:
       - --base-path=/mnt/data
       - --name=charlie-${HOSTNAME:-localhost}-2
       - --node-key=0000000000000000000000000000000000000000000000000000000000000003
-      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
     ports:
       - "30336:30333"
   node-3:
@@ -70,7 +70,7 @@ services:
       - --base-path=/mnt/data
       - --name=dave-${HOSTNAME:-localhost}-3
       - --node-key=0000000000000000000000000000000000000000000000000000000000000004
-      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
     ports:
       - "30337:30333"
   node-4:
@@ -86,7 +86,7 @@ services:
       - --base-path=/mnt/data
       - --name=eve-${HOSTNAME:-localhost}-4
       - --node-key=0000000000000000000000000000000000000000000000000000000000000005
-      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
     ports:
       - "30338:30333"
   node-5:
@@ -97,7 +97,7 @@ services:
       - --chain=/cennznet/genesis/rata.raw.json
       - --name=full-${HOSTNAME:-localhost}-5
       - --base-path=/mnt/data
-      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWA8GrA6UEWr5wiPYkPQ63K111dU5doUCZ5RA39xZ4zaRX
+      - --bootnodes=/dns4/node-0/tcp/30333/p2p/12D3KooWCjJYJPjLJmHH9Q7NGzQRZvN28xwZ4Rjsazf14sCr3uH8
       - --unsafe-ws-external
       - --unsafe-rpc-external
     ports:


### PR DESCRIPTION
This fixes the local docker compose to work with a recent cennznet image and separately updates the  Dockerfile to use a more recent debian image. This also alters the relationships in the dockerfile so the bootnode is alice instead of the RPC node. I haven't 100% confirmed whether an upstream change has definitively changed whether we need bootnodes and rpc nodes to be separate or something like this, but it's my current suspicion.

We still need to confirm that a runtime upgrade does not eventually brick with this change. 